### PR TITLE
RELATED: ONE-3265 Turn off turbo threshold for scatter series

### DIFF
--- a/src/components/visualizations/chart/chartOptionsBuilder.ts
+++ b/src/components/visualizations/chart/chartOptionsBuilder.ts
@@ -454,6 +454,7 @@ export function getScatterPlotSeries(
         });
 
         return [{
+            turboThreshold: 0,
             color: colorPalette[0],
             legendIndex: 0,
             data


### PR DESCRIPTION
Caused by 05a77cc4 refactor which revealed that we still used
smaller limits (DEFAULT_CATEGORIES_LIMIT=365) when rendering scatter.