### PR TITLE
RELATED: BB-1265, RELATED: BB-1268 Fix translations

### DIFF
--- a/src/translations/es-ES.json
+++ b/src/translations/es-ES.json
@@ -48,6 +48,6 @@
    "gs.list.limitExceeded": "Lo sentimos, ha superado el límite ({limit}).",
    "gs.list.noItemsFound": "No se ha encontrado ningún elemento.",
    "gs.list.error": "Error al cargar los elementos de la lista",
-   "measure.title.suffix.same_period_year_ago": "MP último año",
+   "measure.title.suffix.same_period_year_ago": "MP el año anterior",
    "measure.title.suffix.previous_period": "periodo atrás"
 }

--- a/src/translations/ja-JP.json
+++ b/src/translations/ja-JP.json
@@ -49,5 +49,5 @@
    "gs.list.noItemsFound": "アイテムが見つかりません。",
    "gs.list.error": "リストの読み込みエラー",
    "measure.title.suffix.same_period_year_ago": "前年同期",
-   "measure.title.suffix.previous_period": "前期"
+   "measure.title.suffix.previous_period": " 期前"
 }


### PR DESCRIPTION
Space in translation
```
"measure.title.suffix.previous_period": " 期前"
```
is INTENDED