### PR TITLE
BUGFIX: RAIL-1241 Push sorts only once, right after they changed

### DIFF
--- a/src/components/core/base/VisualizationLoadingHOC.tsx
+++ b/src/components/core/base/VisualizationLoadingHOC.tsx
@@ -167,10 +167,7 @@ export function visualizationLoadingHOC<T extends ICommonVisualizationProps & ID
                     // gooddata-js mergePages doesn't support discontinuous page ranges yet
                     this.setState({ result, error: null });
                     this.props.pushData({
-                        result,
-                        properties: {
-                            sortItems: resultSpec ? resultSpec.sorts : []
-                        }
+                        result
                     });
                     this.onLoadingChanged({ isLoading: false });
                     return result;


### PR DESCRIPTION
- Register onSortChangedEvent handler for ag-grid; in this handler:
-- Create sort model (colId + sort direction)
-- Calculate sort items using sort model + previous execution (relying on causality.. sorts can be changed by clicking on the table only after it is rendered == some execution is in place)

- Remove sort item calculation & resultSpec overrides from getGridDataSource() function
-- The code is no longer needed here as the caller gets notified about changed sorts => sends resultSpec with changed sorts

- Do not include { properties: { sortItems } } in pushData in VisualizationHOC.getPage()
-- No longer needed here, caller gets notified about changed sorts immediately after user clicks the caret.