### PR TITLE
RELATED: BB-638 Refactor PoP to Over Time Comparison

### DIFF
--- a/__mocks__/fixtures.ts
+++ b/__mocks__/fixtures.ts
@@ -338,7 +338,7 @@ export const visualizationObjects: [{ visualizationObject: VisualizationObject.I
                 deprecated: false,
                 summary: '',
                 isProduction: true,
-                title: 'PoP',
+                title: 'Over time comparison',
                 category: 'visualizationObject',
                 contributor: '/gdc/account/profile/johndoe'
             }
@@ -417,7 +417,7 @@ export const visualizationObjects: [{ visualizationObject: VisualizationObject.I
                 deprecated: false,
                 summary: '',
                 isProduction: true,
-                title: 'pop headline test',
+                title: 'Headline over time comparison',
                 category: 'visualizationObject',
                 contributor: '/gdc/account/profile/26728eacad349ba6c4c04c5e5cc59437'
             }
@@ -512,7 +512,7 @@ export const visualizationObjects: [{ visualizationObject: VisualizationObject.I
                 deprecated: false,
                 summary: '',
                 isProduction: true,
-                title: 'PoP alias test',
+                title: 'Over time comparison alias',
                 category: 'visualizationObject',
                 contributor: '/gdc/account/profile/johndoe'
             }

--- a/src/components/uri/Visualization.tsx
+++ b/src/components/uri/Visualization.tsx
@@ -18,7 +18,7 @@ import { IDataSource } from '../../interfaces/DataSource';
 import { ISubject } from '../../helpers/async';
 import { getVisualizationTypeFromVisualizationClass } from '../../helpers/visualizationType';
 import * as MdObjectHelper from '../../helpers/MdObjectHelper';
-import { fillPoPTitlesAndAliases } from '../../helpers/popHelper';
+import { fillDerivedMeasuresTitlesAndAliases } from '../../helpers/overTimeComparisonHelper';
 import { LoadingComponent, ILoadingProps } from '../simple/LoadingComponent';
 import { ErrorComponent, IErrorProps } from '../simple/ErrorComponent';
 import {
@@ -360,7 +360,8 @@ export class VisualizationWrapped
                 ).then((visualizationClass) => {
 
                     const suffixFactory = new DerivedMeasureTitleSuffixFactory(this.props.locale);
-                    const processedVisualizationObject = fillPoPTitlesAndAliases(mdObject.content, suffixFactory);
+                    const processedVisualizationObject
+                        = fillDerivedMeasuresTitlesAndAliases(mdObject.content, suffixFactory);
                     const { afm, resultSpec } = toAfmResultSpec(processedVisualizationObject);
 
                     const mdObjectTotals = MdObjectHelper.getTotals(mdObject);

--- a/src/components/visualizations/chart/chartOptionsBuilder.ts
+++ b/src/components/visualizations/chart/chartOptionsBuilder.ts
@@ -206,13 +206,6 @@ export function validateData(limits: IChartLimits, chartOptions: any) {
     };
 }
 
-export function isPopMeasure(measureItem: Execution.IMeasureHeaderItem, afm: AFM.IAfm) {
-    return afm.measures.some((measure: AFM.IMeasure) => {
-        const popMeasureIdentifier = get(measure, 'definition.popMeasure') ? measure.localIdentifier : null;
-        return popMeasureIdentifier && popMeasureIdentifier === measureItem.measureHeaderItem.localIdentifier;
-    });
-}
-
 export function isDerivedMeasure(measureItem: Execution.IMeasureHeaderItem, afm: AFM.IAfm) {
     return afm.measures.some((measure: AFM.IMeasure) => {
         const measureDefinition = get(measure, 'definition.popMeasure')

--- a/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
+++ b/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
@@ -6,7 +6,6 @@ import { immutableSet } from '../../utils/common';
 import {
     isNegativeValueIncluded,
     validateData,
-    isPopMeasure,
     findInDimensionHeaders,
     findMeasureGroupInDimensions,
     findAttributeInDimension,
@@ -295,51 +294,6 @@ describe('chartOptionsBuilder', () => {
                     hasNegativeValue: false
                 });
             });
-        });
-    });
-
-    describe('isPopMeasure', () => {
-        it('should return true if measureItem was defined as a popMeasure', () => {
-            const measureItem = fixtures
-                .barChartWithPopMeasureAndViewByAttribute
-                .executionResponse
-                .dimensions[STACK_BY_DIMENSION_INDEX]
-                .headers[0]
-                .measureGroupHeader
-                .items[0];
-            const { afm } = fixtures.barChartWithPopMeasureAndViewByAttribute.executionRequest;
-            expect(
-                isPopMeasure(measureItem, afm)
-            ).toEqual(true);
-        });
-
-        it('should return false if measureItem was defined as a previousPeriodMeasure', () => {
-            const measureItem = fixtures
-                .barChartWithPreviousPeriodMeasure
-                .executionResponse
-                .dimensions[STACK_BY_DIMENSION_INDEX]
-                .headers[0]
-                .measureGroupHeader
-                .items[0];
-            const { afm } = fixtures.barChartWithPreviousPeriodMeasure.executionRequest;
-            expect(
-                isPopMeasure(measureItem, afm)
-            ).toEqual(false);
-        });
-
-        it('should return false if measureItem was defined as a simple measure', () => {
-            const measureItem = fixtures
-                .barChartWithPopMeasureAndViewByAttribute
-                .executionResponse
-                .dimensions[STACK_BY_DIMENSION_INDEX]
-                .headers[0]
-                .measureGroupHeader
-                .items[1];
-            const { afm } = fixtures.barChartWithPopMeasureAndViewByAttribute.executionRequest;
-
-            expect(
-                isPopMeasure(measureItem, afm)
-            ).toEqual(false);
         });
     });
 

--- a/src/helpers/overTimeComparisonHelper.ts
+++ b/src/helpers/overTimeComparisonHelper.ts
@@ -57,7 +57,7 @@ function getDerivedMeasureTitleBase(masterMeasure: VisualizationObject.IMeasure)
  *
  * @internal
  */
-export function fillPoPTitlesAndAliases(
+export function fillDerivedMeasuresTitlesAndAliases(
     mdObject: IVisualizationObjectContent,
     suffixFactory: DerivedMeasureTitleSuffixFactory
 ): IVisualizationObjectContent {

--- a/src/helpers/tests/overTimeComparisonHelper.spec.ts
+++ b/src/helpers/tests/overTimeComparisonHelper.spec.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2018 GoodData Corporation
-import { fillPoPTitlesAndAliases } from '../popHelper';
+import { fillDerivedMeasuresTitlesAndAliases } from '../overTimeComparisonHelper';
 import { visualizationObjects } from '../../../__mocks__/fixtures';
 import DerivedMeasureTitleSuffixFactory from '../../factory/DerivedMeasureTitleSuffixFactory';
 import { VisualizationObject } from '@gooddata/typings';
@@ -12,14 +12,21 @@ function findVisualizationObjectFixture(metaTitle: string): IVisualizationObject
     return visualizationObject.visualizationObject.content;
 }
 
-describe('popHelper', () => {
-    describe('fillPoPTitlesAndAliases', () => {
-        it('should set title of derived measures based on master title when master is NOT renamed', () => {
-            const suffixFactory = new DerivedMeasureTitleSuffixFactory('en-US');
-            suffixFactory.getSuffix = jest.fn(() => ' - testing pop title');
+describe('overTimeComparisonHelper', () => {
+    describe('fillDerivedMeasuresTitlesAndAliases', () => {
+        const suffixFactory = new DerivedMeasureTitleSuffixFactory('en-US');
+        suffixFactory.getSuffix = jest.fn((measureDefinition) => {
+            if (measureDefinition.popMeasureDefinition) {
+                return ' - pop';
+            } else if (measureDefinition.previousPeriodMeasure) {
+                return ' - previous';
+            }
+            return '';
+        });
 
-            const visualizationObjectContent = findVisualizationObjectFixture('PoP');
-            const result = fillPoPTitlesAndAliases(visualizationObjectContent, suffixFactory);
+        it('should set title of derived measures based on master title when master is NOT renamed', () => {
+            const visualizationObjectContent = findVisualizationObjectFixture('Over time comparison');
+            const result = fillDerivedMeasuresTitlesAndAliases(visualizationObjectContent, suffixFactory);
 
             expect(result.buckets[0].items).toEqual(
                 [
@@ -39,7 +46,7 @@ describe('popHelper', () => {
                     {
                         measure: {
                             localIdentifier: 'm1_pop',
-                            title: '# Accounts with AD Query - testing pop title',
+                            title: '# Accounts with AD Query - pop',
                             definition: {
                                 popMeasureDefinition: {
                                     measureIdentifier: 'm1',
@@ -53,7 +60,7 @@ describe('popHelper', () => {
                     {
                         measure: {
                             localIdentifier: 'm1_previous_period',
-                            title: '# Accounts with AD Query - testing pop title',
+                            title: '# Accounts with AD Query - previous',
                             definition: {
                                 previousPeriodMeasure: {
                                     measureIdentifier: 'm1',
@@ -72,11 +79,8 @@ describe('popHelper', () => {
         });
 
         it('should set title of derived measures based on master alias when master is renamed', () => {
-            const suffixFactory = new DerivedMeasureTitleSuffixFactory('en-US');
-            suffixFactory.getSuffix = jest.fn(() => ' - testing pop title');
-
-            const visualizationObjectContent = findVisualizationObjectFixture('PoP alias test');
-            const result = fillPoPTitlesAndAliases(visualizationObjectContent, suffixFactory);
+            const visualizationObjectContent = findVisualizationObjectFixture('Over time comparison alias');
+            const result = fillDerivedMeasuresTitlesAndAliases(visualizationObjectContent, suffixFactory);
 
             expect(result.buckets[0].items).toEqual(
                 [
@@ -97,7 +101,7 @@ describe('popHelper', () => {
                     {
                         measure: {
                             localIdentifier: 'm1_pop',
-                            title: 'AD Queries - testing pop title',
+                            title: 'AD Queries - pop',
                             definition: {
                                 popMeasureDefinition: {
                                     measureIdentifier: 'm1',
@@ -111,7 +115,7 @@ describe('popHelper', () => {
                     {
                         measure: {
                             localIdentifier: 'm1_previous_period',
-                            title: 'AD Queries - testing pop title',
+                            title: 'AD Queries - previous',
                             definition: {
                                 previousPeriodMeasure: {
                                     measureIdentifier: 'm1',
@@ -130,11 +134,8 @@ describe('popHelper', () => {
         });
 
         it('should set title of derived based on master title even when it is located in a different bucket', () => {
-            const suffixFactory = new DerivedMeasureTitleSuffixFactory('en-US');
-            suffixFactory.getSuffix = jest.fn(() => ' - testing pop title');
-
-            const visualizationObjectContent = findVisualizationObjectFixture('pop headline test');
-            const result = fillPoPTitlesAndAliases(visualizationObjectContent, suffixFactory);
+            const visualizationObjectContent = findVisualizationObjectFixture('Headline over time comparison');
+            const result = fillDerivedMeasuresTitlesAndAliases(visualizationObjectContent, suffixFactory);
 
             expect(result.buckets[0].items).toEqual(
                 [
@@ -161,7 +162,7 @@ describe('popHelper', () => {
                     {
                         measure: {
                             localIdentifier: 'fdd41e4ca6224cd2b5ecce15fdabf062_pop',
-                            title: 'Sum of Email Clicks - testing pop title',
+                            title: 'Sum of Email Clicks - pop',
                             definition: {
                                 popMeasureDefinition: {
                                     measureIdentifier: 'fdd41e4ca6224cd2b5ecce15fdabf062',
@@ -175,7 +176,7 @@ describe('popHelper', () => {
                     {
                         measure: {
                             localIdentifier: 'fdd41e4ca6224cd2b5ecce15fdabf062_previous_period',
-                            title: 'Sum of Email Clicks - testing pop title',
+                            title: 'Sum of Email Clicks - previous',
                             definition: {
                                 previousPeriodMeasure: {
                                     measureIdentifier: 'fdd41e4ca6224cd2b5ecce15fdabf062',

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import { AttributeElements } from './components/filters/AttributeFilter/Attribut
 import * as PropTypes from './proptypes/index';
 import { generateDimensions } from './helpers/dimensions';
 import * as BucketNames from './constants/bucketNames';
-import * as PoPHelper from './helpers/popHelper';
+import * as OverTimeComparisonHelper from './helpers/overTimeComparisonHelper';
 import DerivedMeasureTitleSuffixFactory from './factory/DerivedMeasureTitleSuffixFactory';
 import { IDataSourceProviderInjectedProps } from './components/afm/DataSourceProvider';
 
@@ -97,7 +97,7 @@ export {
     BubbleChart,
     DonutChart,
     Heatmap,
-    PoPHelper,
+    OverTimeComparisonHelper,
     DerivedMeasureTitleSuffixFactory,
     PropTypes,
     RuntimeError,

--- a/stories/test_data/bar_chart_with_paged_legend.ts
+++ b/stories/test_data/bar_chart_with_paged_legend.ts
@@ -9,8 +9,7 @@ const config: any = {
                     objectUri: '/gdc/md/oim7k9wbfmhq1xcpbuwvr41pl7ztaat7/obj/9211',
                     title: '_Close [BOP]',
                     measureFilters: [],
-                    showInPercent: false,
-                    showPoP: false
+                    showInPercent: false
                 }
             }
         ],

--- a/stories/test_data/test_config.ts
+++ b/stories/test_data/test_config.ts
@@ -11,7 +11,6 @@ export const barChart2Series: any = {
                     objectUri: '/gdc/md/tgqkx9leq2tntui4j6fp08tk6epftziu/obj/13465',
                     metricAttributeFilters: [],
                     showInPercent: false,
-                    showPoP: false,
                     format: '#,##0',
                     sorts: []
                 }
@@ -22,7 +21,6 @@ export const barChart2Series: any = {
                     objectUri: '/gdc/md/tgqkx9leq2tntui4j6fp08tk6epftziu/obj/2825',
                     metricAttributeFilters: [],
                     showInPercent: false,
-                    showPoP: false,
                     format: '#,##0',
                     sorts: []
                 }
@@ -61,7 +59,6 @@ export const stackedBar: any = {
                     objectUri: '/gdc/md/tgqkx9leq2tntui4j6fp08tk6epftziu/obj/13465',
                     metricAttributeFilters: [],
                     showInPercent: false,
-                    showPoP: false,
                     format: '#,##0',
                     sorts: []
                 }
@@ -118,7 +115,6 @@ export const pie: any = {
                     objectUri: '/gdc/md/tgqkx9leq2tntui4j6fp08tk6epftziu/obj/13465',
                     metricAttributeFilters: [],
                     showInPercent: false,
-                    showPoP: false,
                     format: '#,##0',
                     sorts: []
                 }
@@ -157,7 +153,6 @@ export const metricPie: any = {
                     objectUri: '/gdc/md/tgqkx9leq2tntui4j6fp08tk6epftziu/obj/324',
                     metricAttributeFilters: [],
                     showInPercent: false,
-                    showPoP: false,
                     format: '#,##0',
                     sorts: []
                 }
@@ -168,7 +163,6 @@ export const metricPie: any = {
                     objectUri: '/gdc/md/tgqkx9leq2tntui4j6fp08tk6epftziu/obj/13465',
                     metricAttributeFilters: [],
                     showInPercent: false,
-                    showPoP: false,
                     format: '#,##0',
                     sorts: []
                 }
@@ -179,7 +173,6 @@ export const metricPie: any = {
                     objectUri: '/gdc/md/tgqkx9leq2tntui4j6fp08tk6epftziu/obj/13468',
                     metricAttributeFilters: [],
                     showInPercent: false,
-                    showPoP: false,
                     format: '#,##0',
                     sorts: []
                 }
@@ -210,8 +203,7 @@ export const longBar: any = {
                     objectUri: '/gdc/md/oim7k9wbfmhq1xcpbuwvr41pl7ztaat7/obj/9211',
                     title: '_Close [BOP]',
                     measureFilters: [],
-                    showInPercent: false,
-                    showPoP: false
+                    showInPercent: false
                 }
             }
         ],


### PR DESCRIPTION
PoP stays in context of measure definition where it is still valid part to backend API