### PR TITLE
BUGFIX: RAIL-1241 Push sorts only once, right after they have changed

### DIFF
--- a/src/components/core/base/VisualizationLoadingHOC.tsx
+++ b/src/components/core/base/VisualizationLoadingHOC.tsx
@@ -167,10 +167,7 @@ export function visualizationLoadingHOC<T extends ICommonVisualizationProps & ID
                     // gooddata-js mergePages doesn't support discontinuous page ranges yet
                     this.setState({ result, error: null });
                     this.props.pushData({
-                        result,
-                        properties: {
-                            sortItems: resultSpec ? resultSpec.sorts : []
-                        }
+                        result
                     });
                     this.onLoadingChanged({ isLoading: false });
                     return result;

--- a/src/components/core/base/test/VisualizationLoadingHOC.spec.tsx
+++ b/src/components/core/base/test/VisualizationLoadingHOC.spec.tsx
@@ -353,8 +353,7 @@ describe('VisualizationLoadingHOC', () => {
 
             return testUtils.delay().then(() => {
                 expect(pushData).toHaveBeenCalledWith({
-                    result: oneMeasureResponse,
-                    properties: { sortItems: undefined }
+                    result: oneMeasureResponse
                 });
                 expect(onLoadingChanged).toHaveBeenCalledWith({ isLoading: false });
             });


### PR DESCRIPTION
**DO NOT MERGE**

The code within changes how sortItems are propagated. 

Before:
- Calculate & send sortItems with every request to getPage() ==> unnecessary cycles spent + repeated dispatch of sortItems 'broke' AD undo/redo

After:
- listen for ag-grid onSortChanged event
- then retrieve sort model from columns, via columnApi incoming in event payload
- calculate sortItems using sortModel & existing execution
- call onSortChange callback received on PivotTable props
- call pushData with properties: { sortItems }