### PR TITLE
TRIVIAL: add preventive null check to PivotTable

### DIFF
--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -496,7 +496,9 @@ export class PivotTableInner extends
 
     public setGridDataSource() {
         this.setState({ execution: null });
-        this.gridApi.setDatasource(this.gridDataSource);
+        if (this.gridApi) {
+            this.gridApi.setDatasource(this.gridDataSource);
+        }
     }
 
     public cellClicked = (cellEvent: IGridCellEvent) => {


### PR DESCRIPTION
Makes sure the `gridApi` object has been set before calling its methods.