### PR TITLE
CONFIG: Revert wrongly overwritten version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/react-components",
-  "version": "6.0.0-alpha27",
+  "version": "5.3.2",
   "description": "GoodData React Components",
   "main": "dist/index.js",
   "repository": "git@github.com:gooddata/gooddata-react-components.git",


### PR DESCRIPTION
The version was overwritten by the wrong release via CI job (the `master` branch was specified instead of intended `next-6.0.0`).