### PR TITLE
RELATED: BB-1116 Add Arithmetic Measures examples

### DIFF
--- a/examples/src/components/ArithmeticMeasureChangeExample.jsx
+++ b/examples/src/components/ArithmeticMeasureChangeExample.jsx
@@ -1,0 +1,83 @@
+// (C) 2007-2018 GoodData Corporation
+
+import React, { Component } from 'react';
+import { Table } from '@gooddata/react-components';
+
+import '@gooddata/react-components/styles/css/main.css';
+
+import {
+    projectId,
+    monthDateIdentifier,
+    monthDateDataSetAttributeIdentifier,
+    totalSalesIdentifier
+} from '../utils/fixtures';
+import {
+    createMeasureBucketItem,
+    createSamePeriodMeasureBucketItem
+} from '../utils/helpers';
+
+export class ArithmeticMeasureChangeExample extends Component {
+    onLoadingChanged(...params) {
+        // eslint-disable-next-line no-console
+        return console.log('ArithmeticMeasureChangeExample onLoadingChanged', ...params);
+    }
+
+    onError(...params) {
+        // eslint-disable-next-line no-console
+        return console.log('ArithmeticMeasureChangeExample onError', ...params);
+    }
+
+    render() {
+        const totalSalesYearAgoBucketItem = createSamePeriodMeasureBucketItem(
+            'totalSales', monthDateDataSetAttributeIdentifier, '$ Total Sales - year ago'
+        );
+        const totalSalesBucketItem = createMeasureBucketItem(
+            totalSalesIdentifier, 'totalSales', '$ Total Sales'
+        );
+        const measures = [
+            totalSalesYearAgoBucketItem,
+            totalSalesBucketItem,
+            {
+                measure: {
+                    localIdentifier: 'totalSalesChange',
+                    title: '% Total Sales Change',
+                    definition: {
+                        arithmeticMeasure: {
+                            measureIdentifiers: [
+                                totalSalesBucketItem.measure.localIdentifier,
+                                totalSalesYearAgoBucketItem.measure.localIdentifier
+                            ],
+                            operator: 'change'
+                        }
+                    },
+                    format: '#,##0%'
+                }
+            }
+        ];
+
+        const attributes = [
+            {
+                visualizationAttribute: {
+                    displayForm: {
+                        identifier: monthDateIdentifier
+                    },
+                    localIdentifier: 'month'
+                }
+            }
+        ];
+
+        return (
+            <div style={{ height: 200 }} className="s-table">
+                <Table
+                    projectId={projectId}
+                    measures={measures}
+                    attributes={attributes}
+                    onLoadingChanged={this.onLoadingChanged}
+                    onError={this.onError}
+                />
+            </div>
+        );
+    }
+}
+
+export default ArithmeticMeasureChangeExample;

--- a/examples/src/components/ArithmeticMeasureDrillingExample.jsx
+++ b/examples/src/components/ArithmeticMeasureDrillingExample.jsx
@@ -1,0 +1,135 @@
+// (C) 2007-2018 GoodData Corporation
+
+import React, { Component } from 'react';
+import { Table, HeaderPredicateFactory } from '@gooddata/react-components';
+
+import '@gooddata/react-components/styles/css/main.css';
+
+import {
+    projectId,
+    locationStateDisplayFormIdentifier,
+    numberOfRestaurantsIdentifier,
+    totalSalesIdentifier
+} from '../utils/fixtures';
+
+export class ArithmeticMeasureDrillingExample extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            drillEvent: null
+        };
+    }
+
+    onDrill = (drillEvent) => {
+        // eslint-disable-next-line no-console
+        console.log('onFiredDrillEvent', drillEvent, JSON.stringify(drillEvent.drillContext.intersection, null, 2));
+        this.setState({
+            drillEvent
+        });
+        return true;
+    };
+
+    onLoadingChanged(...params) {
+        // eslint-disable-next-line no-console
+        return console.log('ArithmeticMeasureDrillingExample onLoadingChanged', ...params);
+    }
+
+    onError(...params) {
+        // eslint-disable-next-line no-console
+        return console.log('ArithmeticMeasureDrillingExample onError', ...params);
+    }
+
+    render() {
+        const { drillEvent } = this.state;
+
+        const localIdentifiers = {
+            numberOfRestaurants: 'numberOfRestaurants',
+            totalSales: 'totalSales',
+            averageRestaurantSales: 'averageRestaurantSales'
+        };
+
+        const measures = [
+            {
+                measure: {
+                    localIdentifier: localIdentifiers.numberOfRestaurants,
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                identifier: numberOfRestaurantsIdentifier
+                            }
+                        }
+                    },
+                    format: '#,##0'
+                }
+            },
+            {
+                measure: {
+                    localIdentifier: localIdentifiers.totalSales,
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                identifier: totalSalesIdentifier
+                            }
+                        }
+                    },
+                    format: '#,##0'
+                }
+            },
+            {
+                measure: {
+                    localIdentifier: 'averageRestaurantSales',
+                    title: '$ Avg Restaurant Sales',
+                    definition: {
+                        arithmeticMeasure: {
+                            measureIdentifiers: [
+                                localIdentifiers.totalSales,
+                                localIdentifiers.numberOfRestaurants
+                            ],
+                            operator: 'ratio'
+                        }
+                    },
+                    format: '#,##0'
+                }
+            }
+        ];
+
+        const attributes = [
+            {
+                visualizationAttribute: {
+                    displayForm: {
+                        identifier: locationStateDisplayFormIdentifier
+                    },
+                    localIdentifier: 'month'
+                }
+            }
+        ];
+
+        const drillNotificationComponent = () => {
+            const averageSales = drillEvent.drillContext.row[drillEvent.drillContext.columnIndex];
+            return (
+                <h3>You have clicked <span className="s-drill-value">{averageSales}</span></h3>
+            );
+        };
+
+        return (
+            <div>
+                {drillEvent === null ? null : drillNotificationComponent()}
+                <div style={{ height: 200 }} className="s-table">
+                    <Table
+                        projectId={projectId}
+                        measures={measures}
+                        attributes={attributes}
+                        onLoadingChanged={this.onLoadingChanged}
+                        onError={this.onError}
+                        drillableItems={[
+                            HeaderPredicateFactory.composedFromIdentifier(totalSalesIdentifier)
+                        ]}
+                        onFiredDrillEvent={this.onDrill}
+                    />
+                </div>
+            </div>
+        );
+    }
+}
+
+export default ArithmeticMeasureDrillingExample;

--- a/examples/src/components/ArithmeticMeasureMultiplicationExample.jsx
+++ b/examples/src/components/ArithmeticMeasureMultiplicationExample.jsx
@@ -1,0 +1,102 @@
+// (C) 2007-2018 GoodData Corporation
+
+import React, { Component } from 'react';
+import { Table } from '@gooddata/react-components';
+
+import '@gooddata/react-components/styles/css/main.css';
+
+import {
+    projectId,
+    locationStateDisplayFormIdentifier,
+    numberOfRestaurantsIdentifier,
+    averageRestaurantDailyCostsIdentifier
+} from '../utils/fixtures';
+
+export class ArithmeticMeasureMultiplicationExample extends Component {
+    onLoadingChanged(...params) {
+        // eslint-disable-next-line no-console
+        return console.log('ArithmeticMeasureMultiplicationExample onLoadingChanged', ...params);
+    }
+
+    onError(...params) {
+        // eslint-disable-next-line no-console
+        return console.log('ArithmeticMeasureMultiplicationExample onError', ...params);
+    }
+
+    render() {
+        const localIdentifiers = {
+            numberOfRestaurants: 'numberOfRestaurants',
+            averageRestaurantDailyCosts: 'averageRestaurantDailyCosts'
+        };
+
+        const measures = [
+            {
+                measure: {
+                    localIdentifier: localIdentifiers.numberOfRestaurants,
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                identifier: numberOfRestaurantsIdentifier
+                            }
+                        }
+                    },
+                    format: '#,##0'
+                }
+            },
+            {
+                measure: {
+                    localIdentifier: localIdentifiers.averageRestaurantDailyCosts,
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                identifier: averageRestaurantDailyCostsIdentifier
+                            }
+                        }
+                    },
+                    format: '#,##0'
+                }
+            },
+            {
+                measure: {
+                    localIdentifier: 'averageStateDailyCosts',
+                    title: '$ Avg State Daily Costs',
+                    definition: {
+                        arithmeticMeasure: {
+                            measureIdentifiers: [
+                                localIdentifiers.numberOfRestaurants,
+                                localIdentifiers.averageRestaurantDailyCosts
+                            ],
+                            operator: 'multiplication'
+                        }
+                    },
+                    format: '#,##0'
+                }
+            }
+        ];
+
+        const attributes = [
+            {
+                visualizationAttribute: {
+                    displayForm: {
+                        identifier: locationStateDisplayFormIdentifier
+                    },
+                    localIdentifier: 'month'
+                }
+            }
+        ];
+
+        return (
+            <div style={{ height: 200 }} className="s-table">
+                <Table
+                    projectId={projectId}
+                    measures={measures}
+                    attributes={attributes}
+                    onLoadingChanged={this.onLoadingChanged}
+                    onError={this.onError}
+                />
+            </div>
+        );
+    }
+}
+
+export default ArithmeticMeasureMultiplicationExample;

--- a/examples/src/components/ArithmeticMeasureRatioExample.jsx
+++ b/examples/src/components/ArithmeticMeasureRatioExample.jsx
@@ -1,0 +1,102 @@
+// (C) 2007-2018 GoodData Corporation
+
+import React, { Component } from 'react';
+import { Table } from '@gooddata/react-components';
+
+import '@gooddata/react-components/styles/css/main.css';
+
+import {
+    projectId,
+    locationStateDisplayFormIdentifier,
+    numberOfRestaurantsIdentifier,
+    totalSalesIdentifier
+} from '../utils/fixtures';
+
+export class ArithmeticMeasureRatioExample extends Component {
+    onLoadingChanged(...params) {
+        // eslint-disable-next-line no-console
+        return console.log('ArithmeticMeasureRatioExample onLoadingChanged', ...params);
+    }
+
+    onError(...params) {
+        // eslint-disable-next-line no-console
+        return console.log('ArithmeticMeasureRatioExample onError', ...params);
+    }
+
+    render() {
+        const localIdentifiers = {
+            numberOfRestaurants: 'numberOfRestaurants',
+            averageRestaurantDailyCosts: 'averageRestaurantDailyCosts'
+        };
+
+        const measures = [
+            {
+                measure: {
+                    localIdentifier: localIdentifiers.numberOfRestaurants,
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                identifier: numberOfRestaurantsIdentifier
+                            }
+                        }
+                    },
+                    format: '#,##0'
+                }
+            },
+            {
+                measure: {
+                    localIdentifier: localIdentifiers.averageRestaurantDailyCosts,
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                identifier: totalSalesIdentifier
+                            }
+                        }
+                    },
+                    format: '#,##0'
+                }
+            },
+            {
+                measure: {
+                    localIdentifier: 'averageRestaurantSales',
+                    title: '$ Avg Restaurant Sales',
+                    definition: {
+                        arithmeticMeasure: {
+                            measureIdentifiers: [
+                                localIdentifiers.averageRestaurantDailyCosts,
+                                localIdentifiers.numberOfRestaurants
+                            ],
+                            operator: 'ratio'
+                        }
+                    },
+                    format: '#,##0'
+                }
+            }
+        ];
+
+        const attributes = [
+            {
+                visualizationAttribute: {
+                    displayForm: {
+                        identifier: locationStateDisplayFormIdentifier
+                    },
+                    localIdentifier: 'month'
+                }
+            }
+        ];
+
+        return (
+            <div style={{ height: 200 }} className="s-table">
+                <Table
+                    projectId={projectId}
+                    measures={measures}
+                    attributes={attributes}
+                    onLoadingChanged={this.onLoadingChanged}
+                    onError={this.onError}
+                />
+            </div>
+        );
+    }
+}
+
+export default ArithmeticMeasureRatioExample;

--- a/examples/src/components/ArithmeticMeasureSumExample.jsx
+++ b/examples/src/components/ArithmeticMeasureSumExample.jsx
@@ -1,0 +1,118 @@
+// (C) 2007-2018 GoodData Corporation
+
+import React, { Component } from 'react';
+import { Table } from '@gooddata/react-components';
+
+import '@gooddata/react-components/styles/css/main.css';
+
+import {
+    projectId,
+    franchiseFeesAdRoyaltyIdentifier,
+    franchiseFeesIdentifierOngoingRoyalty,
+    locationStateDisplayFormIdentifier
+} from '../utils/fixtures';
+
+export class ArithmeticMeasureSumExample extends Component {
+    onLoadingChanged(...params) {
+        // eslint-disable-next-line no-console
+        return console.log('ArithmeticMeasureSumExample onLoadingChanged', ...params);
+    }
+
+    onError(...params) {
+        // eslint-disable-next-line no-console
+        return console.log('ArithmeticMeasureSumExample onError', ...params);
+    }
+
+    render() {
+        const localIdentifiers = {
+            franchiseFeesAdRoyalty: 'franchiseFeesAdRoyalty',
+            franchiseFeesOngoingRoyalty: 'franchiseFeesOngoingRoyalty'
+        };
+
+        const measures = [
+            {
+                measure: {
+                    localIdentifier: localIdentifiers.franchiseFeesAdRoyalty,
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                identifier: franchiseFeesAdRoyaltyIdentifier
+                            }
+                        }
+                    },
+                    format: '#,##0'
+                }
+            },
+            {
+                measure: {
+                    localIdentifier: localIdentifiers.franchiseFeesOngoingRoyalty,
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                identifier: franchiseFeesIdentifierOngoingRoyalty
+                            }
+                        }
+                    },
+                    format: '#,##0'
+                }
+            },
+            {
+                measure: {
+                    localIdentifier: 'franchiseFeesSum',
+                    title: '$ Ongoing / Ad Royalty Sum',
+                    definition: {
+                        arithmeticMeasure: {
+                            measureIdentifiers: [
+                                localIdentifiers.franchiseFeesOngoingRoyalty,
+                                localIdentifiers.franchiseFeesAdRoyalty
+                            ],
+                            operator: 'sum'
+                        }
+                    },
+                    format: '#,##0'
+                }
+            },
+            {
+                measure: {
+                    localIdentifier: 'franchiseFeesDifference',
+                    title: '$ Ongoing / Ad Royalty Difference',
+                    definition: {
+                        arithmeticMeasure: {
+                            measureIdentifiers: [
+                                localIdentifiers.franchiseFeesOngoingRoyalty,
+                                localIdentifiers.franchiseFeesAdRoyalty
+                            ],
+                            operator: 'difference'
+                        }
+                    },
+                    format: '#,##0'
+                }
+            }
+        ];
+
+        const attributes = [
+            {
+                visualizationAttribute: {
+                    displayForm: {
+                        identifier: locationStateDisplayFormIdentifier
+                    },
+                    localIdentifier: 'month'
+                }
+            }
+        ];
+
+        return (
+            <div style={{ height: 200 }} className="s-table">
+                <Table
+                    projectId={projectId}
+                    measures={measures}
+                    attributes={attributes}
+                    onLoadingChanged={this.onLoadingChanged}
+                    onError={this.onError}
+                />
+            </div>
+        );
+    }
+}
+
+export default ArithmeticMeasureSumExample;

--- a/examples/src/components/DrillWithExternalDataExample.jsx
+++ b/examples/src/components/DrillWithExternalDataExample.jsx
@@ -4,7 +4,13 @@ import * as React from 'react';
 import fetch from 'isomorphic-fetch';
 import moment from 'moment';
 import { PropTypes } from 'prop-types';
-import { Table, ColumnChart, LoadingComponent, ErrorComponent } from '@gooddata/react-components';
+import {
+    Table,
+    ColumnChart,
+    LoadingComponent,
+    ErrorComponent,
+    HeaderPredicateFactory
+} from '@gooddata/react-components';
 import {
     projectId,
     employeeNameIdentifier,
@@ -232,9 +238,9 @@ export class DrillWithExternalDataExample extends React.Component {
                     projectId={projectId}
                     measures={[averageDailySalesMeasure]}
                     attributes={[stateAttribute]}
-                    drillableItems={[{
-                        identifier: locationStateDisplayFormIdentifier
-                    }]}
+                    drillableItems={[
+                        HeaderPredicateFactory.identifierMatch(locationStateDisplayFormIdentifier)
+                    ]}
                     onFiredDrillEvent={this.onStateDrill}
                 />
             </div>
@@ -249,9 +255,9 @@ export class DrillWithExternalDataExample extends React.Component {
                     projectId={projectId}
                     measures={[averageDailySalesMeasure]}
                     attributes={[employeeNameAttribute]}
-                    drillableItems={[{
-                        identifier: employeeNameIdentifier
-                    }]}
+                    drillableItems={[
+                        HeaderPredicateFactory.identifierMatch(employeeNameIdentifier)
+                    ]}
                     filters={employeeTableFilters}
                     onFiredDrillEvent={this.onEmployeeDrill}
                 />
@@ -267,9 +273,9 @@ export class DrillWithExternalDataExample extends React.Component {
                     measures={[totalSalesMeasure]}
                     viewBy={locationNameAttribute}
                     filters={salesTableFilters}
-                    drillableItems={[{
-                        identifier: locationNameDisplayFormIdentifier
-                    }]}
+                    drillableItems={[
+                        HeaderPredicateFactory.identifierMatch(locationNameDisplayFormIdentifier)
+                    ]}
                     onFiredDrillEvent={this.onLocationDrill}
                 />
             </div>

--- a/examples/src/components/PivotTableDrillExample.jsx
+++ b/examples/src/components/PivotTableDrillExample.jsx
@@ -1,6 +1,6 @@
 // (C) 2007-2018 GoodData Corporation
 import React, { Component } from 'react';
-import { PivotTable } from '@gooddata/react-components';
+import { PivotTable, HeaderPredicateFactory } from '@gooddata/react-components';
 
 import '@gooddata/react-components/styles/css/main.css';
 
@@ -92,9 +92,9 @@ export class PivotTableDrillExample extends Component {
             }
         ];
 
-        const drillableItems = [{
-            identifier: menuCategoryAttributeDFIdentifier
-        }];
+        const drillableItems = [
+            HeaderPredicateFactory.identifierMatch(menuCategoryAttributeDFIdentifier)
+        ];
 
         const attributes = [
             {

--- a/examples/src/components/PivotTableDynamicExample.jsx
+++ b/examples/src/components/PivotTableDynamicExample.jsx
@@ -1,6 +1,6 @@
 // (C) 2007-2018 GoodData Corporation
 import React, { Component } from 'react';
-import { PivotTable, Table } from '@gooddata/react-components';
+import { PivotTable, Table, HeaderPredicateFactory } from '@gooddata/react-components';
 
 import '@gooddata/react-components/styles/css/main.css';
 
@@ -115,51 +115,37 @@ const drillingPresets = {
     measure: {
         label: 'Measure Franchise Fees',
         key: 'measure',
-        drillableItem: {
-            identifier: franchiseFeesIdentifier
-        }
+        drillableItem: HeaderPredicateFactory.identifierMatch(franchiseFeesIdentifier)
     },
     attributeMonth: {
         label: 'Attribute Month',
         key: 'attributeMonth',
-        drillableItem: {
-            identifier: monthDateIdentifier
-        }
+        drillableItem: HeaderPredicateFactory.identifierMatch(monthDateIdentifier)
     },
     attributeQuarter: {
         label: 'Attribute Quarter',
         key: 'attributeQuarter',
-        drillableItem: {
-            identifier: quarterDateIdentifier
-        }
+        drillableItem: HeaderPredicateFactory.identifierMatch(quarterDateIdentifier)
     },
     attributeLocationState: {
         label: 'Attribute Location state',
         key: 'attributeLocationState',
-        drillableItem: {
-            identifier: locationStateDisplayFormIdentifier
-        }
+        drillableItem: HeaderPredicateFactory.identifierMatch(locationStateDisplayFormIdentifier)
     },
     attributeMenuCategory: {
         label: 'Attribute Menu category',
         key: 'attributeMenuCategory',
-        drillableItem: {
-            identifier: menuCategoryAttributeDFIdentifier
-        }
+        drillableItem: HeaderPredicateFactory.identifierMatch(menuCategoryAttributeDFIdentifier)
     },
     attributeValueCalifornia: {
         label: 'Attribute value California',
         key: 'attributeValueCalifornia',
-        drillableItem: {
-            uri: locationStateAttributeCaliforniaUri
-        }
+        drillableItem: HeaderPredicateFactory.uriMatch(locationStateAttributeCaliforniaUri)
     },
     attributeValueJanuary: {
         label: 'Attribute value January',
         key: 'attributeValueJanuary',
-        drillableItem: {
-            uri: monthDateIdentifierJanuary
-        }
+        drillableItem: HeaderPredicateFactory.uriMatch(monthDateIdentifierJanuary)
     }
 };
 const totalPresets = {

--- a/examples/src/routes/ArithmeticMeasure.jsx
+++ b/examples/src/routes/ArithmeticMeasure.jsx
@@ -1,0 +1,72 @@
+// (C) 2007-2018 GoodData Corporation
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import ExampleWithSource from '../components/utils/ExampleWithSource';
+
+import ArithmeticMeasureSumExample from '../components/ArithmeticMeasureSumExample';
+import ArithmeticMeasureMultiplicationExample from '../components/ArithmeticMeasureMultiplicationExample';
+import ArithmeticMeasureRatioExample from '../components/ArithmeticMeasureRatioExample';
+import ArithmeticMeasureChangeExample from '../components/ArithmeticMeasureChangeExample';
+import ArithmeticMeasureDrillingExample from '../components/ArithmeticMeasureDrillingExample';
+
+import ArithmeticMeasureSumExampleSrc from '!raw-loader!../components/ArithmeticMeasureSumExample'; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
+import ArithmeticMeasureMultiplicationExampleSrc from '!raw-loader!../components/ArithmeticMeasureMultiplicationExample'; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
+import ArithmeticMeasureRatioExampleSrc from '!raw-loader!../components/ArithmeticMeasureRatioExample'; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
+import ArithmeticMeasureChangeExampleSrc from '!raw-loader!../components/ArithmeticMeasureChangeExample'; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
+import ArithmeticMeasureDrillingExampleSrc from '!raw-loader!../components/ArithmeticMeasureDrillingExample'; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
+
+export const ArithmeticMeasure = () => (
+    <div>
+        <h1>Arithmetic Measures</h1>
+        <p>These examples show how to configure visual components like column charts or headlines to show data
+            calculated on demand with defined arithmetical operations.
+        </p>
+        <p>
+            Any arithmetic measure is built on top of two measures and given arithmetic operation between them.
+            The base measures can be of any type (including the complex measures,
+            such as <Link to="/time-over-time-comparison">Time Over Time Comparison</Link> or even another
+            Arithmetic Measure).
+        </p>
+
+        <hr className="separator" />
+
+        <h2>Ratio</h2>
+        <p>Take two measures and divide them (e.g. gross margin = gross profit / net sales).</p>
+        <ExampleWithSource
+            for={ArithmeticMeasureRatioExample}
+            source={ArithmeticMeasureRatioExampleSrc}
+        />
+
+        <h2>Change</h2>
+        <p>Calculate percentual change between two measures.</p>
+
+        <p>Note: This example shows how it is possible to
+            use <Link to="/time-over-time-comparison">Time Over Time Comparison</Link> with Arithmetic Measures to
+            display trend of the given metric.
+        </p>
+        <ExampleWithSource
+            for={ArithmeticMeasureChangeExample}
+            source={ArithmeticMeasureChangeExampleSrc}
+        />
+
+        <h2>Sum and difference</h2>
+        <p>Add or subtract two measures (e.g. revenue in 2017 - revenue in 2016).</p>
+        <ExampleWithSource for={ArithmeticMeasureSumExample} source={ArithmeticMeasureSumExampleSrc} />
+
+        <h2>Multiplication</h2>
+        <p>Multiply two measures (e.g. price per unit x volume = revenue).</p>
+        <ExampleWithSource
+            for={ArithmeticMeasureMultiplicationExample}
+            source={ArithmeticMeasureMultiplicationExampleSrc}
+        />
+
+        <h2>Arithmetic Measures with Drilling</h2>
+        <ExampleWithSource
+            for={ArithmeticMeasureDrillingExample}
+            source={ArithmeticMeasureDrillingExampleSrc}
+        />
+    </div>
+);
+
+export default ArithmeticMeasure;

--- a/examples/src/routes/_list.js
+++ b/examples/src/routes/_list.js
@@ -24,6 +24,7 @@ import PivotTableDynamic from './PivotTableDynamic';
 import AggregationTest from './AggregationTest';
 import WithSubRoutes from './WithSubRoutes';
 import ChartConfiguration from './ChartConfiguration';
+import ArithmeticMeasure from './ArithmeticMeasure';
 
 export const advancedUseCasesRoutes = [
     { path: '/advanced/global-filters', title: 'Global Filters', Component: GlobalFilters },
@@ -51,6 +52,7 @@ export const sideNavigationRoutes = [
     { path: '/sorting', title: 'Sorting', Component: Sorting },
     { path: '/time-over-time-comparison', title: 'Time Over Time Comparison', Component: TimeOverTimeComparison },
     { path: '/attribute-filter-components', title: 'Attribute Filter Components', Component: AttributeFilter },
+    { path: '/arithmetic-measures', title: 'Arithmetic Measures', Component: ArithmeticMeasure },
     { path: '/execute', title: 'Execute Component', Component: Execute },
     { path: '/advanced', pathMatch: 'full', redirectTo: advancedUseCasesRoutes[0].path, title: 'Advanced Use Cases', Component: AdvancedUseCasesRoutes },
     { path: '/next', pathMatch: 'full', redirectTo: nextRoutes[0].path, title: 'Next', Component: NextRoutes }

--- a/examples/src/utils/fixtures.js
+++ b/examples/src/utils/fixtures.js
@@ -49,9 +49,12 @@ export const locationStateDisplayFormIdentifier = 'label.restaurantlocation.loca
 export const menuCategoryAttributeDFIdentifier = 'label.menuitem.menucategory';
 export const menuItemNameAttributeDFIdentifier = 'label.menuitem.menuitemname';
 export const yearDateDataSetAttributeIdentifier = 'date.year';
+export const monthDateDataSetAttributeIdentifier = 'date.month';
 export const quarterDateIdentifier = 'date.aam81lMifn6q';
 export const monthDateIdentifier = 'date.abm81lMifn6q';
 export const monthDateIdentifierJanuary = `/gdc/md/${demoProjectId}/obj/2071/elements?id=1`;
 export const numberOfChecksIdentifier = 'aeOt50ngicOD';
 export const tableVisualizationIdentifier = 'aatFRvXBdilm';
 export const totalSalesIdentifier = 'aa7ulGyKhIE5';
+export const numberOfRestaurantsIdentifier = 'aawAq8YqhM3o';
+export const averageRestaurantDailyCostsIdentifier = 'aaQJzQzoeKwZ';


### PR DESCRIPTION
Add new Arithmetic Measures page to the SDK public
examples project.

Table is used for all samples as it seems to be the
most straightforward visualization. Also, all arithmetic
operations are shown, incl. derived metrics and
arithmetic measure drilling.

New Drilling API from BB-1127 was used and other drilling
examples were updated as well.