### PR TITLE
RELATED: BB-1326 Pass executionResponse to header predicate calls

### DIFF
--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -406,7 +406,7 @@ export class PivotTableInner extends
      * getCellClass returns class for drillable cells. (maybe format in the future as well)
      */
     public getCellClass = (classList: string) => (cellClassParams: CellClassParams): string => {
-        const { dataSource } = this.props;
+        const { dataSource, execution: { executionResponse } } = this.props;
         const { rowIndex } = cellClassParams;
         const colDef = cellClassParams.colDef as IGridHeader;
         const drillablePredicates = this.getDrillablePredicates();
@@ -422,10 +422,8 @@ export class PivotTableInner extends
                 get<CellClassParams, IMappingHeader>(cellClassParams, ['data', 'drillItemMap', colDef.field]);
             const headers: IMappingHeader[] = rowDrillItem ? [...colDef.drillItems, rowDrillItem] : colDef.drillItems;
 
-            hasDrillableHeader = headers
-                .some(
-                    (drillItem: IMappingHeader) => isSomeHeaderPredicateMatched(drillablePredicates, drillItem, afm)
-                );
+            hasDrillableHeader = headers.some((drillItem: IMappingHeader) =>
+                isSomeHeaderPredicateMatched(drillablePredicates, drillItem, afm, executionResponse));
         }
 
         const className = classNames(
@@ -502,7 +500,7 @@ export class PivotTableInner extends
     }
 
     public cellClicked = (cellEvent: IGridCellEvent) => {
-        const { onFiredDrillEvent } = this.props;
+        const { onFiredDrillEvent, execution: { executionResponse } } = this.props;
         const { columnDefs } = this.state;
         const afm: AFM.IAfm = this.props.dataSource.getAfm();
         const drillablePredicates = this.getDrillablePredicates();
@@ -511,10 +509,8 @@ export class PivotTableInner extends
         const isRowTotal = get<IGridCellEvent, string>(cellEvent, ['data', 'type', ROW_TOTAL]);
         const rowDrillItem = get<IGridCellEvent, IMappingHeader>(cellEvent, ['data', 'drillItemMap', colDef.field]);
         const drillItems: IMappingHeader[] = rowDrillItem ? [...colDef.drillItems, rowDrillItem] : colDef.drillItems;
-        const drillableHeaders = drillItems
-            .filter(
-                (drillItem: IMappingHeader) => isSomeHeaderPredicateMatched(drillablePredicates, drillItem, afm)
-            );
+        const drillableHeaders = drillItems.filter((drillItem: IMappingHeader) =>
+            isSomeHeaderPredicateMatched(drillablePredicates, drillItem, afm, executionResponse));
 
         if (isRowTotal || drillableHeaders.length === 0) {
             return false;

--- a/src/components/visualizations/chart/ChartTransformation.tsx
+++ b/src/components/visualizations/chart/ChartTransformation.tsx
@@ -110,7 +110,7 @@ export default class ChartTransformation extends React.Component<IChartTransform
         const {
             drillableItems,
             executionRequest: { afm, resultSpec },
-            executionResponse: { dimensions },
+            executionResponse,
             executionResult: { data, headerItems },
             config,
             onDataTooLarge,
@@ -128,7 +128,7 @@ export default class ChartTransformation extends React.Component<IChartTransform
         this.chartOptions = getChartOptions(
             afm,
             resultSpec,
-            dimensions,
+            executionResponse,
             multiDimensionalData as Execution.DataValue[][],
             headerItems,
             config,

--- a/src/components/visualizations/chart/colorFactory.ts
+++ b/src/components/visualizations/chart/colorFactory.ts
@@ -29,7 +29,8 @@ import { VisualizationTypes } from '../../../constants/visualizationTypes';
 
 import {
     isDerivedMeasure,
-    findParentMeasureIndex
+    findParentMeasureIndex,
+    findMeasureGroupInDimensions
 } from './chartOptionsBuilder';
 
 import {
@@ -55,7 +56,6 @@ export interface ICreateColorAssignmentReturnValue {
 }
 
 export type HighChartColorPalette = string[];
-export type MeasureGroupType = Execution.IMeasureGroupHeader['measureGroupHeader'];
 export const attributeChartSupportedTypes = [
     VisualizationTypes.PIE,
     VisualizationTypes.DONUT,
@@ -72,17 +72,17 @@ export abstract class ColorStrategy implements IColorStrategy {
     constructor(
         colorPalette: IColorPalette,
         colorMapping: IColorMapping[],
-        measureGroup: MeasureGroupType,
         viewByAttribute: any,
         stackByAttribute: any,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ) {
         const { fullColorAssignment, outputColorAssignment } = this.createColorAssignment(
             colorPalette,
             colorMapping,
-            measureGroup,
             viewByAttribute,
             stackByAttribute,
+            executionResponse,
             afm
         );
         this.fullColorAssignment = fullColorAssignment;
@@ -119,9 +119,9 @@ export abstract class ColorStrategy implements IColorStrategy {
     protected abstract createColorAssignment(
         colorPalette: IColorPalette,
         colorMapping: IColorMapping[],
-        measureGroup: MeasureGroupType,
         viewByAttribute: any,
         stackByAttribute: any,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ): ICreateColorAssignmentReturnValue;
 }
@@ -132,25 +132,25 @@ export class MeasureColorStrategy extends ColorStrategy {
     protected createColorAssignment(
         colorPalette: IColorPalette,
         colorMapping: IColorMapping[],
-        measureGroup: MeasureGroupType,
         _viewByAttribute: any,
         _stackByAttribute: any,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ): ICreateColorAssignmentReturnValue {
         const {
             allMeasuresAssignment,
             nonDerivedMeasuresAssignment
-        } = this.mapColorsFromMeasures(measureGroup, afm, colorMapping, colorPalette);
+        } = this.mapColorsFromMeasures(executionResponse, afm, colorMapping, colorPalette);
 
         return {
             fullColorAssignment: this.mapColorsFromDerivedMeasure(
-                measureGroup, afm, allMeasuresAssignment, colorPalette),
+                executionResponse, afm, allMeasuresAssignment, colorPalette),
             outputColorAssignment: nonDerivedMeasuresAssignment
         };
     }
 
     private mapColorsFromMeasures(
-        measureGroup: MeasureGroupType,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm,
         colorMapping: IColorMapping[],
         colorPalette: IColorPalette
@@ -158,6 +158,7 @@ export class MeasureColorStrategy extends ColorStrategy {
         let currentColorPaletteIndex = 0;
 
         const nonDerivedMeasuresAssignment: IColorAssignment[] = [];
+        const measureGroup = findMeasureGroupInDimensions(executionResponse.dimensions);
         const allMeasuresAssignment = measureGroup.items.map((headerItem, index) => {
             if (isDerivedMeasure(measureGroup.items[index], afm)) {
                 return {
@@ -171,6 +172,7 @@ export class MeasureColorStrategy extends ColorStrategy {
                 currentColorPaletteIndex,
                 colorPalette,
                 colorMapping,
+                executionResponse,
                 afm
             );
 
@@ -192,9 +194,10 @@ export class MeasureColorStrategy extends ColorStrategy {
         currentColorPaletteIndex: number,
         colorPalette: IColorPalette,
         colorAssignment: IColorMapping[],
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ): IColorAssignment {
-        const mappedColor = getColorFromMapping(headerItem, colorAssignment, afm);
+        const mappedColor = getColorFromMapping(headerItem, colorAssignment, executionResponse, afm);
 
         const color: IColorItem = isValidMappedColor(mappedColor, colorPalette)
             ? mappedColor
@@ -210,12 +213,13 @@ export class MeasureColorStrategy extends ColorStrategy {
     }
 
     private mapColorsFromDerivedMeasure(
-        measureGroup: MeasureGroupType,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm,
         measuresColorAssignment: IColorAssignment[],
         colorPalette: IColorPalette
     ): IColorAssignment[] {
         return measuresColorAssignment.map((mapItem, measureItemIndex) => {
+            const measureGroup = findMeasureGroupInDimensions(executionResponse.dimensions);
             if (!isDerivedMeasure(measureGroup.items[measureItemIndex], afm)) {
                 return mapItem;
             }
@@ -259,6 +263,7 @@ function getAtributeColorAssignment(
         attribute: any,
         colorPalette: IColorPalette,
         colorMapping: IColorMapping[],
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ): IColorAssignment[] {
     let currentColorPaletteIndex = 0;
@@ -266,7 +271,7 @@ function getAtributeColorAssignment(
         = uniqBy<any, Execution.IResultAttributeHeaderItem>(attribute.items, 'attributeHeaderItem.uri');
 
     return uniqItems.map((headerItem) => {
-        const mappedColor = getColorFromMapping(headerItem, colorMapping, afm);
+        const mappedColor = getColorFromMapping(headerItem, colorMapping, executionResponse, afm);
 
         const color: IColorItem = isValidMappedColor(mappedColor, colorPalette)
             ? mappedColor
@@ -305,13 +310,14 @@ export class AttributeColorStrategy extends ColorStrategy {
     protected createColorAssignment(
         colorPalette: IColorPalette,
         colorMapping: IColorMapping[],
-        _measureGroup: MeasureGroupType,
         viewByAttribute: any,
         stackByAttribute: any,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ): ICreateColorAssignmentReturnValue {
         const attribute = stackByAttribute ? stackByAttribute : viewByAttribute;
-        const colorAssignment = getAtributeColorAssignment(attribute, colorPalette, colorMapping, afm);
+        const colorAssignment =
+            getAtributeColorAssignment(attribute, colorPalette, colorMapping, executionResponse, afm);
         return {
             fullColorAssignment: colorAssignment
         };
@@ -326,16 +332,17 @@ export class HeatmapColorStrategy extends ColorStrategy {
     protected createColorAssignment(
         colorPalette: IColorPalette,
         colorMapping: IColorMapping[],
-        measureGroup: MeasureGroupType,
         _viewByAttribute: any,
         _stackByAttribute: any,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ): ICreateColorAssignmentReturnValue {
         let mappedColor;
         let colorAssignment: IColorAssignment[];
+        const measureGroup = findMeasureGroupInDimensions(executionResponse.dimensions);
         const headerItem = measureGroup && measureGroup.items[0];
         if (colorMapping) {
-            mappedColor = getColorFromMapping(headerItem, colorMapping, afm);
+            mappedColor = getColorFromMapping(headerItem, colorMapping, executionResponse, afm);
             if (mappedColor) {
                 colorAssignment = [{
                     headerItem,
@@ -416,21 +423,22 @@ export class TreemapColorStrategy extends MeasureColorStrategy {
     protected createColorAssignment(
         colorPalette: IColorPalette,
         colorMapping: IColorMapping[],
-        measureGroup: MeasureGroupType,
         viewByAttribute: any,
         stackByAttribute: any,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ): ICreateColorAssignmentReturnValue {
         let colorAssignment: IColorAssignment[];
         if (viewByAttribute) {
-            colorAssignment = getAtributeColorAssignment(viewByAttribute, colorPalette, colorMapping, afm);
+            colorAssignment =
+                getAtributeColorAssignment(viewByAttribute, colorPalette, colorMapping, executionResponse, afm);
         } else {
             const result = super.createColorAssignment(
                 colorPalette,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm
             );
             colorAssignment = result.outputColorAssignment;
@@ -447,11 +455,12 @@ export class PointsChartColorStrategy extends AttributeColorStrategy {
     protected singleMeasureColorMapping(
         colorPalette: IColorPalette,
         colorMapping: IColorMapping[],
-        measureGroup: MeasureGroupType,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ): IColorAssignment[] {
+        const measureGroup = findMeasureGroupInDimensions(executionResponse.dimensions);
         const measureHeaderItem = measureGroup.items[0];
-        const measureColorMapping = getColorFromMapping(measureHeaderItem, colorMapping, afm);
+        const measureColorMapping = getColorFromMapping(measureHeaderItem, colorMapping, executionResponse, afm);
         const color: IColorItem = isValidMappedColor(measureColorMapping, colorPalette)
             ? measureColorMapping : { type: 'guid', value: colorPalette[0].guid };
         return [{
@@ -476,9 +485,9 @@ export class BubbleChartColorStrategy extends PointsChartColorStrategy {
     protected createColorAssignment(
         colorPalette: IColorPalette,
         colorMapping: IColorMapping[],
-        measureGroup: MeasureGroupType,
         viewByAttribute: any,
         stackByAttribute: any,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ): ICreateColorAssignmentReturnValue {
         let colorAssignment;
@@ -486,13 +495,14 @@ export class BubbleChartColorStrategy extends PointsChartColorStrategy {
             colorAssignment = super.createColorAssignment(
                 colorPalette,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm
             ).fullColorAssignment;
         } else {
-            colorAssignment = this.singleMeasureColorMapping(colorPalette, colorMapping, measureGroup, afm);
+            colorAssignment =
+                this.singleMeasureColorMapping(colorPalette, colorMapping, executionResponse, afm);
         }
 
         return {
@@ -518,12 +528,13 @@ export class ScatterPlotColorStrategy extends PointsChartColorStrategy {
     protected createColorAssignment(
         colorPalette: IColorPalette,
         colorMapping: IColorMapping[],
-        measureGroup: MeasureGroupType,
         _viewByAttribute: any,
         _stackByAttribute: any,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm
     ): ICreateColorAssignmentReturnValue {
-            const colorAssignment = this.singleMeasureColorMapping(colorPalette, colorMapping, measureGroup, afm);
+            const colorAssignment =
+                this.singleMeasureColorMapping(colorPalette, colorMapping, executionResponse, afm);
             return {
                 fullColorAssignment: colorAssignment
             };
@@ -548,9 +559,9 @@ export class ColorFactory {
     public static getColorStrategy(
         colorPalette: IColorPalette = DEFAULT_COLOR_PALETTE,
         colorMapping: IColorMapping[],
-        measureGroup: MeasureGroupType,
         viewByAttribute: any,
         stackByAttribute: any,
+        executionResponse: Execution.IExecutionResponse,
         afm: AFM.IAfm,
         type: string
     ): IColorStrategy {
@@ -559,58 +570,64 @@ export class ColorFactory {
             return new HeatmapColorStrategy(
                 colorPalette,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
-                afm);
+                executionResponse,
+                afm
+            );
         }
 
         if (isTreemap(type)) {
             return new TreemapColorStrategy(
                 colorPalette,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
-                afm);
+                executionResponse,
+                afm
+            );
         }
 
         if (isScatterPlot(type)) {
             return new ScatterPlotColorStrategy(
                 colorPalette,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
-                afm);
+                executionResponse,
+                afm
+            );
         }
 
         if (isBubbleChart(type)) {
             return new BubbleChartColorStrategy(
                 colorPalette,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
-                afm);
+                executionResponse,
+                afm
+            );
         }
 
         if (isAttributeColorPalette(type, afm, stackByAttribute)) {
             return new AttributeColorStrategy(
                 colorPalette,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
-                afm);
+                executionResponse,
+                afm
+            );
         }
 
         return new MeasureColorStrategy(
             colorPalette,
             colorMapping,
-            measureGroup,
             viewByAttribute,
             stackByAttribute,
-            afm);
+            executionResponse,
+            afm
+        );
     }
 }

--- a/src/components/visualizations/chart/test/colorFactory.spec.ts
+++ b/src/components/visualizations/chart/test/colorFactory.spec.ts
@@ -121,8 +121,8 @@ describe('ColorFactory', () => {
 
     describe('AttributeColorStrategy', () => {
         it('should return AttributeColorStrategy with two colors from default color palette', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.barChartWithStackByAndViewByAttributes);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.barChartWithStackByAndViewByAttributes);
+            const { executionResponse } = fixtures.barChartWithStackByAndViewByAttributes;
             const { afm } = fixtures.barChartWithStackByAndViewByAttributes.executionRequest;
             const type = 'bar';
             const colorPalette: IColorPalette = undefined;
@@ -130,9 +130,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 colorPalette,
                 undefined,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -148,8 +148,8 @@ describe('ColorFactory', () => {
         });
 
         it('should return AttributeColorStrategy with two colors from custom color palette', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.barChartWithStackByAndViewByAttributes);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.barChartWithStackByAndViewByAttributes);
+            const { executionResponse } = fixtures.barChartWithStackByAndViewByAttributes;
             const { afm } = fixtures.barChartWithStackByAndViewByAttributes.executionRequest;
             const type = 'bar';
             const colorPalette = [{
@@ -178,9 +178,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 colorPalette,
                 undefined,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -196,8 +196,8 @@ describe('ColorFactory', () => {
         });
 
         it('should return AttributeColorStrategy with properly applied mapping', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.barChartWithStackByAndViewByAttributes);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.barChartWithStackByAndViewByAttributes);
+            const { executionResponse } = fixtures.barChartWithStackByAndViewByAttributes;
             const { afm } = fixtures.barChartWithStackByAndViewByAttributes.executionRequest;
             const type = 'bar';
             const colorPalette = [{
@@ -261,9 +261,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 colorPalette,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -279,17 +279,17 @@ describe('ColorFactory', () => {
 
     describe('MeasureColorStrategy', () => {
         it('should return a palette with a lighter color for each pop measure based on it`s source measure', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.barChartWithPopMeasureAndViewByAttribute);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.barChartWithPopMeasureAndViewByAttribute);
+            const { executionResponse } = fixtures.barChartWithPopMeasureAndViewByAttribute;
             const { afm } = fixtures.barChartWithPopMeasureAndViewByAttribute.executionRequest;
             const type = 'column';
 
             const colorStrategy = ColorFactory.getColorStrategy(
                 customPalette,
                 undefined,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -300,17 +300,17 @@ describe('ColorFactory', () => {
         });
 
         it('should return a palette with a lighter color for each previous period based on it`s source measure', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.barChartWithPreviousPeriodMeasure);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.barChartWithPreviousPeriodMeasure);
+            const { executionResponse } = fixtures.barChartWithPreviousPeriodMeasure;
             const { afm } = fixtures.barChartWithPreviousPeriodMeasure.executionRequest;
             const type = 'column';
 
             const colorStrategy = ColorFactory.getColorStrategy(
                 customPalette,
                 undefined,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -321,17 +321,17 @@ describe('ColorFactory', () => {
         });
 
         it('should rotate colors from original palette and generate lighter PoP colors', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.barChartWith6PopMeasuresAndViewByAttribute);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.barChartWith6PopMeasuresAndViewByAttribute);
+            const { executionResponse } = fixtures.barChartWith6PopMeasuresAndViewByAttribute;
             const { afm } = fixtures.barChartWith6PopMeasuresAndViewByAttribute.executionRequest;
             const type = 'column';
 
             const colorStrategy = ColorFactory.getColorStrategy(
                 customPalette,
                 undefined,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -345,17 +345,17 @@ describe('ColorFactory', () => {
         });
 
         it('should rotate colors from original palette and generate lighter previous period measures', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.barChartWith6PreviousPeriodMeasures);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.barChartWith6PreviousPeriodMeasures);
+            const { executionResponse } = fixtures.barChartWith6PreviousPeriodMeasures;
             const { afm } = fixtures.barChartWith6PreviousPeriodMeasures.executionRequest;
             const type = 'column';
 
             const colorStrategy = ColorFactory.getColorStrategy(
                 customPalette,
                 undefined,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -371,7 +371,8 @@ describe('ColorFactory', () => {
 
         it('should just return the original palette if there are no pop measures shorten to cover all legend items',
             () => {
-                const [measureGroup, viewByAttribute, stackByAttribute] = getMVS(fixtures.barChartWithoutAttributes);
+                const { measureGroup, viewByAttribute, stackByAttribute } = getMVS(fixtures.barChartWithoutAttributes);
+                const { executionResponse } = fixtures.barChartWithoutAttributes;
                 const { afm } = fixtures.barChartWithoutAttributes.executionRequest;
                 const type = 'column';
                 const colorPalette: IColorPalette = undefined;
@@ -379,9 +380,9 @@ describe('ColorFactory', () => {
                 const colorStrategy = ColorFactory.getColorStrategy(
                     colorPalette,
                     undefined,
-                    measureGroup,
                     viewByAttribute,
                     stackByAttribute,
+                    executionResponse,
                     afm,
                     type
                 );
@@ -393,8 +394,8 @@ describe('ColorFactory', () => {
             });
 
         it('should return MeasureColorStrategy with properly applied mapping', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.barChartWith6PopMeasuresAndViewByAttribute);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.barChartWith6PopMeasuresAndViewByAttribute);
+            const { executionResponse } = fixtures.barChartWith6PopMeasuresAndViewByAttribute;
             const { afm } = fixtures.barChartWith6PopMeasuresAndViewByAttribute.executionRequest;
             const type = 'column';
             const colorMapping: IColorMapping[] = [
@@ -425,9 +426,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 customPalette,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -442,17 +443,17 @@ describe('ColorFactory', () => {
         });
 
         it('should return only non-derived measures in getColorAssignment', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.barChartWith6PopMeasuresAndViewByAttribute);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.barChartWith6PopMeasuresAndViewByAttribute);
+            const { executionResponse } = fixtures.barChartWith6PopMeasuresAndViewByAttribute;
             const { afm } = fixtures.barChartWith6PopMeasuresAndViewByAttribute.executionRequest;
             const type = 'column';
 
             const colorStrategy = ColorFactory.getColorStrategy(
                 customPalette,
                 undefined,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -463,8 +464,8 @@ describe('ColorFactory', () => {
 
     describe('TreemapColorStrategy', () => {
         it('should return TreemapColorStrategy strategy with two colors from default color palette', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.treemapWithMetricViewByAndStackByAttribute);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.treemapWithMetricViewByAndStackByAttribute);
+            const { executionResponse } = fixtures.treemapWithMetricViewByAndStackByAttribute;
             const { afm } = fixtures.treemapWithMetricViewByAndStackByAttribute.executionRequest;
             const type = 'treemap';
             const colorPalette: IColorPalette = undefined;
@@ -472,9 +473,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 colorPalette,
                 undefined,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -490,8 +491,8 @@ describe('ColorFactory', () => {
         });
 
         it('should return TreemapColorStrategy with properly applied mapping', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.treemapWithMetricViewByAndStackByAttribute);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.treemapWithMetricViewByAndStackByAttribute);
+            const { executionResponse } = fixtures.treemapWithMetricViewByAndStackByAttribute;
             const { afm } = fixtures.treemapWithMetricViewByAndStackByAttribute.executionRequest;
             const type = 'treemap';
 
@@ -509,9 +510,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 customPalette,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -527,17 +528,17 @@ describe('ColorFactory', () => {
 
     describe('HeatmapColorStrategy', () => {
         it('should return HeatmapColorStrategy strategy with 7 colors from default heatmap color palette', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.heatmapMetricRowColumn);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.heatmapMetricRowColumn);
+            const { executionResponse } = fixtures.heatmapMetricRowColumn;
             const { afm } = fixtures.heatmapMetricRowColumn.executionRequest;
             const type = 'heatmap';
 
             const colorStrategy = ColorFactory.getColorStrategy(
                 undefined,
                 undefined,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -550,8 +551,8 @@ describe('ColorFactory', () => {
 
         it('should return HeatmapColorStrategy strategy with 7 colors'
             + ' based on the first color from custom palette', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.heatmapMetricRowColumn);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.heatmapMetricRowColumn);
+            const { executionResponse } = fixtures.heatmapMetricRowColumn;
             const { afm } = fixtures.heatmapMetricRowColumn.executionRequest;
             const type = 'heatmap';
 
@@ -568,9 +569,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 CUSTOM_COLOR_PALETTE,
                 undefined,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -582,8 +583,8 @@ describe('ColorFactory', () => {
         });
 
         it('should return HeatmapColorStrategy with properly applied mapping', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.heatmapMetricRowColumn);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.heatmapMetricRowColumn);
+            const { executionResponse } = fixtures.heatmapMetricRowColumn;
             const { afm } = fixtures.heatmapMetricRowColumn.executionRequest;
             const type = 'heatmap';
 
@@ -610,9 +611,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 CUSTOM_COLOR_PALETTE,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -626,8 +627,8 @@ describe('ColorFactory', () => {
 
     describe('BubbleChartStrategy', () => {
         it('shouls create palette with color from first measure', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.bubbleChartWith3Metrics);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.bubbleChartWith3Metrics);
+            const { executionResponse } = fixtures.bubbleChartWith3Metrics;
             const { afm } = fixtures.bubbleChartWith3Metrics.executionRequest;
             const type = 'bubble';
 
@@ -650,9 +651,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 CUSTOM_COLOR_PALETTE,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -663,8 +664,8 @@ describe('ColorFactory', () => {
         });
 
         it('should create palette with color for each attribute element', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.bubbleChartWith3MetricsAndAttribute);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.bubbleChartWith3MetricsAndAttribute);
+            const { executionResponse } = fixtures.bubbleChartWith3MetricsAndAttribute;
             const { afm } = fixtures.bubbleChartWith3MetricsAndAttribute.executionRequest;
             const type = 'bubble';
 
@@ -688,9 +689,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 CUSTOM_COLOR_PALETTE,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );
@@ -703,8 +704,8 @@ describe('ColorFactory', () => {
 
     describe('ScatterPlotColorStrategy', () => {
         it('should create palette with same color from first measure for all attribute elements', () => {
-            const [measureGroup, viewByAttribute, stackByAttribute] =
-                getMVS(fixtures.scatterPlotWith2MetricsAndAttribute);
+            const { viewByAttribute, stackByAttribute } = getMVS(fixtures.scatterPlotWith2MetricsAndAttribute);
+            const { executionResponse } = fixtures.scatterPlotWith2MetricsAndAttribute;
             const { afm } = fixtures.scatterPlotWith2MetricsAndAttribute.executionRequest;
             const type = 'scatter';
 
@@ -728,9 +729,9 @@ describe('ColorFactory', () => {
             const colorStrategy = ColorFactory.getColorStrategy(
                 CUSTOM_COLOR_PALETTE,
                 colorMapping,
-                measureGroup,
                 viewByAttribute,
                 stackByAttribute,
+                executionResponse,
                 afm,
                 type
             );

--- a/src/components/visualizations/chart/test/helper.ts
+++ b/src/components/visualizations/chart/test/helper.ts
@@ -24,13 +24,13 @@ export function generateChartOptions(
 ): IChartOptions {
     const {
         executionRequest: { afm, resultSpec },
-        executionResponse: { dimensions },
+        executionResponse,
         executionResult: { data, headerItems }
     } = dataSet;
     return getChartOptions(
         afm,
         resultSpec,
-        dimensions,
+        executionResponse,
         data,
         headerItems,
         config,
@@ -52,9 +52,9 @@ export function getMVS(dataSet: any) {
         dimensions[STACK_BY_DIMENSION_INDEX],
         headerItems[STACK_BY_DIMENSION_INDEX]
     );
-    return [
+    return {
         measureGroup,
         viewByAttribute,
         stackByAttribute
-    ];
+    };
 }

--- a/src/components/visualizations/headline/utils/HeadlineTransformationUtils.ts
+++ b/src/components/visualizations/headline/utils/HeadlineTransformationUtils.ts
@@ -158,13 +158,13 @@ export function applyDrillableItems(headlineData: IHeadlineData,
 
     if (!isEmpty(primaryItem) && !isEmpty(primaryItemHeader)) {
         primaryItem.isDrillable = isSomeHeaderPredicateMatched(
-            drillableItems, primaryItemHeader, executionRequest.afm
+            drillableItems, primaryItemHeader, executionRequest.afm, executionResponse
         );
     }
 
     if (!isEmpty(secondaryItem) && !isEmpty(secondaryItemHeader)) {
         secondaryItem.isDrillable = isSomeHeaderPredicateMatched(
-            drillableItems, secondaryItemHeader, executionRequest.afm
+            drillableItems, secondaryItemHeader, executionRequest.afm, executionResponse
         );
     }
 

--- a/src/components/visualizations/table/ResponsiveTable.tsx
+++ b/src/components/visualizations/table/ResponsiveTable.tsx
@@ -1,7 +1,7 @@
 // (C) 2007-2018 GoodData Corporation
 import * as React from 'react';
 import { noop } from 'lodash';
-import { AFM } from '@gooddata/typings';
+import { AFM, Execution } from '@gooddata/typings';
 
 import { ITableProps, Table } from './Table';
 import { TableControls } from './TableControls';
@@ -22,6 +22,7 @@ export interface IResponsiveTableProps {
     onLess?: (onLessObj: { rows: number }) => void;
     onSortChange?: OnSortChangeWithItem;
     executionRequest: AFM.IExecution;
+    executionResponse: Execution.IExecutionResponse;
 }
 
 export interface IResponsiveTableState {

--- a/src/components/visualizations/table/TableTransformation.tsx
+++ b/src/components/visualizations/table/TableTransformation.tsx
@@ -96,6 +96,7 @@ export class TableTransformation extends React.Component<ITableTransformationPro
             onTotalsEdit,
             drillablePredicates,
             executionRequest,
+            executionResponse,
             headers,
             onFiredDrillEvent,
             onSortChange,

--- a/src/components/visualizations/table/TableVisualization.tsx
+++ b/src/components/visualizations/table/TableVisualization.tsx
@@ -5,7 +5,7 @@ import * as classNames from 'classnames';
 import { injectIntl } from 'react-intl';
 import { debounce, isEqual, noop, pick, uniqueId } from 'lodash';
 import { Cell, CellProps, Column, Table } from 'fixed-data-table-2';
-import { AFM } from '@gooddata/typings';
+import { AFM, Execution } from '@gooddata/typings';
 
 import 'nodelist-foreach-polyfill';
 
@@ -119,8 +119,9 @@ export interface ITableVisualizationProps {
     afterRender?: Function;
     drillablePredicates?: IHeaderPredicate[];
     executionRequest: AFM.IExecution;
-    hasHiddenRows?: boolean;
+    executionResponse: Execution.IExecutionResponse;
     headers?: IMappingHeader[];
+    hasHiddenRows?: boolean;
     rows?: TableRow[];
     onFiredDrillEvent?: OnFiredDrillEvent;
     onSortChange?: OnSortChangeWithItem;
@@ -767,6 +768,7 @@ export class TableVisualizationClass
     ): (cellProps: CellProps) => JSX.Element {
         const {
             executionRequest,
+            executionResponse,
             drillablePredicates,
             onFiredDrillEvent,
             rows,
@@ -774,7 +776,7 @@ export class TableVisualizationClass
         } = this.props;
         const afm = executionRequest.execution.afm;
         const header: IMappingHeader = headers[columnIndex];
-        const drillable = isSomeHeaderPredicateMatched(drillablePredicates, header, afm);
+        const drillable = isSomeHeaderPredicateMatched(drillablePredicates, header, afm, executionResponse);
 
         return (cellProps: CellProps) => {
             const rowIndex: number = cellProps.rowIndex;

--- a/src/components/visualizations/table/test/ResponsiveTable.spec.tsx
+++ b/src/components/visualizations/table/test/ResponsiveTable.spec.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { noop, range } from 'lodash';
-import { AFM } from '@gooddata/typings';
+import { AFM, Execution } from '@gooddata/typings';
 
 import { withIntl } from '../../utils/intlUtils';
 import { TableRow } from '../../../../interfaces/Table';
@@ -11,7 +11,12 @@ import { IResponsiveTableProps, IResponsiveTableState, ResponsiveTable } from '.
 import { Table } from '../Table';
 import { IMappingHeader } from '../../../../interfaces/MappingHeader';
 
-import { EXECUTION_REQUEST_1A_2M, TABLE_HEADERS_1A_2M, TABLE_ROWS_1A_2M } from '../fixtures/1attribute2measures';
+import {
+    EXECUTION_REQUEST_1A_2M,
+    TABLE_HEADERS_1A_2M,
+    TABLE_ROWS_1A_2M,
+    EXECUTION_RESPONSE_1A_2M
+} from '../fixtures/1attribute2measures';
 import 'jest';
 
 const ROWS_PER_PAGE: number = 10;
@@ -22,6 +27,7 @@ const getLess = (wrapper: ReactWrapper<IResponsiveTableProps, IResponsiveTableSt
 
 interface ITableData {
     executionRequest: AFM.IExecution;
+    executionResponse: Execution.IExecutionResponse;
     headers: IMappingHeader[];
     rows: TableRow[];
     totalsWithData?: ITotalWithData[];
@@ -30,6 +36,7 @@ interface ITableData {
 describe('Responsive Table', () => {
     const TABLE_DATA: ITableData = {
         executionRequest: EXECUTION_REQUEST_1A_2M,
+        executionResponse: EXECUTION_RESPONSE_1A_2M,
         headers: TABLE_HEADERS_1A_2M,
         rows: TABLE_ROWS_1A_2M
     };
@@ -95,6 +102,7 @@ describe('Responsive Table', () => {
     describe('when data contains more than 1 page of rows', () => {
         const tableData: ITableData = {
             executionRequest: EXECUTION_REQUEST_1A_2M,
+            executionResponse: EXECUTION_RESPONSE_1A_2M,
             headers: TABLE_HEADERS_1A_2M,
             rows: range(0, 25).map(() => TABLE_ROWS_1A_2M[0])
         };

--- a/src/components/visualizations/table/test/TableVisualization.spec.tsx
+++ b/src/components/visualizations/table/test/TableVisualization.spec.tsx
@@ -17,7 +17,12 @@ import {
 import { TableRow } from '../../../../interfaces/Table';
 import { IMappingHeader } from '../../../../interfaces/MappingHeader';
 import { ASC, DESC } from '../../../../constants/sort';
-import { EXECUTION_REQUEST_1A_2M, TABLE_HEADERS_1A_2M, TABLE_ROWS_1A_2M } from '../fixtures/1attribute2measures';
+import {
+    EXECUTION_REQUEST_1A_2M,
+    EXECUTION_RESPONSE_1A_2M,
+    TABLE_HEADERS_1A_2M,
+    TABLE_ROWS_1A_2M
+} from '../fixtures/1attribute2measures';
 import { EXECUTION_REQUEST_2M, TABLE_HEADERS_2M, TABLE_ROWS_2M } from '../fixtures/2measures';
 import { RemoveRows } from '../totals/RemoveRows';
 import { EXECUTION_REQUEST_2A_3M, TABLE_HEADERS_2A_3M, TABLE_ROWS_2A_3M } from '../fixtures/2attributes3measures';
@@ -49,6 +54,7 @@ describe('Table', () => {
             rows: TABLE_ROWS_1A_2M,
             headers: TABLE_HEADERS_1A_2M,
             executionRequest: EXECUTION_REQUEST_1A_2M,
+            executionResponse: EXECUTION_RESPONSE_1A_2M,
             ...customProps
         };
 

--- a/src/components/visualizations/utils/color.ts
+++ b/src/components/visualizations/utils/color.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2018 GoodData Corporation
-import { AFM, VisualizationObject } from '@gooddata/typings';
+import { AFM, Execution, VisualizationObject } from '@gooddata/typings';
 import isEmpty = require('lodash/isEmpty');
 import isEqual = require('lodash/isEqual');
 import { getMappingHeaderLocalIdentifier } from '../../../helpers/mappingHeader';
@@ -13,7 +13,7 @@ import {
     IColorMapping,
     IRGBColorItem
 } from '../../../interfaces/Config';
-import { IHeaderPredicate } from '../../../interfaces/HeaderPredicate';
+import { IHeaderPredicate, IHeaderPredicateContext } from '../../../interfaces/HeaderPredicate';
 import { IMappingHeader, isMappingHeaderAttributeItem } from '../../../interfaces/MappingHeader';
 
 export const WHITE = 'rgb(255, 255, 255)';
@@ -242,6 +242,7 @@ export function isRgbColorItem(color: IColorItem): color is IRGBColorItem {
 export function getColorFromMapping(
     mappingHeader: IMappingHeader,
     colorMapping: IColorMapping[],
+    executionResponse: Execution.IExecutionResponse,
     afm: AFM.IAfm
 ): IColorItem {
     if (!colorMapping) {
@@ -249,7 +250,7 @@ export function getColorFromMapping(
     }
 
     const mapping = colorMapping.find(item =>
-        item.predicate(mappingHeader, afm)
+        item.predicate(mappingHeader, { afm, executionResponse })
     );
     return mapping && mapping.color;
 }
@@ -268,7 +269,7 @@ export function getColorMappingPredicate(
     id: string,
     references: VisualizationObject.IReferenceItems
 ): IHeaderPredicate {
-    return (header: IMappingHeader, _afm: AFM.IAfm): boolean => {
+    return (header: IMappingHeader, _context: IHeaderPredicateContext): boolean => {
         if (isMappingHeaderAttributeItem(header)) {
             const attributeItemUri = references && references[id];
             return attributeItemUri ? attributeItemUri === header.attributeHeaderItem.uri : false;

--- a/src/components/visualizations/utils/test/color.spec.ts
+++ b/src/components/visualizations/utils/test/color.spec.ts
@@ -3,7 +3,8 @@ import {
     afmWithDerived,
     measureHeaderItem,
     attributeHeaderItem,
-    attributeHeader
+    attributeHeader,
+    executionResponseWithDerived
 } from '../../../../factory/tests/mocks';
 import { IHeaderPredicate } from '../../../../interfaces/HeaderPredicate';
 import {
@@ -100,14 +101,20 @@ describe('getColorMappingPredicate', () => {
         it('should match predicate when measure local identifier matches and measureHeaderItem tested', () => {
             const predicate: IHeaderPredicate = getColorMappingPredicate('measureHeaderItem.localIdentifier', {});
 
-            expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(true);
+            expect(predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(true);
         });
 
         // tslint:disable-next-line:max-line-length
         it('should not match predicate when measure local identifier does not match and measureHeaderItem tested', () => {
             const predicate: IHeaderPredicate = getColorMappingPredicate('someOtherMeasure.localIdentifier', {});
 
-            expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(false);
+            expect(predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
     });
 
@@ -117,7 +124,7 @@ describe('getColorMappingPredicate', () => {
                 identifier: '/attributeHeaderItem.uri'
             });
 
-            expect(predicate(measureHeaderItem, {})).toEqual(false);
+            expect(predicate(measureHeaderItem, {} as any)).toEqual(false);
         });
 
         it('should not match predicate when referenced uri matches and attributeHeader tested', () => {
@@ -125,7 +132,7 @@ describe('getColorMappingPredicate', () => {
                 identifier: '/attributeHeaderItem.uri'
             });
 
-            expect(predicate(attributeHeader, {})).toEqual(false);
+            expect(predicate(attributeHeader, {} as any)).toEqual(false);
         });
 
         it('should match predicate when referenced uri matches and attributeItemHeader tested', () => {
@@ -133,7 +140,7 @@ describe('getColorMappingPredicate', () => {
                 identifier: '/attributeHeaderItem.uri'
             });
 
-            expect(predicate(attributeHeaderItem, {})).toEqual(true);
+            expect(predicate(attributeHeaderItem, {} as any)).toEqual(true);
         });
 
         // tslint:disable-next-line:max-line-length
@@ -142,7 +149,7 @@ describe('getColorMappingPredicate', () => {
                 identifier: '/attributeHeaderItem.uri'
             });
 
-            expect(predicate(attributeHeaderItem, {})).toEqual(false);
+            expect(predicate(attributeHeaderItem, {} as any)).toEqual(false);
         });
 
         it('should match predicate when measure local identifier matches and measureHeaderItem tested', () => {
@@ -150,7 +157,10 @@ describe('getColorMappingPredicate', () => {
                 identifier: '/attributeHeaderItem.uri'
             });
 
-            expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(true);
+            expect(predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(true);
         });
     });
 });

--- a/src/factory/HeaderPredicateFactory.ts
+++ b/src/factory/HeaderPredicateFactory.ts
@@ -8,7 +8,7 @@ import {
     hasMappingHeaderIndentifier,
     hasMappingHeaderLocalIdentifier
 } from '../helpers/mappingHeader';
-import { IHeaderPredicate } from '../interfaces/HeaderPredicate';
+import { IHeaderPredicate, IHeaderPredicateContext } from '../interfaces/HeaderPredicate';
 import { IMappingHeader, isMappingHeaderAttributeItem, isMappingHeaderMeasureItem } from '../interfaces/MappingHeader';
 
 type IObjectQualifierPredicate = (qualifier: AFM.ObjQualifier) => boolean;
@@ -33,11 +33,12 @@ function arithmeticMeasureLocalIdentifierDeepMatch(
 }
 
 function composedFromQualifier(predicate: IObjectQualifierPredicate): IHeaderPredicate {
-    return (header: IMappingHeader, afm: AFM.IAfm): boolean => {
+    return (header: IMappingHeader, context: IHeaderPredicateContext): boolean => {
         if (!isMappingHeaderMeasureItem(header)) {
             return false;
         }
 
+        const { afm } = context;
         const measureLocalIdentifier = getMappingHeaderLocalIdentifier(header);
         const arithmeticMeasure = afm.measures.find((measure) => {
             return measure.localIdentifier === measureLocalIdentifier;
@@ -54,7 +55,7 @@ function composedFromQualifier(predicate: IObjectQualifierPredicate): IHeaderPre
 }
 
 export function uriMatch(uri: string): IHeaderPredicate {
-    return (header: IMappingHeader, afm: AFM.IAfm): boolean => {
+    return (header: IMappingHeader, context: IHeaderPredicateContext): boolean => {
         const headerUri = getMappingHeaderUri(header);
         if (headerUri && headerUri === uri) {
             return true;
@@ -66,7 +67,7 @@ export function uriMatch(uri: string): IHeaderPredicate {
 
         const headerLocalIdentifier = getMappingHeaderLocalIdentifier(header);
         if (headerLocalIdentifier) {
-            const measureHeader = getMasterMeasureObjQualifier(afm, headerLocalIdentifier);
+            const measureHeader = getMasterMeasureObjQualifier(context.afm, headerLocalIdentifier);
             return measureHeader && measureHeader.uri ? measureHeader.uri === uri : false;
         }
 
@@ -75,7 +76,7 @@ export function uriMatch(uri: string): IHeaderPredicate {
 }
 
 export function identifierMatch(identifier: string): IHeaderPredicate {
-    return (header: IMappingHeader, afm: AFM.IAfm): boolean => {
+    return (header: IMappingHeader, context: IHeaderPredicateContext): boolean => {
         if (!hasMappingHeaderIndentifier(header)) {
             return false;
         }
@@ -87,7 +88,7 @@ export function identifierMatch(identifier: string): IHeaderPredicate {
 
         const headerLocalIdentifier = getMappingHeaderLocalIdentifier(header);
         if (headerLocalIdentifier) {
-            const measureHeader = getMasterMeasureObjQualifier(afm, headerLocalIdentifier);
+            const measureHeader = getMasterMeasureObjQualifier(context.afm, headerLocalIdentifier);
             return measureHeader && measureHeader.identifier ? measureHeader.identifier === identifier : false;
         }
 
@@ -96,7 +97,7 @@ export function identifierMatch(identifier: string): IHeaderPredicate {
 }
 
 export function attributeItemNameMatch(name: string): IHeaderPredicate  {
-    return (header: IMappingHeader, _afm: AFM.IAfm): boolean => {
+    return (header: IMappingHeader, _context: IHeaderPredicateContext): boolean => {
         return isMappingHeaderAttributeItem(header)
             ? header.attributeHeaderItem && (header.attributeHeaderItem.name === name)
             : false;
@@ -104,7 +105,7 @@ export function attributeItemNameMatch(name: string): IHeaderPredicate  {
 }
 
 export function localIdentifierMatch(localIdentifier: string): IHeaderPredicate  {
-    return (header: IMappingHeader, _afm: AFM.IAfm): boolean => {
+    return (header: IMappingHeader, _context: IHeaderPredicateContext): boolean => {
         if (!hasMappingHeaderLocalIdentifier(header)) {
             return false;
         }

--- a/src/factory/tests/HeaderPredicateFactory.spec.ts
+++ b/src/factory/tests/HeaderPredicateFactory.spec.ts
@@ -10,7 +10,9 @@ import {
     measureHeaderItem,
     measureHeaderItemWithoutUriAndIndentifier,
     measureHeaderItemPP,
-    measureHeaderItemSP
+    measureHeaderItemSP,
+    executionResponseWithDerived,
+    executionResponseWithAmMeasures
 } from './mocks';
 
 describe('uriMatch', () => {
@@ -18,33 +20,48 @@ describe('uriMatch', () => {
         it('should match predicate when measure item uri matches', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch('/measureHeaderItem.uri');
 
-            expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(true);
+            expect(predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(true);
         });
 
         it('should not match predicate when measure item uri does not matches', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch('/someOtherUri');
 
-            expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(false);
+            expect(predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
 
         it('should not match predicate when empty uri provided', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch(null);
 
-            expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(false);
+            expect(predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
 
         describe('uknown header uri (adhoc measures)', () => {
             it('should match uri predicate against AFM when header uri is undefined', () => {
                 const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch('/measureHeaderItem.uri');
 
-                expect(predicate(measureHeaderItemWithoutUriAndIndentifier, afmWithDerived)).toEqual(true);
+                expect(predicate(measureHeaderItemWithoutUriAndIndentifier, {
+                    afm: afmWithDerived,
+                    executionResponse: executionResponseWithDerived
+                })).toEqual(true);
             });
 
             // tslint:disable-next-line:max-line-length
             it('should not match uri predicate against AFM when header uri is undefined and measure is not found in AFM', () => {
                 const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch('/someOtherUri');
 
-                expect(predicate(measureHeaderItemWithoutUriAndIndentifier, afmWithDerived)).toEqual(false);
+                expect(predicate(measureHeaderItemWithoutUriAndIndentifier, {
+                    afm: afmWithDerived,
+                    executionResponse: executionResponseWithDerived
+                })).toEqual(false);
             });
         });
 
@@ -52,13 +69,19 @@ describe('uriMatch', () => {
             it('should match PP derived measure when master measure uri provided', () => {
                 const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch('/measureHeaderItem.uri');
 
-                expect(predicate(measureHeaderItemPP, afmWithDerived)).toEqual(true);
+                expect(predicate(measureHeaderItemPP, {
+                    afm: afmWithDerived,
+                    executionResponse: executionResponseWithDerived
+                })).toEqual(true);
             });
 
             it('should match SP derived measure when master measure uri provided', () => {
                 const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch('/measureHeaderItem.uri');
 
-                expect(predicate(measureHeaderItemSP, afmWithDerived)).toEqual(true);
+                expect(predicate(measureHeaderItemSP, {
+                    afm: afmWithDerived,
+                    executionResponse: executionResponseWithDerived
+                })).toEqual(true);
             });
         });
     });
@@ -67,19 +90,28 @@ describe('uriMatch', () => {
         it('should match predicate when measure item uri matches', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch('/attributeHeader.uri');
 
-            expect(predicate(attributeHeader, afmWithDerived)).toEqual(true);
+            expect(predicate(attributeHeader, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(true);
         });
 
         it('should not match predicate when measure item uri does not match', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch('/someOtherUri');
 
-            expect(predicate(attributeHeader, afmWithDerived)).toEqual(false);
+            expect(predicate(attributeHeader, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
 
         it('should not match predicate when empty uri provided', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch(null);
 
-            expect(predicate(attributeHeader, afmWithDerived)).toEqual(false);
+            expect(predicate(attributeHeader, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
     });
 
@@ -87,19 +119,28 @@ describe('uriMatch', () => {
         it('should match predicate when measure item uri matches', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch('/attributeHeaderItem.uri');
 
-            expect(predicate(attributeHeaderItem, afmWithDerived)).toEqual(true);
+            expect(predicate(attributeHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(true);
         });
 
         it('should not match predicate when measure item uri does not match', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch('/someOtherUri');
 
-            expect(predicate(attributeHeaderItem, afmWithDerived)).toEqual(false);
+            expect(predicate(attributeHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
 
         it('should not match predicate when empty uri provided', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch(null);
 
-            expect(predicate(attributeHeaderItem, afmWithDerived)).toEqual(false);
+            expect(predicate(attributeHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
     });
 });
@@ -109,19 +150,28 @@ describe('identifierMatch', () => {
         it('should match predicate when measure item identifier matches', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch('measureHeaderItem.identifier');
 
-            expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(true);
+            expect(predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(true);
         });
 
         it('should not match predicate when measure item identifier does not match', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch('someOtherId');
 
-            expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(false);
+            expect(predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
 
         it('should not match predicate when empty identifier provided', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(null);
 
-            expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(false);
+            expect(predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
 
         describe('uknown header uri (adhoc measures)', () => {
@@ -129,14 +179,20 @@ describe('identifierMatch', () => {
                 const predicate: IHeaderPredicate =
                     headerPredicateFactory.identifierMatch('measureHeaderItem.identifier');
 
-                expect(predicate(measureHeaderItemWithoutUriAndIndentifier, afmWithDerived)).toEqual(true);
+                expect(predicate(measureHeaderItemWithoutUriAndIndentifier, {
+                    afm: afmWithDerived,
+                    executionResponse: executionResponseWithDerived
+                })).toEqual(true);
             });
 
             // tslint:disable-next-line:max-line-length
             it('should not match identifier predicate against AFM when header identifier is undefined and measure is not found in AFM', () => {
                 const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch('someOtherId');
 
-                expect(predicate(measureHeaderItemWithoutUriAndIndentifier, afmWithDerived)).toEqual(false);
+                expect(predicate(measureHeaderItemWithoutUriAndIndentifier, {
+                    afm: afmWithDerived,
+                    executionResponse: executionResponseWithDerived
+                })).toEqual(false);
             });
         });
 
@@ -145,14 +201,20 @@ describe('identifierMatch', () => {
                 const predicate: IHeaderPredicate =
                     headerPredicateFactory.identifierMatch('measureHeaderItem.identifier');
 
-                expect(predicate(measureHeaderItemPP, afmWithDerived)).toEqual(true);
+                expect(predicate(measureHeaderItemPP, {
+                    afm: afmWithDerived,
+                    executionResponse: executionResponseWithDerived
+                })).toEqual(true);
             });
 
             it('should match SP derived measure when master measure identifier provided', () => {
                 const predicate: IHeaderPredicate =
                     headerPredicateFactory.identifierMatch('measureHeaderItem.identifier');
 
-                expect(predicate(measureHeaderItemSP, afmWithDerived)).toEqual(true);
+                expect(predicate(measureHeaderItemSP, {
+                    afm: afmWithDerived,
+                    executionResponse: executionResponseWithDerived
+                })).toEqual(true);
             });
         });
     });
@@ -161,19 +223,28 @@ describe('identifierMatch', () => {
         it('should match predicate when measure item identifier matches', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch('attributeHeader.identifier');
 
-            expect(predicate(attributeHeader, afmWithDerived)).toEqual(true);
+            expect(predicate(attributeHeader, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(true);
         });
 
         it('should not match predicate when measure item identifier does not match', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch('someOtherId');
 
-            expect(predicate(attributeHeader, afmWithDerived)).toEqual(false);
+            expect(predicate(attributeHeader, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
 
         it('should not match predicate when empty identifier provided', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(null);
 
-            expect(predicate(attributeHeader, afmWithDerived)).toEqual(false);
+            expect(predicate(attributeHeader, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
     });
 
@@ -181,7 +252,10 @@ describe('identifierMatch', () => {
         it('should not match predicate since attributeHeaderItem does not have identifier', () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(null);
 
-            expect(predicate(attributeHeaderItem, afmWithDerived)).toEqual(false);
+            expect(predicate(attributeHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(false);
         });
     });
 });
@@ -190,25 +264,37 @@ describe('composedFromUri', () => {
     it('should match predicate when measure uri is in measure tree', () => {
         const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri('/m1.uri');
 
-        expect(predicate(amMeasureHeaderItems.am1, afmWithAmMeasures)).toEqual(true);
+        expect(predicate(amMeasureHeaderItems.am1, {
+            afm: afmWithAmMeasures,
+            executionResponse: executionResponseWithAmMeasures
+        })).toEqual(true);
     });
 
     it('should match predicate when measure uri is in measure multilevel tree', () => {
         const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri('/m1.uri');
 
-        expect(predicate(amMeasureHeaderItems.am3, afmWithAmMeasures)).toEqual(true);
+        expect(predicate(amMeasureHeaderItems.am3, {
+            afm: afmWithAmMeasures,
+            executionResponse: executionResponseWithAmMeasures
+        })).toEqual(true);
     });
 
     it('should not match predicate when measure uri is not in measure tree', () => {
         const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri('/some-other-uri');
 
-        expect(predicate(amMeasureHeaderItems.am1, afmWithAmMeasures)).toEqual(false);
+        expect(predicate(amMeasureHeaderItems.am1, {
+            afm: afmWithAmMeasures,
+            executionResponse: executionResponseWithAmMeasures
+        })).toEqual(false);
     });
 
     it('should not match predicate when measure uri is not in multilevel measure tree', () => {
         const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri('/some-other-uri');
 
-        expect(predicate(amMeasureHeaderItems.am3, afmWithAmMeasures)).toEqual(false);
+        expect(predicate(amMeasureHeaderItems.am3, {
+            afm: afmWithAmMeasures,
+            executionResponse: executionResponseWithAmMeasures
+        })).toEqual(false);
     });
 });
 
@@ -216,25 +302,37 @@ describe('composedFromIdentifier', () => {
     it('should match predicate when measure identifier is in measure tree', () => {
         const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier('m1.identifier');
 
-        expect(predicate(amMeasureHeaderItems.am1, afmWithAmMeasures)).toEqual(true);
+        expect(predicate(amMeasureHeaderItems.am1, {
+            afm: afmWithAmMeasures,
+            executionResponse: executionResponseWithAmMeasures
+        })).toEqual(true);
     });
 
     it('should match predicate when measure identifier is in measure multilevel tree', () => {
         const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier('m1.identifier');
 
-        expect(predicate(amMeasureHeaderItems.am3, afmWithAmMeasures)).toEqual(true);
+        expect(predicate(amMeasureHeaderItems.am3, {
+            afm: afmWithAmMeasures,
+            executionResponse: executionResponseWithAmMeasures
+        })).toEqual(true);
     });
 
     it('should not match predicate when measure identifier is not in measure tree', () => {
         const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier('someOtherId');
 
-        expect(predicate(amMeasureHeaderItems.am1, afmWithAmMeasures)).toEqual(false);
+        expect(predicate(amMeasureHeaderItems.am1, {
+            afm: afmWithAmMeasures,
+            executionResponse: executionResponseWithAmMeasures
+        })).toEqual(false);
     });
 
     it('should not match predicate when measure identifier is not in multilevel measure tree', () => {
         const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier('someOtherId');
 
-        expect(predicate(amMeasureHeaderItems.am3, afmWithAmMeasures)).toEqual(false);
+        expect(predicate(amMeasureHeaderItems.am3, {
+            afm: afmWithAmMeasures,
+            executionResponse: executionResponseWithAmMeasures
+        })).toEqual(false);
     });
 });
 
@@ -244,19 +342,28 @@ describe('localIdentifierMatch', () => {
             'measureHeaderItem.localIdentifier'
         );
 
-        expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(true);
+        expect(predicate(measureHeaderItem, {
+            afm: afmWithDerived,
+            executionResponse: executionResponseWithDerived
+        })).toEqual(true);
     });
 
     it('should not match predicate when measureHeaderItem localIdentifier does not match', () => {
         const predicate = headerPredicateFactory.localIdentifierMatch('someOtherLocalIdentifier');
 
-        expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(false);
+        expect(predicate(measureHeaderItem, {
+            afm: afmWithDerived,
+            executionResponse: executionResponseWithDerived
+        })).toEqual(false);
     });
 
     it('should not match predicate when empty localIdentifier provided', () => {
         const predicate = headerPredicateFactory.localIdentifierMatch(null);
 
-        expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(false);
+        expect(predicate(measureHeaderItem, {
+            afm: afmWithDerived,
+            executionResponse: executionResponseWithDerived
+        })).toEqual(false);
     });
 
     it('should return false when object is not measureHeaderItem', () => {
@@ -264,7 +371,10 @@ describe('localIdentifierMatch', () => {
             'measureHeaderItem.localIdentifier'
         );
 
-        expect(predicate(attributeHeaderItem, afmWithDerived)).toEqual(false);
+        expect(predicate(attributeHeaderItem, {
+            afm: afmWithDerived,
+            executionResponse: executionResponseWithDerived
+        })).toEqual(false);
     });
 });
 
@@ -272,24 +382,36 @@ describe('attributeItemNameMatch', () => {
     it('should match predicate when attributeHeaderItem name matches', () => {
         const predicate = headerPredicateFactory.attributeItemNameMatch('attributeHeaderItem.name');
 
-        expect(predicate(attributeHeaderItem, afmWithDerived)).toEqual(true);
+        expect(predicate(attributeHeaderItem, {
+            afm: afmWithDerived,
+            executionResponse: executionResponseWithDerived
+        })).toEqual(true);
     });
 
     it('should not match predicate when attributeHeaderItem name does not match', () => {
         const predicate = headerPredicateFactory.attributeItemNameMatch('someOtherName');
 
-        expect(predicate(attributeHeaderItem, afmWithDerived)).toEqual(false);
+        expect(predicate(attributeHeaderItem, {
+            afm: afmWithDerived,
+            executionResponse: executionResponseWithDerived
+        })).toEqual(false);
     });
 
     it('should not match predicate when empty name provided', () => {
         const predicate = headerPredicateFactory.attributeItemNameMatch(null);
 
-        expect(predicate(attributeHeaderItem, afmWithDerived)).toEqual(false);
+        expect(predicate(attributeHeaderItem, {
+            afm: afmWithDerived,
+            executionResponse: executionResponseWithDerived
+        })).toEqual(false);
     });
 
     it('should return false when object is not attributeHeaderItem', () => {
         const predicate = headerPredicateFactory.attributeItemNameMatch('attributeHeaderItem.name');
 
-        expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(false);
+        expect(predicate(measureHeaderItem, {
+            afm: afmWithDerived,
+            executionResponse: executionResponseWithDerived
+        })).toEqual(false);
     });
 });

--- a/src/factory/tests/mocks.ts
+++ b/src/factory/tests/mocks.ts
@@ -81,6 +81,27 @@ export const measureHeaderItemSP: IMappingHeader = {
     }
 };
 
+export const executionResponseWithDerived: Execution.IExecutionResponse = {
+    dimensions: [
+        {
+            headers: [
+                {
+                    measureGroupHeader: {
+                        items: [
+                            measureHeaderItem,
+                            measureHeaderItemPP,
+                            measureHeaderItemSP
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    links: {
+        executionResult: 'foo'
+    }
+};
+
 export const attributeHeader: IMappingHeader = {
     attributeHeader: {
         uri: '/attributeHeader.uri',
@@ -192,5 +213,45 @@ export const amMeasureHeaderItems = {
             name: 'AM3',
             format: '#,##0.00'
         }
+    }
+};
+
+export const executionResponseWithAmMeasures: Execution.IExecutionResponse = {
+    dimensions: [
+        {
+            headers: [
+                {
+                    measureGroupHeader: {
+                        items: [
+                            amMeasureHeaderItems.m1,
+                            amMeasureHeaderItems.m2,
+                            amMeasureHeaderItems.am1,
+                            amMeasureHeaderItems.am2,
+                            amMeasureHeaderItems.am3
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    links: {
+        executionResult: 'foo'
+    }
+};
+
+export const emptyExecutionResponse: Execution.IExecutionResponse = {
+    dimensions: [
+        {
+            headers: [
+                {
+                    measureGroupHeader: {
+                        items: []
+                    }
+                }
+            ]
+        }
+    ],
+    links: {
+        executionResult: 'foo'
     }
 };

--- a/src/helpers/headerPredicate.ts
+++ b/src/helpers/headerPredicate.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2018 GoodData Corporation
-import { AFM } from '@gooddata/typings';
+import { AFM, Execution } from '@gooddata/typings';
 import { identifierMatch, uriMatch } from '../factory/HeaderPredicateFactory';
 import { IDrillableItem, isDrillableItemIdentifier, isDrillableItemUri } from '../interfaces/DrillEvents';
 import { IHeaderPredicate, isHeaderPredicate } from '../interfaces/HeaderPredicate';
@@ -8,9 +8,11 @@ import { IMappingHeader } from '../interfaces/MappingHeader';
 export function isSomeHeaderPredicateMatched(
     drillablePredicates: IHeaderPredicate[],
     header: IMappingHeader,
-    afm: AFM.IAfm
+    afm: AFM.IAfm,
+    executionResponse: Execution.IExecutionResponse
 ): boolean {
-    return drillablePredicates.some((drillablePredicate: IHeaderPredicate) => drillablePredicate(header, afm));
+    return drillablePredicates.some((drillablePredicate: IHeaderPredicate) =>
+        drillablePredicate(header, { afm, executionResponse }));
 }
 
 export function convertDrillableItemsToPredicates(

--- a/src/helpers/tests/headerPredicate.spec.ts
+++ b/src/helpers/tests/headerPredicate.spec.ts
@@ -1,36 +1,53 @@
 // (C) 2007-2018 GoodData Corporation
 import { AFM } from '@gooddata/typings';
 import * as headerPredicateFactory from '../../factory/HeaderPredicateFactory';
-import { afmWithDerived, measureHeaderItem } from '../../factory/tests/mocks';
+import {
+    afmWithDerived,
+    measureHeaderItem,
+    emptyExecutionResponse,
+    executionResponseWithDerived
+} from '../../factory/tests/mocks';
 import { IMappingHeader } from '../../interfaces/MappingHeader';
 import { IHeaderPredicate } from '../../interfaces/HeaderPredicate';
 import { convertDrillableItemsToPredicates, isSomeHeaderPredicateMatched } from '../headerPredicate';
 
 describe('isSomeHeaderPredicateMatched', () => {
+    const emptyAfm: AFM.IAfm = {};
+
     it('should return true when some of predicates match header', () => {
         const header: IMappingHeader = { attributeHeaderItem: { uri: 'uri', name: 'name' } };
-        const afm: AFM.IAfm = {};
         const drillablePredicates: IHeaderPredicate[] = [
             jest.fn(() => false),
             jest.fn(() => true)
         ];
 
-        expect(isSomeHeaderPredicateMatched(drillablePredicates, header, afm)).toBe(true);
-        expect(drillablePredicates[0]).toBeCalledWith(header, afm);
-        expect(drillablePredicates[1]).toBeCalledWith(header, afm);
+        expect(isSomeHeaderPredicateMatched(drillablePredicates, header, emptyAfm, emptyExecutionResponse)).toBe(true);
+        expect(drillablePredicates[0]).toBeCalledWith(header, {
+            afm: emptyAfm,
+            executionResponse: emptyExecutionResponse
+        });
+        expect(drillablePredicates[1]).toBeCalledWith(header, {
+            afm: emptyAfm,
+            executionResponse: emptyExecutionResponse
+        });
     });
 
     it('should return false when none of predicates match header', () => {
         const header: IMappingHeader = { attributeHeaderItem: { uri: 'uri', name: 'name' } };
-        const afm: AFM.IAfm = {};
         const drillablePredicates: IHeaderPredicate[] = [
             jest.fn(() => false),
             jest.fn(() => false)
         ];
 
-        expect(isSomeHeaderPredicateMatched(drillablePredicates, header, afm)).toBe(false);
-        expect(drillablePredicates[0]).toBeCalledWith(header, afm);
-        expect(drillablePredicates[1]).toBeCalledWith(header, afm);
+        expect(isSomeHeaderPredicateMatched(drillablePredicates, header, emptyAfm, emptyExecutionResponse)).toBe(false);
+        expect(drillablePredicates[0]).toBeCalledWith(header, {
+            afm: emptyAfm,
+            executionResponse: emptyExecutionResponse
+        });
+        expect(drillablePredicates[1]).toBeCalledWith(header, {
+            afm: emptyAfm,
+            executionResponse: emptyExecutionResponse
+        });
     });
 
     it('should return false when no of predicates provided', () => {
@@ -38,7 +55,7 @@ describe('isSomeHeaderPredicateMatched', () => {
         const afm: AFM.IAfm = {};
         const drillablePredicates: IHeaderPredicate[] = [];
 
-        expect(isSomeHeaderPredicateMatched(drillablePredicates, header, afm)).toBe(false);
+        expect(isSomeHeaderPredicateMatched(drillablePredicates, header, afm, emptyExecutionResponse)).toBe(false);
     });
 });
 
@@ -54,7 +71,10 @@ describe('convertDrillableItemsToPredicates', () => {
         expect(drillablePredicates).toHaveLength(drillableItems.length);
         drillablePredicates.forEach((predicate) => {
             expect(typeof predicate).toBe('function');
-            expect(typeof predicate(measureHeaderItem, afmWithDerived)).toBe('boolean');
+            expect(typeof predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toBe('boolean');
         });
     });
 
@@ -71,7 +91,10 @@ describe('convertDrillableItemsToPredicates', () => {
         expect(drillablePredicates).toHaveLength(drillableItems.length);
         drillablePredicates.forEach((predicate) => {
             expect(typeof predicate).toBe('function');
-            expect(typeof predicate(measureHeaderItem, afmWithDerived)).toBe('boolean');
+            expect(typeof predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toBe('boolean');
         });
     });
 
@@ -88,7 +111,10 @@ describe('convertDrillableItemsToPredicates', () => {
         expect(drillablePredicates).toHaveLength(2);
         drillablePredicates.forEach((predicate) => {
             expect(typeof predicate).toBe('function');
-            expect(typeof predicate(measureHeaderItem, afmWithDerived)).toBe('boolean');
+            expect(typeof predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toBe('boolean');
         });
     });
 
@@ -100,7 +126,10 @@ describe('convertDrillableItemsToPredicates', () => {
         ];
 
         const [ predicate ] = convertDrillableItemsToPredicates(drillableItems);
-        expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(true);
+        expect(predicate(measureHeaderItem, {
+            afm: afmWithDerived,
+            executionResponse: executionResponseWithDerived
+        })).toEqual(true);
     });
 
     it('should match converted legacy drillable item with identifier', () => {
@@ -111,7 +140,10 @@ describe('convertDrillableItemsToPredicates', () => {
         ];
 
         const [ predicate ] = convertDrillableItemsToPredicates(drillableItems);
-        expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(true);
+        expect(predicate(measureHeaderItem, {
+            afm: afmWithDerived,
+            executionResponse: executionResponseWithDerived
+        })).toEqual(true);
     });
 
     it('should match both converted legacy drillable items with identifier and uri', () => {
@@ -124,7 +156,10 @@ describe('convertDrillableItemsToPredicates', () => {
 
         const drillablePredicates = convertDrillableItemsToPredicates(drillableItems);
         drillablePredicates.forEach((predicate) => {
-            expect(predicate(measureHeaderItem, afmWithDerived)).toEqual(true);
+            expect(predicate(measureHeaderItem, {
+                afm: afmWithDerived,
+                executionResponse: executionResponseWithDerived
+            })).toEqual(true);
         });
     });
 });

--- a/src/interfaces/HeaderPredicate.ts
+++ b/src/interfaces/HeaderPredicate.ts
@@ -1,9 +1,14 @@
 // (C) 2007-2018 GoodData Corporation
-import { AFM } from '@gooddata/typings';
+import { AFM, Execution } from '@gooddata/typings';
 import { IMappingHeader } from './MappingHeader';
 import { IDrillableItem } from './DrillEvents';
 
-export type IHeaderPredicate = (header: IMappingHeader, afm: AFM.IAfm) => boolean;
+export interface IHeaderPredicateContext {
+    afm: AFM.IAfm;
+    executionResponse: Execution.IExecutionResponse;
+}
+
+export type IHeaderPredicate = (header: IMappingHeader, context: IHeaderPredicateContext) => boolean;
 
 export function isHeaderPredicate(item: IDrillableItem | IHeaderPredicate): item is IHeaderPredicate {
     return typeof item === 'function';

--- a/stories/internal/Visualization.tsx
+++ b/stories/internal/Visualization.tsx
@@ -19,7 +19,7 @@ export interface IDynamicVisualizationState {
     legendOption: any;
 }
 
-class DynamicVisualization extends React.Component<null, IDynamicVisualizationState> {
+class DynamicVisualization extends React.Component<{}, IDynamicVisualizationState> {
     private fixtures: any;
     private legendOptions: any;
     private chartTypes: any;


### PR DESCRIPTION
This PR adds ability to work with execution response in header predicates. Execution response is needed to fully support drilling on AMs because only AFM is not enough to obtain information such identifier from measure headers.