### PR TITLE
RELATED: BB-703 Base the derived measure title on the current master measure name

### DIFF
--- a/__mocks__/fixtures.ts
+++ b/__mocks__/fixtures.ts
@@ -391,7 +391,86 @@ export const visualizationObjects: [{ visualizationObject: VisualizationObject.I
                 contributor: '/gdc/account/profile/26728eacad349ba6c4c04c5e5cc59437'
             }
         }
-    }
+    },
+    {
+        visualizationObject: {
+            content: {
+                visualizationClass: {
+                    uri: '/gdc/md/myproject/obj/table'
+                },
+                buckets: [
+                    {
+                        localIdentifier: 'measures',
+                        items: [
+                            {
+                                measure: {
+                                    localIdentifier: 'm1',
+                                    title: '# Accounts with AD Query',
+                                    alias: 'AD Queries',
+                                    definition: {
+                                        measureDefinition: {
+                                            item: {
+                                                uri: '/gdc/md/myproject/obj/8172'
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                measure: {
+                                    localIdentifier: 'm1_pop',
+                                    definition: {
+                                        popMeasureDefinition: {
+                                            measureIdentifier: 'm1',
+                                            popAttribute: {
+                                                uri: '/gdc/md/myproject/obj/1514'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        localIdentifier: 'attribute',
+                        items: [
+                            {
+                                visualizationAttribute: {
+                                    localIdentifier: 'a1',
+                                    displayForm: {
+                                        uri: '/gdc/md/myproject/obj/1515'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ],
+                properties: JSON.stringify({
+                    sortItems: [
+                        {
+                            attributeSortItem: {
+                                direction: 'asc',
+                                attributeIdentifier: 'a1'
+                            }
+                        }
+                    ]
+                })
+            },
+            meta: {
+                author: '/gdc/account/profile/johndoe',
+                uri: '/gdc/md/myproject/obj/2',
+                tags: '',
+                created: new Date('2015-05-23T09:24:41Z'),
+                identifier: 'aa5CD0OcfSpg',
+                deprecated: false,
+                summary: '',
+                isProduction: true,
+                title: 'PoP alias test',
+                category: 'visualizationObject',
+                contributor: '/gdc/account/profile/johndoe'
+            }
+        }
+    },
 ];
 
 export const visualizationClasses: [{ visualizationClass: VisualizationClass.IVisualizationClass }] = [

--- a/src/helpers/popHelper.ts
+++ b/src/helpers/popHelper.ts
@@ -78,18 +78,18 @@ export function fillPoPTitlesAndAliases(
             const masterMeasure = getMasterMeasure(measureBucketItems,
                 get<string>(popDefinition, 'measureIdentifier'));
 
-            const originalTitle = get(masterMeasure, ['measure', 'title']);
-            const originalAlias = get(masterMeasure, ['measure', 'alias']);
+            const masterMeasureTitle = get(masterMeasure, ['measure', 'title']);
+            const masterMeasureAlias = get(masterMeasure, ['measure', 'alias']);
 
-            const title = `${originalTitle}${popSuffix}`;
-            const alias = `${originalAlias}${popSuffix}`;
+            const derivedMeasureTitleBase = masterMeasureAlias === undefined
+                ? masterMeasureTitle
+                : masterMeasureAlias;
 
-            const titleProp = originalTitle ? { title } : {};
-            const aliasProp = originalAlias ? { alias } : {};
+            const titleProp = { title: `${derivedMeasureTitleBase}${popSuffix}` };
+
             set(bucketItem, 'measure', {
                 ...bucketItem.measure,
-                ...titleProp,
-                ...aliasProp
+                ...titleProp
             });
         }
         return bucketItem;

--- a/src/helpers/tests/popHelper.spec.ts
+++ b/src/helpers/tests/popHelper.spec.ts
@@ -4,7 +4,7 @@ import { visualizationObjects } from '../../../__mocks__/fixtures';
 
 describe('popHelper', () => {
     describe('fillPoPTitlesAndAliases', () => {
-        it('should add missing title and alias for PoP measure', () => {
+        it('should set title of PoP measure based on master measure title when master measure is NOT renamed', () => {
             const visContentWithPoP = visualizationObjects.find(chart =>
                 chart.visualizationObject.meta.title === 'PoP'
             ).visualizationObject.content;
@@ -41,7 +41,46 @@ describe('popHelper', () => {
             );
         });
 
-        it('should add title and alias to pop measure in different bucket', () => {
+        it('should set title of PoP measure based on master measure alias when master measure is renamed', () => {
+            const visContentWithPoP = visualizationObjects.find(chart =>
+                chart.visualizationObject.meta.title === 'PoP alias test'
+            ).visualizationObject.content;
+            expect(fillPoPTitlesAndAliases(visContentWithPoP, ' - testing pop title').buckets[0].items).toEqual(
+                [
+                    {
+                        measure: {
+                            localIdentifier: 'm1',
+                            title: '# Accounts with AD Query',
+                            alias: 'AD Queries',
+                            definition: {
+                                measureDefinition: {
+                                    item: {
+                                        uri: '/gdc/md/myproject/obj/8172'
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        measure: {
+                            localIdentifier: 'm1_pop',
+                            title: 'AD Queries - testing pop title',
+                            definition: {
+                                popMeasureDefinition: {
+                                    measureIdentifier: 'm1',
+                                    popAttribute: {
+                                        uri: '/gdc/md/myproject/obj/1514'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            );
+        });
+
+        // tslint:disable-next-line:max-line-length
+        it('should set title of PoP measure based on master measure title even when master measure is located in a different bucket', () => {
             const headlineWithPoP = visualizationObjects.find(visualizationObject =>
                 visualizationObject.visualizationObject.meta.title === 'pop headline test'
             ).visualizationObject.content;
@@ -88,12 +127,12 @@ describe('popHelper', () => {
     });
 
     describe('getPoPSuffix', () => {
-        it('it should return formatted suffix for popMeasureDefinition', () => {
+        it('should return formatted suffix for popMeasureDefinition', () => {
             const popSuffix = getPoPSuffix('popMeasureDefinition', 'en-US');
             expect(popSuffix).toEqual(' - previous year');
         });
 
-        it('it should return formatted suffix for overPeriodMeasureDefinition', () => {
+        it('should return formatted suffix for overPeriodMeasureDefinition', () => {
             const popSuffix = getPoPSuffix('overPeriodMeasureDefinition', 'en-US');
             expect(popSuffix).toEqual(' - SP year ago');
         });


### PR DESCRIPTION
The title of the derived measure must be created from the current name of the master measure. 
* When a **master measure is not renamed** then the derived measure name must be based on the **master measure title**. 
* When a **master measure is renamed** the derived measure name must be based on **master measure alias**. 