### PR TITLE
RELATED: RAIL-1137 add sorting direction s- class to HeaderCell

### DIFF
--- a/src/components/core/pivotTable/HeaderCell.tsx
+++ b/src/components/core/pivotTable/HeaderCell.tsx
@@ -182,7 +182,7 @@ export default class HeaderCell extends React.Component<IProps, IState> {
         const { enableSorting } = this.props;
         const { currentSortDirection } = this.state;
 
-        const sortClasses = classNames('s-sort-direction-arrow', {
+        const sortClasses = classNames('s-sort-direction-arrow', `s-sorted-${currentSortDirection}`, {
             'gd-pivot-table-header-arrow-up': currentSortDirection === 'asc',
             'gd-pivot-table-header-arrow-down': currentSortDirection === 'desc'
         });
@@ -218,6 +218,7 @@ export default class HeaderCell extends React.Component<IProps, IState> {
                 <div
                     className={classNames(
                         'gd-pivot-table-header',
+                        's-pivot-table-header',
                         {
                             'gd-pivot-table-header--open': this.state.isMenuOpen
                         }

--- a/src/components/core/pivotTable/tests/HeaderCell.spec.tsx
+++ b/src/components/core/pivotTable/tests/HeaderCell.spec.tsx
@@ -47,6 +47,7 @@ describe('HeaderCell renderer', () => {
             component.simulate('mouseEnter');
             expect(component.state('currentSortDirection')).toEqual('asc');
             expect(component.find('.s-sort-direction-arrow')).toHaveLength(1);
+            expect(component.find('.s-sorted-asc')).toHaveLength(1);
         });
 
         it('should call onSortChaged when clicked on label', () => {


### PR DESCRIPTION
Adds sorting direction `s-` class to PivotTabel HeaderCell to facilitate testing