### PR TITLE
RELATED: BB-1203 Migrate date filters merging from web client to backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Supported REST API versions
+
+This table shows which version of the GoodData.UI introduced support for a particular API version. 
+
+The REST API versions in the table are just for your information as the values are set internally and cannot be overridden. 
+
+|GoodData.UI Version | REST API version
+|:---:|:---:
+|\>= 6.1.0|3
+|<= 6.0.0|2
+
 ## Unreleased/planned
 
 - We are working on arithmetic measures support.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "yup": "^0.24.1"
   },
   "dependencies": {
-    "@gooddata/gooddata-js": "8.4.1",
+    "@gooddata/gooddata-js": "10.0.0",
     "@gooddata/goodstrap": "57.3.0",
     "@gooddata/js-utils": "3.2.0",
     "@gooddata/numberjs": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,11 +96,11 @@
     eslint-plugin-jsx-a11y "6.0.3"
     eslint-plugin-react "7.6.1"
 
-"@gooddata/gooddata-js@8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-8.4.1.tgz#4b8fbaefeca36eeea60b069119ad58c777e39a18"
+"@gooddata/gooddata-js@10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-10.0.0.tgz#861b352c0d6fd2da83a567b99571ebf2d1cf9e76"
   dependencies:
-    "@gooddata/typings" "2.4.0"
+    "@gooddata/typings" "2.4.1"
     es6-promise "3.0.2"
     fetch-cookie "0.7.0"
     invariant "2.2.2"


### PR DESCRIPTION
The logic of the date filter merging is moved from frontend to the backend as the backend needs to know which filters were global and which local (measure filters) in order to construct correct MAQL queries.

In addition to that, the backend REST API is versioned now. The original API version 1 still expects the date filters to be merged by the frontend (in order for GoodData.UI SDK to be backward compatible for at least a year) while API version 2  and newer expects the filters in the original buckets as they were set by the user.

When the backend returns X-GDC-DEPRECATED response header, the frontend client will output warning into the browser's console. The header is returned in the case when value sent in the X-GDC-VERSION does not identify the latest REST API version deployed on the backend server.