### PR TITLE
BUGFIX: RAIL-1180 AFM Table Component generates resultSpec without measureGroup when afm.measures=[]

### DIFF
--- a/src/components/afm/Table.tsx
+++ b/src/components/afm/Table.tsx
@@ -17,7 +17,7 @@ function generateDefaultDimensions(afm: AFM.IAfm): AFM.IDimension[] {
             itemIdentifiers: (afm.attributes || []).map(a => a.localIdentifier)
         },
         {
-            itemIdentifiers: afm.measures ? ['measureGroup'] : []
+            itemIdentifiers: afm.measures && afm.measures.length > 0 ? ['measureGroup'] : []
         }
     ];
 }

--- a/src/components/afm/tests/Table.spec.tsx
+++ b/src/components/afm/tests/Table.spec.tsx
@@ -5,7 +5,11 @@ import { testUtils } from '@gooddata/js-utils';
 import { Table } from '../Table';
 import { SortableTable } from '../../core/SortableTable';
 import { dummyExecuteAfmAdapterFactoryTable } from './utils/DummyExecuteAfmAdapter';
-import { executionRequest, executionRequestWithoutMeasureAndWithoutResultSpec } from './utils/dummyFixture';
+import {
+    executionRequest,
+    executionRequestWithEmptyMeasuresArray,
+    executionRequestWithoutMeasureAndWithoutResultSpec
+} from './utils/dummyFixture';
 
 describe('Table', () => {
     it('should provide default resultSpec to the core Table with attribute and measure', () => {
@@ -33,6 +37,26 @@ describe('Table', () => {
             <Table
                 projectId="projectId"
                 afm={executionRequestWithoutMeasureAndWithoutResultSpec.execution.afm}
+                adapterFactory={dummyExecuteAfmAdapterFactoryTable}
+            />
+        );
+
+        return testUtils.delay().then(() => {
+            wrapper.update();
+            const dimensions = wrapper.find(SortableTable).props().resultSpec.dimensions;
+
+            expect(dimensions).toEqual([
+                { itemIdentifiers: ['departmentAttribute'] },
+                { itemIdentifiers: [] }
+            ]);
+        });
+    });
+
+    it('should provide default resultSpec to the core Table when afm.measures=[]', () => {
+        const wrapper = mount(
+            <Table
+                projectId="projectId"
+                afm={executionRequestWithEmptyMeasuresArray.execution.afm}
                 adapterFactory={dummyExecuteAfmAdapterFactoryTable}
             />
         );

--- a/src/components/afm/tests/utils/dummyFixture.ts
+++ b/src/components/afm/tests/utils/dummyFixture.ts
@@ -1,7 +1,7 @@
 // (C) 2007-2018 GoodData Corporation
 // from indigo-visualizations/stories/test_data/bar_chart_with_view_by_attribute
 
-import { Execution } from '@gooddata/typings';
+import { AFM, Execution } from '@gooddata/typings';
 
 export const executionRequest = {
     execution: {
@@ -57,6 +57,22 @@ export const executionRequestWithoutMeasureAndWithoutResultSpec = {
                     localIdentifier: 'departmentAttribute'
                 }
             ]
+        }
+    }
+};
+
+export const executionRequestWithEmptyMeasuresArray: AFM.IExecution = {
+    execution: {
+        afm: {
+            attributes: [
+                {
+                    displayForm: {
+                        uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1027'
+                    },
+                    localIdentifier: 'departmentAttribute'
+                }
+            ],
+            measures: []
         }
     }
 };


### PR DESCRIPTION
`6.0.0-ocetnik-doc-afm-measure-empty-array-2018-10-18T10-48-02-035Z`