### PR TITLE
RELATED: RAIL-900 Upgrade gooddata-js, mock-js and convert other than apiResponse errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "@gooddata/mock-js": "1.2.0",
+    "@gooddata/mock-js": "1.3.1",
     "@gooddata/test-storybook": "1.2.1",
     "@storybook/addon-actions": "3.4.0",
     "@storybook/addon-options": "3.4.0",
@@ -91,7 +91,7 @@
     "yup": "^0.24.1"
   },
   "dependencies": {
-    "@gooddata/gooddata-js": "6.0.0",
+    "@gooddata/gooddata-js": "6.1.1",
     "@gooddata/goodstrap": "56.0.2",
     "@gooddata/js-utils": "^2.0.1",
     "@gooddata/numberjs": "^3.1.2",

--- a/src/execution/fixtures/ExecuteAfm.fixtures.ts
+++ b/src/execution/fixtures/ExecuteAfm.fixtures.ts
@@ -1,4 +1,5 @@
 // (C) 2007-2018 GoodData Corporation
+import { ApiResponseError } from '@gooddata/gooddata-js';
 import { AFM, Execution } from '@gooddata/typings';
 import { MEASUREGROUP } from '../../constants/dimensions';
 
@@ -162,9 +163,10 @@ const attributeOnlyResponse: Execution.IExecutionResponses = {
     }
 };
 
-const tooLargeResponse: Execution.IError = {
+const tooLargeResponse: ApiResponseError = {
     name: 'Error 413',
     message: 'Response is too large',
+    cause: null,
     response: {
         status: 413,
         body: null as ReadableStream | null, // tslint:disable-line
@@ -184,12 +186,14 @@ const tooLargeResponse: Execution.IError = {
         arrayBuffer: jest.fn(),
         blob: jest.fn(),
         formData: jest.fn()
-    }
+    },
+    responseBody: ''
 };
 
-const badRequestResponse: Execution.IError = {
+const badRequestResponse: ApiResponseError = {
     name: 'Error 400',
     message: 'Bad request',
+    cause: null,
     response: {
         status: 400,
         body: null as ReadableStream | null, // tslint:disable-line
@@ -209,7 +213,8 @@ const badRequestResponse: Execution.IError = {
         arrayBuffer: jest.fn(),
         blob: jest.fn(),
         formData: jest.fn()
-    }
+    },
+    responseBody: ''
 };
 
 const oneMeasureAfm: AFM.IAfm = {

--- a/src/helpers/errorHandlers.ts
+++ b/src/helpers/errorHandlers.ts
@@ -15,6 +15,10 @@ function getJSONFromText(data: string): object {
     }
 }
 
+function isApiResponseError(error: TypeError | ApiResponseError): error is ApiResponseError {
+    return (error as ApiResponseError).response !== undefined;
+}
+
 export interface IErrorMap {
     [key: string]: {
         icon?: string;
@@ -51,7 +55,12 @@ export function generateErrorMap(intl: InjectedIntl): IErrorMap {
     return errorMap;
 }
 
-export function convertErrors(error: ApiResponseError): RuntimeError {
+// CAREFUL: error can also be of different type than listed
+export function convertErrors(error: ApiResponseError | TypeError): RuntimeError {
+    if (!isApiResponseError(error)) {
+        return new RuntimeError(error.message, error);
+    }
+
     const errorCode: number = error.response.status;
     switch (errorCode) {
         case HttpStatusCodes.NO_CONTENT:

--- a/src/helpers/tests/errorHandlers.spec.ts
+++ b/src/helpers/tests/errorHandlers.spec.ts
@@ -27,7 +27,18 @@ async function createMockedError(status: number, body: string = '{}') {
     return new ApiResponseError('Response error', response, responseBody);
 }
 
+async function createTypeError() {
+    return new TypeError('TypeError message');
+}
+
 describe('convertErrors', async () => {
+    it('should return RuntimeError with message when error type is not ApiResponseError', async () => {
+        const e = convertErrors(await createTypeError());
+
+        expect(e).toBeInstanceOf(RuntimeError);
+        expect(e.message).toEqual('TypeError message');
+    });
+
     it('should return `NO_DATA` error', async () => {
         const e = convertErrors(await createMockedError(204));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,9 +54,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@gooddata/gooddata-js@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-6.0.0.tgz#b4c5e37823ee2a1d5123767162285cdf7e675553"
+"@gooddata/gooddata-js@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-6.1.1.tgz#3e01139857d52879a52a96cebf111a9935b32657"
   dependencies:
     "@gooddata/typings" "2.0.0"
     es6-promise "3.0.2"
@@ -105,9 +105,9 @@
     js-cookie "^2.1.4"
     lodash "^4.17.4"
 
-"@gooddata/mock-js@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/mock-js/-/mock-js-1.2.0.tgz#5095621e6eabbb1c62b84941cece4f105680a524"
+"@gooddata/mock-js@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@gooddata/mock-js/-/mock-js-1.3.1.tgz#c60d9856e78c71a160eedea75a0bd4b692bddccf"
   dependencies:
     "@gooddata/typings" "1.0.1"
     "@types/seedrandom" "2.4.27"


### PR DESCRIPTION
`5.2.0-ocetnik-doc-gd-js-paging-2018-07-03T12-13-59-398Z`