### PR TITLE
RELATED: BB-631 Fix visualization date filter enabled 

### DIFF
--- a/src/components/core/PureTable.tsx
+++ b/src/components/core/PureTable.tsx
@@ -267,8 +267,9 @@ export class PureTable extends React.Component<ITableProps, ITableState> {
         );
     }
 
-    private onError(errorCode: string, dataSource = this.props.dataSource, options = {}) {
+    private onError(errorCode: string, dataSource = this.props.dataSource) {
         if (DataSourceUtils.dataSourcesMatch(this.props.dataSource, dataSource)) {
+            const options = getVisualizationOptions(this.props.dataSource.getAfm());
             this.setState({
                 error: errorCode
             });

--- a/src/components/core/tests/PureTable.spec.tsx
+++ b/src/components/core/tests/PureTable.spec.tsx
@@ -229,7 +229,9 @@ describe('PureTable', () => {
             expect(onError).toHaveBeenCalledTimes(2);
             expect(onError).toHaveBeenLastCalledWith({
                 status: ErrorStates.DATA_TOO_LARGE_TO_COMPUTE,
-                options: expect.any(Object)
+                options: {
+                    dateOptionsDisabled: false
+                }
             });
         });
     });


### PR DESCRIPTION
In KD the date filter in right panel was enabled even if the visualization had an metric date filter but execution ended up with no data