### PR TITLE
RELATED: BB-1318 Drilling cleanup vol 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ The REST API versions in the table are just for your information as the values a
 
 - We ask developers to consider using the Headline component instead of the KPI component. The KPI component may be eventually marked as deprecated in one of the next major versions.
 
+## 6.3.0
+
+### Changed
+
+-   Treemap and Heatmap visualization now emits drill events with `value` property of type `string` instead of `number` same as other visualizations. (BB-1318)
+
+
 ## 6.2.0
 
 January 28, 2019

--- a/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
+++ b/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
@@ -10,7 +10,7 @@ import {
     validateData,
     getSeriesItemData,
     getSeries,
-    getDrillContext,
+    getDrillIntersection,
     getDrillableSeries,
     customEscape,
     generateTooltipFn,
@@ -1595,8 +1595,8 @@ describe('chartOptionsBuilder', () => {
         });
     });
 
-    describe('getDrillContext', () => {
-        it('should return correct drillContext for bar chart with stack by and view by attributes', () => {
+    describe('getDrillIntersection', () => {
+        it('should return correct intersection for bar chart with stack by and view by attributes', () => {
             const dataSet = fixtures.barChartWithStackByAndViewByAttributes;
             const { measureGroup, viewByAttribute, stackByAttribute } = getMVS(dataSet);
             /*
@@ -1607,9 +1607,7 @@ describe('chartOptionsBuilder', () => {
                 "uri": "/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1279",
                 "identifier": "ah1EuQxwaCqs"
             }
-
-             */
-
+            */
             const measures = [measureGroup.items[0].measureHeaderItem];
 
             const viewByItem = {
@@ -1623,10 +1621,9 @@ describe('chartOptionsBuilder', () => {
             };
 
             const { afm } = dataSet.executionRequest;
-            const drillContext = getDrillContext(stackByItem, viewByItem, measures, afm);
-            expect(drillContext).toEqual([
+            const drillIntersection = getDrillIntersection(stackByItem, viewByItem, measures, afm);
+            expect(drillIntersection).toEqual([
                 {
-                    format: '#,##0.00',
                     id: 'amountMetric',
                     identifier: 'ah1EuQxwaCqs',
                     uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1279',
@@ -1647,7 +1644,7 @@ describe('chartOptionsBuilder', () => {
             ]);
         });
 
-        it('should return correct drillContex for pie chart measures only', () => {
+        it('should return correct intersection for pie chart measures only', () => {
             const dataSet = fixtures.pieChartWithMetricsOnly;
             const { measureGroup } = getMVS(dataSet);
             const measures = [measureGroup.items[0].measureHeaderItem];
@@ -1656,10 +1653,9 @@ describe('chartOptionsBuilder', () => {
             const stackByItem: any = null;
 
             const { afm } = dataSet.executionRequest;
-            const drillContext = getDrillContext(stackByItem, viewByItem, measures, afm);
-            expect(drillContext).toEqual([
+            const drillIntersection = getDrillIntersection(stackByItem, viewByItem, measures, afm);
+            expect(drillIntersection).toEqual([
                 {
-                    format: '#,##0.00',
                     id: 'lostMetric',
                     identifier: 'af2Ewj9Re2vK',
                     uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1283',
@@ -1711,19 +1707,17 @@ describe('chartOptionsBuilder', () => {
                 type
             );
 
-            it('should assign correct drillContext to pointData with drilldown true', () => {
+            it('should assign correct drillIntersection to pointData with drilldown true', () => {
                 expect(drillableMeasuresSeriesData
-                    .map((seriesItem: any) => seriesItem.data[0].drillContext)
+                    .map((seriesItem: any) => seriesItem.data[0].drillIntersection)
                 ).toEqual([
                     [
                         {
-                            format: '#,##0.00',
                             id: 'lostMetric',
                             identifier: 'af2Ewj9Re2vK',
                             uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1283',
                             value: '<button>Lost</button> ...'
                         }, {
-                            format: '#,##0.00',
                             id: 'wonMetric',
                             identifier: 'afSEwRwdbMeQ',
                             uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1284',
@@ -1823,7 +1817,7 @@ describe('chartOptionsBuilder', () => {
                 type
             );
 
-            it('should assign correct drillContext to pointData with drilldown true', () => {
+            it('should assign correct drillIntersection to pointData with drilldown true', () => {
                 expect(drillableMeasuresSeriesData.length).toBe(20);
                 expect(drillableMeasuresSeriesData[8].data[0]).toEqual({
                     x: 245,
@@ -1831,24 +1825,21 @@ describe('chartOptionsBuilder', () => {
                     z: 2280481.04,
                     format: '$#,#00.00',
                     drilldown: true,
-                    drillContext: [
+                    drillIntersection: [
                         {
                             id: '784a5018a51049078e8f7e86247e08a3',
-                            format: '#,##0.00',
                             value: '_Snapshot [EOP-2]',
                             identifier: 'ab0bydLaaisS',
                             uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/67097'
                         },
                         {
                             id: '9e5c3cd9a93f4476a93d3494cedc6010',
-                            format: '#,##0',
                             value: '# of Open Opps.',
                             identifier: 'aaYh6Voua2yj',
                             uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/13465'
                         },
                         {
                             id: '71d50cf1d13746099b7f506576d78e4a',
-                            format: '$#,#00.00',
                             value: 'Remaining Quota',
                             identifier: 'ab4EFOAmhjOx',
                             uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/1543'
@@ -1953,13 +1944,13 @@ describe('chartOptionsBuilder', () => {
                     type
                 );
 
-                it('should assign correct drillContext to pointData with drilldown true', () => {
+                it('should assign correct drillIntersection to pointData with drilldown true', () => {
                     const startYear = parseInt(// should be 2008
-                        drillableMeasuresSeriesData[0].data[0].drillContext[1].value, 10
+                        drillableMeasuresSeriesData[0].data[0].drillIntersection[1].value, 10
                     );
                     drillableMeasuresSeriesData.forEach((seriesItem: any) => {
                         seriesItem.data.forEach((point: any, index: number) => {
-                            expect(point.drillContext[1].value - index).toEqual(startYear);
+                            expect(point.drillIntersection[1].value - index).toEqual(startYear);
                         });
                     });
                 });
@@ -2003,13 +1994,13 @@ describe('chartOptionsBuilder', () => {
                     type
                 );
 
-                it('should assign correct drillContext to pointData with drilldown true', () => {
+                it('should assign correct drillIntersection to pointData with drilldown true', () => {
                     const startYear = parseInt(// should be 2008
-                        drillableMeasuresSeriesData[0].data[0].drillContext[1].value, 10
+                        drillableMeasuresSeriesData[0].data[0].drillIntersection[1].value, 10
                     );
                     drillableMeasuresSeriesData.forEach((seriesItem: any) => {
                         seriesItem.data.forEach((point: any, index: number) => {
-                            expect(point.drillContext[1].value - index).toEqual(startYear);
+                            expect(point.drillIntersection[1].value - index).toEqual(startYear);
                         });
                     });
                 });
@@ -2062,32 +2053,32 @@ describe('chartOptionsBuilder', () => {
                         .map((seriesItem: any) => seriesItem.isDrillable)).toEqual([false, false, false]);
                 });
 
-                it('should return new pointData items drilldown false and no drillContext', () => {
+                it('should return new pointData items drilldown false and no drillIntersection', () => {
                     expect(noDrillableSeriesData
-                        .map((seriesItem: any) => seriesItem.data.map(({ drilldown, drillContext }: any) => {
-                            return { drilldown, drillContext };
+                        .map((seriesItem: any) => seriesItem.data.map(({ drilldown, drillIntersection }: any) => {
+                            return { drilldown, drillIntersection };
                         }))
                     ).toEqual([
                         [
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false }
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false }
                         ],
                         [
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false }
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false }
                         ],
                         [
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false },
-                            { drillContext: undefined, drilldown: false }
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false },
+                            { drillIntersection: undefined, drilldown: false }
                         ]
                     ]);
                 });
@@ -2126,13 +2117,12 @@ describe('chartOptionsBuilder', () => {
                     ]);
                 });
 
-                it('should assign correct drillContext to pointData with drilldown true', () => {
+                it('should assign correct drillIntersection to pointData with drilldown true', () => {
                     expect(twoDrillableMeasuresSeriesData
-                        .map((seriesItem: any) => seriesItem.data[0].drillContext)
+                        .map((seriesItem: any) => seriesItem.data[0].drillIntersection)
                     ).toEqual([
                         [
                             {
-                                format: '#,##0.00',
                                 id: 'lostMetric',
                                 identifier: 'af2Ewj9Re2vK',
                                 uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1283',
@@ -2147,7 +2137,6 @@ describe('chartOptionsBuilder', () => {
                         undefined,
                         [
                             {
-                                format: '#,##0.00',
                                 id: 'expectedMetric',
                                 identifier: 'alUEwmBtbwSh',
                                 uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1285',

--- a/src/components/visualizations/table/utils/dataTransformation.ts
+++ b/src/components/visualizations/table/utils/dataTransformation.ts
@@ -3,7 +3,7 @@ import { AFM, Execution } from '@gooddata/typings';
 import * as invariant from 'invariant';
 import { get, has, isEmpty, zip } from 'lodash';
 import { getMappingHeaderName } from '../../../../helpers/mappingHeader';
-import { IDrillIntersection } from '../../../../interfaces/DrillEvents';
+import { ILegacyDrillIntersection } from '../../../../interfaces/DrillEvents';
 import {
     IMappingHeader,
     isMappingHeaderAttribute,
@@ -145,7 +145,7 @@ export function validateTableProportions(headers: IMappingHeader[], rows: TableR
     );
 }
 
-export function getIntersectionForDrilling(afm: AFM.IAfm, header: IMappingHeader): IDrillIntersection {
+export function getIntersectionForDrilling(afm: AFM.IAfm, header: IMappingHeader): ILegacyDrillIntersection {
     if (isMappingHeaderAttribute(header)) {
         return {
             id: header.attributeHeader.identifier,

--- a/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
+++ b/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
@@ -33,7 +33,7 @@ describe('Drilldown Eventing', () => {
             x: 1,
             y: 2,
             value: 678.00,
-            drillContext: [
+            drillIntersection: [
                 {
                     id: 'id',
                     title: 'title',
@@ -181,7 +181,7 @@ describe('Drilldown Eventing', () => {
 
         expect(target.dispatchEvent).toHaveBeenCalled();
 
-        expect(target.dispatchEvent.mock.calls[0][0].detail.drillContext.value).toBe(678.00);
+        expect(target.dispatchEvent.mock.calls[0][0].detail.drillContext.value).toBe('678');
 
         chartClick(
             drillConfig,
@@ -194,7 +194,7 @@ describe('Drilldown Eventing', () => {
 
         expect(target.dispatchEvent).toHaveBeenCalled();
 
-        expect(target.dispatchEvent.mock.calls[0][0].detail.drillContext.value).toBe(678.00);
+        expect(target.dispatchEvent.mock.calls[0][0].detail.drillContext.value).toBe('678');
     });
 
     it('should correctly handle z coordinate of point', () => {
@@ -320,7 +320,7 @@ describe('Drilldown Eventing', () => {
             points: [{
                 x: 1,
                 y: 2,
-                drillContext: [
+                drillIntersection: [
                     {
                         id: 'id',
                         title: 'title',

--- a/src/constants/visualizationTypes.ts
+++ b/src/constants/visualizationTypes.ts
@@ -27,5 +27,8 @@ export type ChartType = 'bar' | 'column' | 'pie' | 'line' | 'area' | 'donut' |
     'scatter' | 'bubble' | 'heatmap' | 'geo' | 'combo' | 'histogram' |
     'bullet' | 'treemap' | 'waterfall' | 'funnel' | 'pareto' | 'alluvial';
 export type VisType = ChartType | 'table' | 'pivotTable' | 'headline';
-export type ChartElementType = 'slice' | 'bar' | 'point';
-export type VisElementType = ChartElementType | 'cell' | 'primaryValue' | 'secondaryValue';
+
+export type ChartElementType = 'slice' | 'bar' | 'point' | 'label';
+export type HeadlineElementType = 'primaryValue' | 'secondaryValue';
+export type TableElementType = 'cell';
+export type VisElementType = ChartElementType | HeadlineElementType | TableElementType;

--- a/src/interfaces/DrillEvents.ts
+++ b/src/interfaces/DrillEvents.ts
@@ -25,41 +25,52 @@ export function isDrillableItemIdentifier(item: IDrillableItem): item is IDrilla
 
 export type IDrillEventCallback = (event: IDrillEvent) => void | boolean;
 
-// Internal precursor to IDrillEventIntersectionElement
-// TODO: Refactor internal drilling functions and replace with IDrillEventIntersectionElement
-export interface IDrillIntersection {
-    id: string;
-    title?: string;
-    value?: Execution.DataValue;
-    name?: string;
-    uri: string;
-    identifier: AFM.Identifier;
-}
-
-// IDrillEvent is a parameter of the onFiredDrillEvent is callback
-export interface IDrillEvent {
-    executionContext: AFM.IAfm;
-    drillContext: {
-        type: VisType; // type of visualization
-        element: VisElementType; // type of visualization element drilled
-        x?: number; // chart x coordinate (if supported)
-        y?: number; // chart y coordinate (if supported)
-        columnIndex?: number;
-        rowIndex?: number;
-        row?: any[]; // table row data of the drilled row
-        value?: string; // cell or element value drilled
-        // some drill headers that are relevant for current drill element
-        intersection: IDrillEventIntersectionElement[];
-        // A collection of chart series points (if available)
-        points?: IDrillEventPoint[];
-    };
-}
-
 // Chart series point with intersection element
 export interface IDrillEventPoint {
     x: number;
     y: number;
     intersection: IDrillEventIntersectionElement[];
+}
+
+// Internal precursor to IDrillEventIntersectionElement
+// TODO: Refactor internal drilling functions and replace with IDrillEventIntersectionElement
+export interface ILegacyDrillIntersection {
+    id: string; // attribute value id or measure localIndentifier
+    title?: string;
+    value?: Execution.DataValue; // text label of attribute value or formatted measure value
+    name?: string;
+    uri: string; // uri of measure
+    identifier: AFM.Identifier; // identifier of attribute or measure
+}
+
+export interface IDrillEventContextBase {
+    type: VisType; // type of visualization
+    element: VisElementType; // type of visualization element drilled
+    x?: number; // chart x coordinate (if supported)
+    y?: number; // chart y coordinate (if supported)
+    columnIndex?: number;
+    rowIndex?: number;
+    row?: any[]; // table row data of the drilled row
+    value?: string; // cell or element value drilled
+}
+
+// Drill context for standard vsualization click
+export interface IDrillEventContextSingle extends IDrillEventContextBase {
+    intersection: IDrillEventIntersectionElement[]; // drill headers relevant for current drill element
+}
+
+// Drill context for group clicks (multiple series chart + click on axis value)
+// Every point has own intersection
+export interface IDrillEventContextGroup extends IDrillEventContextBase {
+    points: IDrillEventPoint[]; // a collection of chart series points
+}
+
+export type DrillEventContext = IDrillEventContextSingle | IDrillEventContextGroup;
+
+// IDrillEvent is a parameter of the onFiredDrillEvent is callback
+export interface IDrillEvent {
+    executionContext: AFM.IAfm;
+    drillContext: DrillEventContext;
 }
 
 // Intersection element


### PR DESCRIPTION
First volume of drill cleanup:
1. Marked old drillable intersection as `ILegacyDrillIntersection`. This legacy type will be replaced by `IDrillEventIntersectionElement` in next volume.
2. Added type `DrillEventContext` to some lines of code that was not been typed previously to easily search where we use such type.
3. Drill context was split into 2 interfaces `IDrillEventContextSingle` for classic context, `IDrillEventContextGroup` for group context (group is used when chart has more series drill-activated and user clicks on axis label - group event is fired - every point has own intersection).
4. Renamed property of HC helper object including interface`IHighchartsPointObject`- original was `drillContext`, correct is `drillIntersection`
5. Heatmap and Treemap now return value as strings instead of number when drilling. This is in sync with other vis. types which returns value as string. 
6. Removed `format` property from legacy drill intersection elements (and relevant tests). This property is not propagated to drill events and is irrelevant.
7. Added new VisElementType `label` which was not present before, but was used (blind TSC).
8. Added `ILegacyHeader*` helper types that will be replaced by drillable headers in next volume.