### PR TITLE
RELATED: BB-1159 Refactor of the derived measures title factory

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "build-dev": "bash scripts/build.sh --dev",
     "dev": "bash scripts/build.sh --dev-watch",
     "test": "jest --watch",
+    "test-once": "jest",
     "run-tslint": "tslint -p tsconfig.json",
     "tslint": "yarn run-tslint -t verbose $npm_package_config_tslint",
     "tslint-ci": "mkdir -p ./ci/results && yarn run-tslint -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",

--- a/src/factory/DerivedMeasureTitleSuffixFactory.ts
+++ b/src/factory/DerivedMeasureTitleSuffixFactory.ts
@@ -1,10 +1,10 @@
 // (C) 2007-2018 GoodData Corporation
-import { Localization, VisualizationObject } from '@gooddata/typings';
+import { Localization } from '@gooddata/typings';
 import IntlStore from '../helpers/IntlStore';
-import IMeasureDefinitionType = VisualizationObject.IMeasureDefinitionType;
+import { OverTimeComparisonType, OverTimeComparisonTypes } from '..';
 
 /**
- * Factory that builds formatted localized suffix string for derived measure based on the measure definition type.
+ * Factory that builds formatted localized suffix string for derived measure based on the over time comparison type.
  * The suffix is used during AFM execution and for bucket item titles.
  *
  * @internal
@@ -22,25 +22,26 @@ export default class DerivedMeasureTitleSuffixFactory {
     }
 
     /**
-     * Returns formatted localized suffix string for derived measure based on the measure definition type.
-     * In case when simple measure definition is provided the empty string is returned.
+     * Returns formatted localized suffix string for derived measure based on the over time comparison type.
+     * In case when unsupported over time comparison type is provided the empty string is returned.
      *
-     * @param {VisualizationObject.IMeasureDefinitionType} measureDefinition - The measure definition for which the
+     * @param {OverTimeComparisonType} overTimeComparisonType - The over time comparison type for which the
      *      suffix must be obtained.
      * @returns {string}
      */
-    public getSuffix(measureDefinition: IMeasureDefinitionType): string {
-        const localizationKey = this.getSuffixLocalizationKey(measureDefinition);
+    public getSuffix(overTimeComparisonType: OverTimeComparisonType): string {
+        const localizationKey = this.getSuffixLocalizationKey(overTimeComparisonType);
         return localizationKey === null ? '' : ` - ${this.translateKey(localizationKey)}`;
     }
 
-    private getSuffixLocalizationKey(measureDefinition: IMeasureDefinitionType): string {
-        if (VisualizationObject.isPopMeasureDefinition(measureDefinition)) {
-            return 'measure.title.suffix.same_period_year_ago';
-        } else if (VisualizationObject.isPreviousPeriodMeasureDefinition(measureDefinition)) {
-            return 'measure.title.suffix.previous_period';
-        } else {
-            return null;
+    private getSuffixLocalizationKey(overTimeComparisonType: OverTimeComparisonType): string {
+        switch (overTimeComparisonType) {
+            case OverTimeComparisonTypes.SAME_PERIOD_PREVIOUS_YEAR:
+                return 'measure.title.suffix.same_period_year_ago';
+            case OverTimeComparisonTypes.PREVIOUS_PERIOD:
+                return 'measure.title.suffix.previous_period';
+            default:
+                return null;
         }
     }
 

--- a/src/factory/tests/DerivedMeasureTitleSuffixFactory.spec.ts
+++ b/src/factory/tests/DerivedMeasureTitleSuffixFactory.spec.ts
@@ -1,46 +1,24 @@
 // (C) 2007-2018 GoodData Corporation
 import DerivedMeasureTitleSuffixFactory from '../DerivedMeasureTitleSuffixFactory';
+import { OverTimeComparisonTypes } from '../..';
 
 describe('DerivedMeasureTitleSuffixFactory', () => {
     describe('getSuffix', () => {
-        it('should return empty string for simple measure', () => {
+        it('should return empty string for unknown over time comparison type', () => {
             const suffixFactory = new DerivedMeasureTitleSuffixFactory('en-US');
-            const suffix = suffixFactory.getSuffix({
-                measureDefinition: {
-                    item: {
-                        uri: '/uri'
-                    }
-                }
-            });
+            const suffix = suffixFactory.getSuffix(OverTimeComparisonTypes.NOTHING);
             expect(suffix).toEqual('');
         });
 
-        it('should return correct suffix for PoP measure', () => {
+        it('should return correct suffix for PoP over time comparison type', () => {
             const suffixFactory = new DerivedMeasureTitleSuffixFactory('en-US');
-            const suffix = suffixFactory.getSuffix({
-                popMeasureDefinition: {
-                    measureIdentifier: 'm1',
-                    popAttribute: {
-                        uri: '/uri'
-                    }
-                }
-            });
+            const suffix = suffixFactory.getSuffix(OverTimeComparisonTypes.SAME_PERIOD_PREVIOUS_YEAR);
             expect(suffix).toEqual(' - SP year ago');
         });
 
-        it('should return correct suffix for previous period measure', () => {
+        it('should return correct suffix for previous period over time comparison type', () => {
             const suffixFactory = new DerivedMeasureTitleSuffixFactory('en-US');
-            const suffix = suffixFactory.getSuffix({
-                previousPeriodMeasure: {
-                    measureIdentifier: 'm1',
-                    dateDataSets: [{
-                        dataSet: {
-                            uri: '/uri'
-                        },
-                        periodsAgo: 1
-                    }]
-                }
-            });
+            const suffix = suffixFactory.getSuffix(OverTimeComparisonTypes.PREVIOUS_PERIOD);
             expect(suffix).toEqual(' - period ago');
         });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import Chart,
 import ChartTransformation from './components/visualizations/chart/ChartTransformation';
 import { RuntimeError } from './errors/RuntimeError';
 import { IMeasureTitleProps, IArithmeticMeasureTitleProps } from './interfaces/MeasureTitle';
+import { OverTimeComparisonType, OverTimeComparisonTypes } from './interfaces/OverTimeComparison';
 
 /**
  * CoreComponents
@@ -114,5 +115,7 @@ export {
     VisualizationEnvironment,
     VisualizationTypes,
     ChartTransformation,
-    Chart
+    Chart,
+    OverTimeComparisonType,
+    OverTimeComparisonTypes
 };

--- a/src/interfaces/OverTimeComparison.ts
+++ b/src/interfaces/OverTimeComparison.ts
@@ -1,0 +1,8 @@
+// (C) 2007-2018 GoodData Corporation
+export const OverTimeComparisonTypes = {
+    SAME_PERIOD_PREVIOUS_YEAR: 'same_period_previous_year' as 'same_period_previous_year',
+    PREVIOUS_PERIOD: 'previous_period' as 'previous_period',
+    NOTHING: 'nothing' as 'nothing'
+};
+
+export type OverTimeComparisonType = 'same_period_previous_year' | 'previous_period' | 'nothing';


### PR DESCRIPTION
The factory should not be dependent on the measure definition (similarly to the arithmetic measure title factory). This way the whole measure definition does not need to be stored in the decorated bucket item in Analytical Designer. For this purpose the OverTimeComparison interface was moved from gdc-app-components into the gooddata-react-component repo.