### PR TITLE
next 6.2.0 => next 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/react-components",
-  "version": "6.2.0-alpha20",
+  "version": "6.2.0-alpha21",
   "description": "GoodData React Components",
   "main": "dist/index.js",
   "repository": "git@github.com:gooddata/gooddata-react-components.git",


### PR DESCRIPTION
Merge commits from `next-6.2.0` that was merged after SDK code drop to `next-6.3.0`.