### PR TITLE
RELATED: BB-1318 Drilling cleanup vol 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,9 @@ The REST API versions in the table are just for your information as the values a
 
 -   Treemap and Heatmap visualization now emits drill events with `value` property of type `string` instead of `number` same as other visualizations. (BB-1318)
 
--   Table visualization now emits drill events with correct intersection containing also non-empty `header.identifier` properties. 
+-   Table visualization and all chart visualizations now emits drill events with correct intersection containing also non-empty `header.identifier` properties when executed using `uri`. 
 
-
-TODO:
-
--   Table visualization now emits drill event with `value` property same as other visualizations. (BB-1318)
+-   Pivot Table visualization now emits drill events without `value` property in `drillContext`. Value can be obtained from `row` property using `columnIndex`.
 
 
 ## 6.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ The REST API versions in the table are just for your information as the values a
 
 -   Treemap and Heatmap visualization now emits drill events with `value` property of type `string` instead of `number` same as other visualizations. (BB-1318)
 
+-   Table visualization now emits drill events with correct intersection containing also non-empty `header.identifier` properties. 
+
+
+TODO:
+
+-   Table visualization now emits drill event with `value` property same as other visualizations. (BB-1318)
+
 
 ## 6.2.0
 

--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -594,6 +594,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
         }
 
         const leafColumnDefs = getTreeLeaves(columnDefs);
+        // TODO BB-1318 Drill context generator - Pivot Table
         const drillEvent: IDrillEvent = {
             executionContext: afm,
             drillContext: {
@@ -603,7 +604,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
                 rowIndex,
                 row: getDrillRowData(leafColumnDefs, cellEvent.data),
                 intersection: getDrillIntersection(drillItems, afm),
-                value: cellEvent.value ? cellEvent.value.toString() : null
+                value: cellEvent.value ? cellEvent.value.toString() : null // TODO BB-1318 I think we dont want to have this
             }
         };
 

--- a/src/components/visualizations/chart/chartOptionsBuilder.ts
+++ b/src/components/visualizations/chart/chartOptionsBuilder.ts
@@ -25,7 +25,7 @@ import { findAttributeInDimension, findMeasureGroupInDimensions } from '../../..
 import { isSomeHeaderPredicateMatched } from '../../../helpers/headerPredicate';
 import { unwrap } from '../../../helpers/utils';
 import { IChartConfig, IChartLimits, IColorAssignment } from '../../../interfaces/Config';
-import { ILegacyDrillIntersection } from '../../../interfaces/DrillEvents';
+import { IDrillEventIntersectionElement } from '../../../interfaces/DrillEvents';
 import { IHeaderPredicate } from '../../../interfaces/HeaderPredicate';
 import { IMappingHeader } from '../../../interfaces/MappingHeader';
 import { getLighterColor } from '../utils/color';
@@ -844,6 +844,7 @@ export function generateTooltipTreemapFn(viewByAttribute: any, stackByAttribute:
     };
 }
 
+// TODO BB-1318 Legacy interface should be replaced by MappingHeader
 export interface ILegacyMeasureHeader {
     uri: string; // header attribute value or measure uri
     identifier?: string;
@@ -861,16 +862,19 @@ export function isLegacyAttributeHeader(header: ILegacyHeader): header is ILegac
     return (header as ILegacyAttributeHeader).attribute !== undefined;
 }
 
-function createLegacyDrillIntersectionElement(header: ILegacyHeader, afm: AFM.IAfm): ILegacyDrillIntersection {
+// TODO BB-1318 Drill intersection generator - Visualization
+function createDrillIntersectionElement(header: ILegacyHeader, afm: AFM.IAfm): IDrillEventIntersectionElement {
     const { name } = header;
 
     if (isLegacyAttributeHeader(header)) {
         const { attribute, uri } = header;
         return {
             id: getAttributeElementIdFromAttributeElementUri(uri),
-            value: name,
-            uri: attribute.uri,
-            identifier: attribute.identifier
+            title: name,
+            header: {
+                uri: attribute.uri,
+                identifier: attribute.identifier
+            }
         };
     }
 
@@ -878,9 +882,11 @@ function createLegacyDrillIntersectionElement(header: ILegacyHeader, afm: AFM.IA
 
     return {
         id: localIdentifier,
-        value: name,
-        uri: get<string>(getMasterMeasureObjQualifier(afm, localIdentifier), 'uri'),
-        identifier
+        title: name,
+        header: {
+            uri: get<string>(getMasterMeasureObjQualifier(afm, localIdentifier), 'uri'),
+            identifier
+        }
     };
 }
 
@@ -889,10 +895,10 @@ export function getDrillIntersection(
     viewByItem: any,
     measures: any[],
     afm: AFM.IAfm
-): ILegacyDrillIntersection[] {
+): IDrillEventIntersectionElement[] {
     const headers = without([...measures, viewByItem, stackByItem], null);
 
-    return headers.map(header => createLegacyDrillIntersectionElement(header, afm));
+    return headers.map(header => createDrillIntersectionElement(header, afm));
 }
 
 function getViewBy(viewByAttribute: IUnwrappedAttributeHeadersWithItems, viewByIndex: number) {

--- a/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
+++ b/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
@@ -1625,21 +1625,27 @@ describe('chartOptionsBuilder', () => {
             expect(drillIntersection).toEqual([
                 {
                     id: 'amountMetric',
-                    identifier: 'ah1EuQxwaCqs',
-                    uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1279',
-                    value: 'Amount'
+                    title: 'Amount',
+                    header: {
+                        identifier: 'ah1EuQxwaCqs',
+                        uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1279'
+                    }
                 },
                 {
                     id: '1226',
-                    identifier: 'label.owner.department',
-                    uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1027',
-                    value: 'Direct Sales'
+                    title: 'Direct Sales',
+                    header: {
+                        identifier: 'label.owner.department',
+                        uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1027'
+                    }
                 },
                 {
                     id: '1225',
-                    identifier: 'label.owner.region',
-                    uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1024',
-                    value: 'East Coast'
+                    title: 'East Coast',
+                    header: {
+                        identifier: 'label.owner.region',
+                        uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1024'
+                    }
                 }
             ]);
         });
@@ -1657,9 +1663,11 @@ describe('chartOptionsBuilder', () => {
             expect(drillIntersection).toEqual([
                 {
                     id: 'lostMetric',
-                    identifier: 'af2Ewj9Re2vK',
-                    uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1283',
-                    value: 'Lost'
+                    title: 'Lost',
+                    header: {
+                        identifier: 'af2Ewj9Re2vK',
+                        uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1283'
+                    }
                 }
             ]);
         });
@@ -1714,19 +1722,25 @@ describe('chartOptionsBuilder', () => {
                     [
                         {
                             id: 'lostMetric',
-                            identifier: 'af2Ewj9Re2vK',
-                            uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1283',
-                            value: '<button>Lost</button> ...'
+                            title: '<button>Lost</button> ...',
+                            header: {
+                                identifier: 'af2Ewj9Re2vK',
+                                uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1283'
+                            }
                         }, {
                             id: 'wonMetric',
-                            identifier: 'afSEwRwdbMeQ',
-                            uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1284',
-                            value: 'Won'
+                            title: 'Won',
+                            header: {
+                                identifier: 'afSEwRwdbMeQ',
+                                uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1284'
+                            }
                         }, {
                             id: '2008',
-                            identifier: 'created.aag81lMifn6q',
-                            uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/158',
-                            value: '<button>2008</button>'
+                            title: '<button>2008</button>',
+                            header: {
+                                identifier: 'created.aag81lMifn6q',
+                                uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/158'
+                            }
                         }
                     ]
                 ]);
@@ -1828,27 +1842,35 @@ describe('chartOptionsBuilder', () => {
                     drillIntersection: [
                         {
                             id: '784a5018a51049078e8f7e86247e08a3',
-                            value: '_Snapshot [EOP-2]',
-                            identifier: 'ab0bydLaaisS',
-                            uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/67097'
+                            title: '_Snapshot [EOP-2]',
+                            header: {
+                                identifier: 'ab0bydLaaisS',
+                                uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/67097'
+                            }
                         },
                         {
                             id: '9e5c3cd9a93f4476a93d3494cedc6010',
-                            value: '# of Open Opps.',
-                            identifier: 'aaYh6Voua2yj',
-                            uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/13465'
+                            title: '# of Open Opps.',
+                            header: {
+                                identifier: 'aaYh6Voua2yj',
+                                uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/13465'
+                            }
                         },
                         {
                             id: '71d50cf1d13746099b7f506576d78e4a',
-                            value: 'Remaining Quota',
-                            identifier: 'ab4EFOAmhjOx',
-                            uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/1543'
+                            title: 'Remaining Quota',
+                            header: {
+                                identifier: 'ab4EFOAmhjOx',
+                                uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/1543'
+                            }
                         },
                         {
                             id: '1235',
-                            value: 'Jessica Traven',
-                            identifier: 'label.owner.id.name',
-                            uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/1028'
+                            title: 'Jessica Traven',
+                            header: {
+                                identifier: 'label.owner.id.name',
+                                uri: '/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/1028'
+                            }
                         }
                     ]
                 });
@@ -2124,28 +2146,36 @@ describe('chartOptionsBuilder', () => {
                         [
                             {
                                 id: 'lostMetric',
-                                identifier: 'af2Ewj9Re2vK',
-                                uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1283',
-                                value: '<button>Lost</button> ...'
+                                title: '<button>Lost</button> ...',
+                                header: {
+                                    identifier: 'af2Ewj9Re2vK',
+                                    uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1283'
+                                }
                             }, {
                                 id: '2008',
-                                identifier: 'created.aag81lMifn6q',
-                                uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/158',
-                                value: '<button>2008</button>'
+                                title: '<button>2008</button>',
+                                header: {
+                                    identifier: 'created.aag81lMifn6q',
+                                    uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/158'
+                                }
                             }
                         ],
                         undefined,
                         [
                             {
                                 id: 'expectedMetric',
-                                identifier: 'alUEwmBtbwSh',
-                                uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1285',
-                                value: 'Expected'
+                                title: 'Expected',
+                                header: {
+                                    identifier: 'alUEwmBtbwSh',
+                                    uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1285'
+                                }
                             }, {
                                 id: '2008',
-                                identifier: 'created.aag81lMifn6q',
-                                uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/158',
-                                value: '<button>2008</button>'
+                                title: '<button>2008</button>',
+                                header: {
+                                    identifier: 'created.aag81lMifn6q',
+                                    uri: '/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/158'
+                                }
                             }
                         ]
                     ]);

--- a/src/components/visualizations/headline/Headline.tsx
+++ b/src/components/visualizations/headline/Headline.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import noop = require('lodash/noop');
 import { AFM } from '@gooddata/typings';
-import { VisElementType } from '../../../constants/visualizationTypes';
+import { HeadlineElementType, VisElementTypes } from '../../../constants/visualizationTypes';
 import ResponsiveText from '@gooddata/goodstrap/lib/ResponsiveText/ResponsiveText';
 import {
     IFormattedHeadlineDataItem,
@@ -16,7 +16,7 @@ import { IChartConfig } from '../../../interfaces/Config';
 export interface IHeadlineFiredDrillEventItemContext {
     localIdentifier: AFM.Identifier;
     value: string | null;
-    element: VisElementType;
+    element: HeadlineElementType;
 }
 
 export type IHeadlineFiredDrillEvent = (
@@ -102,7 +102,7 @@ export default class Headline extends React.Component<IHeadlineVisualizationProp
         });
     }
 
-    private fireDrillEvent(item: IHeadlineDataItem, elementName: VisElementType, elementTarget: HTMLElement) {
+    private fireDrillEvent(item: IHeadlineDataItem, elementName: HeadlineElementType, elementTarget: HTMLElement) {
         const { onFiredDrillEvent } = this.props;
 
         if (onFiredDrillEvent) {
@@ -119,13 +119,13 @@ export default class Headline extends React.Component<IHeadlineVisualizationProp
     private handleClickOnPrimaryItem(event: React.MouseEvent<HTMLElement>) {
         const { data: { primaryItem } } = this.props;
 
-        this.fireDrillEvent(primaryItem, 'primaryValue', event.target as HTMLElement);
+        this.fireDrillEvent(primaryItem, VisElementTypes.PRIMARY_VALUE, event.target as HTMLElement);
     }
 
     private handleClickOnSecondaryItem(event: React.MouseEvent<HTMLElement>) {
         const { data: { secondaryItem } } = this.props;
 
-        this.fireDrillEvent(secondaryItem, 'secondaryValue', event.target as HTMLElement);
+        this.fireDrillEvent(secondaryItem, VisElementTypes.SECONDARY_VALUE, event.target as HTMLElement);
     }
 
     private renderTertiaryItem() {

--- a/src/components/visualizations/headline/test/fixtures/drill_event_data.ts
+++ b/src/components/visualizations/headline/test/fixtures/drill_event_data.ts
@@ -4,7 +4,8 @@ export const DRILL_EVENT_DATA_BY_MEASURE_URI = {
         element: 'primaryValue',
         intersection: [{
             header: {
-                uri: '/gdc/md/project_id/obj/1'
+                uri: '/gdc/md/project_id/obj/1',
+                identifier: ''
             },
             id: 'm1',
             title: 'Lost'
@@ -31,7 +32,8 @@ export const DRILL_EVENT_DATA_BY_MEASURE_IDENTIFIER = {
         element: 'primaryValue',
         intersection: [{
             header: {
-                identifier: 'metric.lost'
+                identifier: 'metric.lost',
+                uri: ''
             },
             id: 'm1',
             title: 'Lost'
@@ -58,7 +60,8 @@ export const DRILL_EVENT_DATA_FOR_SECONDARY_ITEM = {
         element: 'secondaryValue',
         intersection: [{
             header: {
-                identifier: 'measure.found'
+                identifier: 'measure.found',
+                uri: ''
             },
             id: 'm2',
             title: 'Found'

--- a/src/components/visualizations/headline/utils/HeadlineTransformationUtils.ts
+++ b/src/components/visualizations/headline/utils/HeadlineTransformationUtils.ts
@@ -201,9 +201,13 @@ export function buildDrillEventData(itemContext: IHeadlineDrillItemContext,
     const { identifier, uri } = measureIds;
 
     if (identifier || uri) {
-        intersection.header = { identifier, uri };
+        intersection.header = {
+            identifier: identifier || '',
+            uri: uri || ''
+        };
     }
 
+    // TODO BB-1318 Drill context generator - Headline
     return {
         executionContext: executionRequest.afm,
         drillContext: {
@@ -224,6 +228,7 @@ export function buildDrillEventData(itemContext: IHeadlineDrillItemContext,
  * @param drillEventData - The event data in {executionContext, drillContext} format.
  * @param target - The target where the built event must be dispatched.
  */
+// TODO BB-1318 This is duplicated, use function  in drilldownEventing.ts
 export function fireDrillEvent(drillEventFunction: IDrillEventCallback,
                                drillEventData: IDrillEvent,
                                target: EventTarget) {

--- a/src/components/visualizations/headline/utils/HeadlineTransformationUtils.ts
+++ b/src/components/visualizations/headline/utils/HeadlineTransformationUtils.ts
@@ -7,16 +7,17 @@ import * as CustomEventPolyfill from 'custom-event';
 import * as invariant from 'invariant';
 import { AFM, Execution } from '@gooddata/typings';
 import { InjectedIntl } from 'react-intl';
+import { getMasterMeasureObjQualifier } from '../../../../helpers/afmHelper';
 import { isSomeHeaderPredicateMatched } from '../../../../helpers/headerPredicate';
 import { IHeaderPredicate } from '../../../../interfaces/HeaderPredicate';
-import { getMasterMeasureObjQualifier } from '../../../../helpers/afmHelper';
 import {
     IDrillEvent,
     IDrillEventCallback,
-    IDrillEventIntersectionElement
+    IDrillEventContextHeadline
 } from '../../../../interfaces/DrillEvents';
-import { VisualizationTypes, VisElementType } from '../../../../constants/visualizationTypes';
+import { VisualizationTypes, HeadlineElementType } from '../../../../constants/visualizationTypes';
 import { IHeadlineData, IHeadlineDataItem } from '../../../../interfaces/Headlines';
+import { createDrillIntersectionElement } from '../../utils/drilldownEventing';
 
 export interface IHeadlineExecutionData {
     measureHeaderItem: Execution.IMeasureHeaderItem['measureHeaderItem'];
@@ -26,7 +27,7 @@ export interface IHeadlineExecutionData {
 export interface IHeadlineDrillItemContext {
     localIdentifier: AFM.Identifier;
     value: string;
-    element: VisElementType;
+    element: HeadlineElementType;
 }
 
 function createHeadlineDataItem(executionDataItem: IHeadlineExecutionData): IHeadlineDataItem {
@@ -193,31 +194,22 @@ export function buildDrillEventData(itemContext: IHeadlineDrillItemContext,
         throw new Error('The metric ids has not been found in execution request!');
     }
 
-    const intersection: IDrillEventIntersectionElement = {
-        id: measureHeaderItem.localIdentifier,
-        title: measureHeaderItem.name
+    const intersectionElement = createDrillIntersectionElement(
+        measureHeaderItem.localIdentifier,
+        measureHeaderItem.name,
+        measureIds.uri,
+        measureIds.identifier
+    );
+    const drillContext: IDrillEventContextHeadline = {
+        type: VisualizationTypes.HEADLINE,
+        element: itemContext.element,
+        value: itemContext.value,
+        intersection: [ intersectionElement ]
     };
 
-    const { identifier, uri } = measureIds;
-
-    if (identifier || uri) {
-        intersection.header = {
-            identifier: identifier || '',
-            uri: uri || ''
-        };
-    }
-
-    // TODO BB-1318 Drill context generator - Headline
     return {
         executionContext: executionRequest.afm,
-        drillContext: {
-            type: VisualizationTypes.HEADLINE,
-            element: itemContext.element,
-            value: itemContext.value,
-            intersection: [
-                intersection
-            ]
-        }
+        drillContext
     };
 }
 

--- a/src/components/visualizations/headline/utils/test/HeadlineTransformationUtils.spec.ts
+++ b/src/components/visualizations/headline/utils/test/HeadlineTransformationUtils.spec.ts
@@ -531,7 +531,8 @@ describe('HeadlineTransformationUtils', () => {
                             id: 'm1',
                             title: 'Lost',
                             header: {
-                                uri: '/gdc/md/project_id/obj/1'
+                                uri: '/gdc/md/project_id/obj/1',
+                                identifier: ''
                             }
                         }
                     ]
@@ -574,7 +575,8 @@ describe('HeadlineTransformationUtils', () => {
                             id: 'm1',
                             title: 'Lost',
                             header: {
-                                identifier: 'metric.lost'
+                                identifier: 'metric.lost',
+                                uri: ''
                             }
                         }
                     ]
@@ -627,7 +629,8 @@ describe('HeadlineTransformationUtils', () => {
                             id: 'm2',
                             title: 'Found',
                             header: {
-                                uri: '/gdc/md/project_id/obj/2'
+                                uri: '/gdc/md/project_id/obj/2',
+                                identifier: ''
                             }
                         }
                     ]

--- a/src/components/visualizations/headline/utils/test/HeadlineTransformationUtils.spec.ts
+++ b/src/components/visualizations/headline/utils/test/HeadlineTransformationUtils.spec.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2018 GoodData Corporation
-import { VisElementType } from '../../../../../constants/visualizationTypes';
+import { HeadlineElementType } from '../../../../../constants/visualizationTypes';
 import { IDrillEvent } from '../../../../../interfaces/DrillEvents';
 import { IHeadlineData } from '../../../../../interfaces/Headlines';
 import * as headerPredicateFactory from '../../../../../factory/HeaderPredicateFactory';
@@ -499,7 +499,7 @@ describe('HeadlineTransformationUtils', () => {
         it('should build expected drill event data from execution request made with metric uri', () => {
             const itemContext = {
                 localIdentifier: 'm1',
-                element: 'primaryValue' as VisElementType,
+                element: 'primaryValue' as HeadlineElementType,
                 value: '42'
             };
             const eventData = buildDrillEventData(
@@ -543,7 +543,7 @@ describe('HeadlineTransformationUtils', () => {
         it('should build expected drill event data from execution request made with metric identifier', () => {
             const itemContext = {
                 localIdentifier: 'm1',
-                element: 'primaryValue' as VisElementType,
+                element: 'primaryValue' as HeadlineElementType,
                 value: '42'
             };
             const eventData = buildDrillEventData(
@@ -587,7 +587,7 @@ describe('HeadlineTransformationUtils', () => {
         it('should build drill event data from execution for secondary value', () => {
             const itemContext = {
                 localIdentifier: 'm2',
-                element: 'secondaryValue' as VisElementType,
+                element: 'secondaryValue' as HeadlineElementType,
                 value: '12345678'
             };
             const eventData = buildDrillEventData(
@@ -642,7 +642,7 @@ describe('HeadlineTransformationUtils', () => {
             const itemContext = {
                 localIdentifier: 'abc',
                 uri: '/gdc/md/project_id/obj/2',
-                element: 'primaryValue' as VisElementType,
+                element: 'primaryValue' as HeadlineElementType,
                 value: '42'
             };
             expect(() => buildDrillEventData(

--- a/src/components/visualizations/table/fixtures/arithmericMeasures.ts
+++ b/src/components/visualizations/table/fixtures/arithmericMeasures.ts
@@ -121,8 +121,6 @@ export const TABLE_HEADERS_AM: Execution.IMeasureHeaderItem[] = [
     },
     {
         measureHeaderItem: {
-            uri: '/am1uri',
-            identifier: 'am1id',
             localIdentifier: 'am1',
             name: 'AM1(M1,M2)',
             format: '#,##0'
@@ -130,8 +128,6 @@ export const TABLE_HEADERS_AM: Execution.IMeasureHeaderItem[] = [
     },
     {
         measureHeaderItem: {
-            uri: '/am2uri',
-            identifier: 'am2id',
             localIdentifier: 'am2',
             name: 'AM2(AM1,M2)',
             format: '#,##0'
@@ -139,8 +135,6 @@ export const TABLE_HEADERS_AM: Execution.IMeasureHeaderItem[] = [
     },
     {
         measureHeaderItem: {
-            uri: '/am3uri',
-            identifier: 'am3id',
             localIdentifier: 'am3',
             name: 'AM3(M0,M2)',
             format: '#,##0'
@@ -148,8 +142,6 @@ export const TABLE_HEADERS_AM: Execution.IMeasureHeaderItem[] = [
     },
     {
         measureHeaderItem: {
-            uri: '/dam1uri',
-            identifier: 'dam1id',
             localIdentifier: 'dam1',
             name: 'DAM1(AM1)',
             format: '#,##0'
@@ -196,8 +188,6 @@ export const EXECUTION_RESPONSE_AM: Execution.IExecutionResponse = {
                             },
                             {
                                 measureHeaderItem: {
-                                    uri: '/am1uri',
-                                    identifier: 'am1id',
                                     localIdentifier: 'am1',
                                     name: 'AM1(M1,M2)',
                                     format: '#,##0'
@@ -205,8 +195,6 @@ export const EXECUTION_RESPONSE_AM: Execution.IExecutionResponse = {
                             },
                             {
                                 measureHeaderItem: {
-                                    uri: '/am2uri',
-                                    identifier: 'am2id',
                                     localIdentifier: 'am2',
                                     name: 'AM2(AM1,M2)',
                                     format: '#,##0'
@@ -214,8 +202,6 @@ export const EXECUTION_RESPONSE_AM: Execution.IExecutionResponse = {
                             },
                             {
                                 measureHeaderItem: {
-                                    uri: '/am3uri',
-                                    identifier: 'am3id',
                                     localIdentifier: 'am3',
                                     name: 'AM3(M0,A2)',
                                     format: '#,##0'
@@ -223,8 +209,6 @@ export const EXECUTION_RESPONSE_AM: Execution.IExecutionResponse = {
                             },
                             {
                                 measureHeaderItem: {
-                                    uri: '/dam1uri',
-                                    identifier: 'dam1id',
                                     localIdentifier: 'dam1',
                                     name: 'DAM1(AM1)',
                                     format: '#,##0'

--- a/src/components/visualizations/table/utils/dataTransformation.ts
+++ b/src/components/visualizations/table/utils/dataTransformation.ts
@@ -25,6 +25,7 @@ import {
 import { IIndexedTotalItem, ITotalWithData } from '../../../../interfaces/Totals';
 import { getAttributeElementIdFromAttributeElementUri } from '../../utils/common';
 import { getMasterMeasureObjQualifier } from '../../../../helpers/afmHelper';
+import { createDrillIntersectionElement } from '../../utils/drilldownEventing';
 import { AVAILABLE_TOTALS } from '../totals/utils';
 
 export function getHeaders(executionResponse: Execution.IExecutionResponse): IMappingHeader[] {
@@ -150,38 +151,24 @@ export function validateTableProportions(headers: IMappingHeader[], rows: TableR
     );
 }
 
-// TODO BB-1318 Intersection generator - Table
 export function getIntersectionForDrilling(afm: AFM.IAfm, header: IMappingHeader): IDrillEventIntersectionElement {
     if (isMappingHeaderAttribute(header)) {
-        return {
-            id: getMappingHeaderIdentifier(header),
-            title: getMappingHeaderName(header),
-            header: {
-                uri: getMappingHeaderUri(header),
-                identifier: getMappingHeaderIdentifier(header)
-            }
-        };
+        return createDrillIntersectionElement(
+            getMappingHeaderIdentifier(header),
+            getMappingHeaderName(header),
+            getMappingHeaderUri(header),
+            getMappingHeaderIdentifier(header)
+        );
     }
 
     if (isMappingHeaderMeasureItem(header)) {
-        const element = {
-            id: getMappingHeaderLocalIdentifier(header),
-            title: getMappingHeaderName(header)
-        };
-
         const masterQualifier = getMasterMeasureObjQualifier(afm, getMappingHeaderLocalIdentifier(header));
-
-        if (masterQualifier.uri || masterQualifier.identifier) {
-            return {
-                ...element,
-                header: {
-                    uri: masterQualifier.uri || '',
-                    identifier: masterQualifier.identifier || ''
-                }
-            };
-        }
-
-        return element;
+        return createDrillIntersectionElement(
+            getMappingHeaderLocalIdentifier(header),
+            getMappingHeaderName(header),
+            masterQualifier.uri,
+            masterQualifier.identifier
+        );
     }
 
     throw new Error(`Unknown mapping header type ${Object.keys(header)}`);

--- a/src/components/visualizations/table/utils/test/dataTransformation.spec.ts
+++ b/src/components/visualizations/table/utils/test/dataTransformation.spec.ts
@@ -2,6 +2,7 @@
 import { set, cloneDeep } from 'lodash';
 import { Execution } from '@gooddata/typings';
 import { TableRow } from '../../../../../interfaces/Table';
+import { EXECUTION_REQUEST_AM, TABLE_HEADERS_AM } from '../../fixtures/arithmericMeasures';
 
 import {
     getIntersectionForDrilling,
@@ -241,40 +242,56 @@ describe('Table utils - Data transformation', () => {
         });
     });
 
-    describe('Intersection for drilling', () => {
-        it('should get intersection for attribute', () => {
+    describe('getIntersectionForDrilling', () => {
+        it('should return intersection for attribute', () => {
             expect(getIntersectionForDrilling(
                 EXECUTION_REQUEST_1M.execution.afm,
                 TABLE_HEADERS_1A[0])
             ).toEqual({
                 id: '1st_attr_df_identifier',
-                identifier: '1st_attr_df_identifier',
-                uri: '/gdc/md/project_id/obj/1st_attr_df_uri_id',
-                title: 'Product'
+                title: 'Product',
+                header: {
+                    identifier: '1st_attr_df_identifier',
+                    uri: '/gdc/md/project_id/obj/1st_attr_df_uri_id'
+                }
             });
         });
 
-        it('should get intersection for simple measure', () => {
+        it('should return intersection for simple measure', () => {
             expect(getIntersectionForDrilling(
                 EXECUTION_REQUEST_1M.execution.afm,
                 TABLE_HEADERS_1M[0])
             ).toEqual({
                 id: '1st_measure_local_identifier',
-                identifier: '',
-                uri: '/gdc/md/project_id/obj/1st_measure_uri_id',
-                title: 'Lost'
+                title: 'Lost',
+                header: {
+                    identifier: '',
+                    uri: '/gdc/md/project_id/obj/1st_measure_uri_id'
+                }
             });
         });
 
-        it('should get intersection for ad hoc measure', () => {
+        it('should return intersection for ad hoc measure', () => {
             expect(getIntersectionForDrilling(
                 EXECUTION_REQUEST_POP.execution.afm,
                 TABLE_HEADERS_POP[1])
             ).toEqual({
                 id: 'pop_measure_local_identifier',
-                identifier: '',
-                uri: '/gdc/md/project_id/obj/measure_uri_id',
-                title: 'Close [BOP] - Previous year'
+                title: 'Close [BOP] - Previous year',
+                header: {
+                    identifier: '',
+                    uri: '/gdc/md/project_id/obj/measure_uri_id'
+                }
+            });
+        });
+
+        it('should return intersection without header for arithmetic measure', () => {
+            expect(getIntersectionForDrilling(
+                EXECUTION_REQUEST_AM.execution.afm,
+                TABLE_HEADERS_AM[3])
+            ).toEqual({
+                id: 'am1',
+                title: 'AM1(M1,M2)'
             });
         });
     });

--- a/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
+++ b/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
@@ -6,7 +6,8 @@ import {
     chartClick,
     cellClick,
     IHighchartsChartDrilldownEvent,
-    IHighchartsPointObject
+    IHighchartsPointObject,
+    createDrillIntersectionElement
 } from '../drilldownEventing';
 import { VisualizationTypes } from '../../../../constants/visualizationTypes';
 
@@ -69,7 +70,6 @@ describe('Drilldown Eventing', () => {
         expect(fn(VisualizationTypes.PIE)).toBe('slice');
         expect(fn(VisualizationTypes.TREEMAP)).toBe('slice');
         expect(fn(VisualizationTypes.HEATMAP)).toBe('cell');
-        expect(fn(VisualizationTypes.TABLE)).toBe('cell');
         expect(() => {
             fn('headline'); // headline is not defined
         }).toThrowError();
@@ -435,6 +435,70 @@ describe('Drilldown Eventing', () => {
                     }
                 }]
             }
+        });
+    });
+
+    describe('createDrillIntersectionElement', () => {
+        it('should return null when id not provided', () => {
+            const element = createDrillIntersectionElement(undefined, 'title');
+
+            expect(element).toBe(null);
+        });
+
+        it('should return null when title not provided', () => {
+            const element = createDrillIntersectionElement('id', undefined);
+
+            expect(element).toBe(null);
+        });
+
+        it('should return intersection element with only id and title when no uri and identifier provided', () => {
+            const element = createDrillIntersectionElement('id', 'title');
+
+            expect(element).toEqual({
+                id: 'id',
+                title: 'title'
+            });
+        });
+
+        it('should return intersection element with header', () => {
+            const element = createDrillIntersectionElement('id', 'title', 'uri', 'identifier');
+
+            expect(element).toEqual({
+                id: 'id',
+                title: 'title',
+                header: {
+                    uri: 'uri',
+                    identifier: 'identifier'
+                }
+            });
+        });
+
+        // tslint:disable-next-line:max-line-length
+        it('should return intersection element with header with uri and empty identifier when only uri provided', () => {
+            const element = createDrillIntersectionElement('id', 'title', 'uri');
+
+            expect(element).toEqual({
+                id: 'id',
+                title: 'title',
+                header: {
+                    uri: 'uri',
+                    identifier: ''
+                }
+            });
+        });
+
+        // tslint:disable-next-line:max-line-length
+        it('should return intersection element with header with identifier and empty uri when only identifier provided', () => {
+            const element = createDrillIntersectionElement('id', 'title', undefined, 'identifier');
+
+            expect(element).toEqual({
+                id: 'id',
+                title: 'title',
+                header: {
+                    uri: '',
+                    identifier: 'identifier'
+                }
+            });
         });
     });
 });

--- a/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
+++ b/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
@@ -5,7 +5,8 @@ import {
     getClickableElementNameByChartType,
     chartClick,
     cellClick,
-    IHighchartsChartDrilldownEvent
+    IHighchartsChartDrilldownEvent,
+    IHighchartsPointObject
 } from '../drilldownEventing';
 import { VisualizationTypes } from '../../../../constants/visualizationTypes';
 
@@ -27,45 +28,38 @@ describe('Drilldown Eventing', () => {
             }
         ]
     };
-
-    const pointClickEventData = {
-        point: {
-            x: 1,
-            y: 2,
-            value: 678.00,
-            drillIntersection: [
-                {
-                    id: 'id',
-                    title: 'title',
-                    value: '123',
-                    name: 'name1',
+    const point: Partial<IHighchartsPointObject> = {
+        x: 1,
+        y: 2,
+        value: 678.00,
+        drillIntersection: [
+            {
+                id: 'id',
+                title: 'title',
+                header: {
                     identifier: 'identifier1',
-                    uri: 'uri1',
-                    some: 'nonrelevant data'
-                },
-                {
-                    id: 'id',
-                    title: 'title',
-                    value: '123',
-                    name: 'name2',
+                    uri: 'uri1'
+                }
+            },
+            {
+                id: 'id',
+                title: 'title',
+                header: {
                     identifier: 'identifier2',
                     uri: 'uri2'
-                },
-                {
-                    id: 'id',
-                    title: 'title',
-                    value: '123',
-                    name: 'name3',
+                }
+            },
+            {
+                id: 'id',
+                title: 'title',
+                header: {
                     identifier: 'identifier3',
                     uri: 'uri3'
                 }
-            ],
-            some: 'nonrelevant data'
-        }
+            }
+        ]
     };
-
-    const pointClickWitZEventData = cloneDeep(pointClickEventData);
-    (pointClickWitZEventData as any as IHighchartsChartDrilldownEvent).point.z = 12000;
+    const pointClickEventData = { point } as any as IHighchartsChartDrilldownEvent;
 
     it('should get clickable chart element name', () => {
         const fn = getClickableElementNameByChartType;
@@ -84,13 +78,14 @@ describe('Drilldown Eventing', () => {
     it('should call point drill context (non-group) when event.points given but null', () => {
         const drillConfig = { afm, onFiredDrillEvent: () => true };
         const target = { dispatchEvent: jest.fn() };
+        const pointClickEventDataWithNullPoints: IHighchartsChartDrilldownEvent = {
+            ...pointClickEventData,
+            points: null
+        };
 
         chartClick(
             drillConfig,
-            {
-                ...pointClickEventData,
-                points: null
-            } as any as IHighchartsChartDrilldownEvent,
+            pointClickEventDataWithNullPoints,
             target as any as EventTarget,
             VisualizationTypes.LINE
         );
@@ -107,7 +102,7 @@ describe('Drilldown Eventing', () => {
 
         chartClick(
             drillConfig,
-            pointClickEventData as any as IHighchartsChartDrilldownEvent,
+            pointClickEventData ,
             target as any as EventTarget,
             VisualizationTypes.LINE
         );
@@ -172,7 +167,7 @@ describe('Drilldown Eventing', () => {
 
         chartClick(
             drillConfig,
-            pointClickEventData as any as IHighchartsChartDrilldownEvent,
+            pointClickEventData,
             target as any as EventTarget,
             VisualizationTypes.TREEMAP
         );
@@ -185,7 +180,7 @@ describe('Drilldown Eventing', () => {
 
         chartClick(
             drillConfig,
-            pointClickEventData as any as IHighchartsChartDrilldownEvent,
+            pointClickEventData,
             target as any as EventTarget,
             VisualizationTypes.HEATMAP
         );
@@ -200,10 +195,13 @@ describe('Drilldown Eventing', () => {
     it('should correctly handle z coordinate of point', () => {
         const drillConfig = { afm, onFiredDrillEvent: () => true };
         const target = { dispatchEvent: jest.fn() };
+        const pointClickWitZEventData = cloneDeep(pointClickEventData);
+
+        pointClickWitZEventData.point.z = 12000;
 
         chartClick(
             drillConfig,
-            pointClickWitZEventData as any as IHighchartsChartDrilldownEvent,
+            pointClickWitZEventData,
             target as any as EventTarget,
             VisualizationTypes.BUBBLE
         );
@@ -269,7 +267,7 @@ describe('Drilldown Eventing', () => {
 
         chartClick(
             drillConfig,
-            pointClickEventData as any as IHighchartsChartDrilldownEvent,
+            pointClickEventData,
             target as any as EventTarget,
             VisualizationTypes.LINE
         );
@@ -285,7 +283,7 @@ describe('Drilldown Eventing', () => {
 
         chartClick(
             drillConfig,
-            pointClickEventData as any as IHighchartsChartDrilldownEvent,
+            pointClickEventData,
             target as any as EventTarget,
             VisualizationTypes.LINE
         );
@@ -302,7 +300,7 @@ describe('Drilldown Eventing', () => {
 
         chartClick(
             drillConfig,
-            pointClickEventData as any as IHighchartsChartDrilldownEvent,
+            pointClickEventData,
             target as any as EventTarget,
             VisualizationTypes.LINE
         );
@@ -316,28 +314,27 @@ describe('Drilldown Eventing', () => {
     it('should call fire event on label click', () => {
         const drillConfig = { afm, onFiredDrillEvent: () => true };
         const target = { dispatchEvent: jest.fn() };
-        const labelClickEventData = {
-            points: [{
-                x: 1,
-                y: 2,
-                drillIntersection: [
-                    {
-                        id: 'id',
-                        title: 'title',
-                        identifier: 'identifier1',
-                        uri: 'uri1',
-                        value: '123',
-                        name: 'name1',
-                        some: 'nonrelevant data'
-                    }
-                ],
-                some: 'nonrelevant data'
+        const clickedPoint: Partial<IHighchartsPointObject> = {
+            x: 1,
+            y: 2,
+            drillIntersection: [{
+                id: 'id',
+                title: 'title',
+                header: {
+                    identifier: 'identifier1',
+                    uri: 'uri1'
+                }
             }]
         };
+        const labelClickEventData = {
+            points: [
+                clickedPoint
+            ]
+        } as any as IHighchartsChartDrilldownEvent;
 
         chartClick(
             drillConfig,
-            labelClickEventData as any as IHighchartsChartDrilldownEvent,
+            labelClickEventData,
             target as any as EventTarget,
             VisualizationTypes.LINE
         );
@@ -391,15 +388,13 @@ describe('Drilldown Eventing', () => {
             rowIndex: 2,
             row: ['3'],
             intersection: [{
-                title: 'title1',
                 id: 'id1',
-                identifier: 'identifier1',
-                uri: 'uri1',
-                name: 'name1',
-                value: '123',
-                some: 'irrelevant data'
-            }],
-            some: 'nonrelevant data'
+                title: 'title1',
+                header: {
+                    identifier: 'identifier1',
+                    uri: 'uri1'
+                }
+            }]
         };
 
         cellClick(

--- a/src/constants/visualizationTypes.ts
+++ b/src/constants/visualizationTypes.ts
@@ -26,9 +26,21 @@ export const VisualizationTypes = {
 export type ChartType = 'bar' | 'column' | 'pie' | 'line' | 'area' | 'donut' |
     'scatter' | 'bubble' | 'heatmap' | 'geo' | 'combo' | 'histogram' |
     'bullet' | 'treemap' | 'waterfall' | 'funnel' | 'pareto' | 'alluvial';
-export type VisType = ChartType | 'table' | 'pivotTable' | 'headline';
+export type HeadlineType = 'headline';
+export type TableType = 'table' | 'pivotTable';
+export type VisType = ChartType | HeadlineType | TableType;
 
-export type ChartElementType = 'slice' | 'bar' | 'point' | 'label';
+export const VisElementTypes = {
+    SLICE: 'slice' as 'slice',
+    BAR: 'bar' as 'bar',
+    POINT: 'point' as 'point',
+    LABEL: 'label' as 'label',
+    CELL: 'cell' as 'cell',
+    PRIMARY_VALUE: 'primaryValue' as 'primaryValue',
+    SECONDARY_VALUE: 'secondaryValue' as 'secondaryValue'
+};
+
+export type ChartElementType = 'slice' | 'bar' | 'point' | 'label' | 'cell'; // 'cell' for heatmap
 export type HeadlineElementType = 'primaryValue' | 'secondaryValue';
 export type TableElementType = 'cell';
 export type VisElementType = ChartElementType | HeadlineElementType | TableElementType;

--- a/src/interfaces/DrillEvents.ts
+++ b/src/interfaces/DrillEvents.ts
@@ -1,6 +1,13 @@
 // (C) 2007-2018 GoodData Corporation
-import { AFM, Execution } from '@gooddata/typings';
-import { VisElementType, VisType } from '../constants/visualizationTypes';
+import { AFM } from '@gooddata/typings';
+import {
+    ChartElementType,
+    ChartType,
+    HeadlineElementType,
+    HeadlineType,
+    TableElementType,
+    TableType
+} from '../constants/visualizationTypes';
 
 export interface IDrillableItemUri {
     uri: string;
@@ -25,56 +32,7 @@ export function isDrillableItemIdentifier(item: IDrillableItem): item is IDrilla
 
 export type IDrillEventCallback = (event: IDrillEvent) => void | boolean;
 
-// Chart series point with intersection element
-export interface IDrillEventPoint {
-    x: number;
-    y: number;
-    intersection: IDrillEventIntersectionElement[];
-}
-
-// Internal precursor to IDrillEventIntersectionElement
-// TODO: Refactor internal drilling functions and replace with IDrillEventIntersectionElement
-export interface ILegacyDrillIntersection {
-    id: string; // attribute value id or measure localIndentifier
-    title?: string;
-    value?: Execution.DataValue; // text label of attribute value or formatted measure value
-    name?: string;
-    uri: string; // uri of measure
-    identifier: AFM.Identifier; // identifier of attribute or measure
-}
-
-export interface IDrillEventContextBase {
-    type: VisType; // type of visualization
-    element: VisElementType; // type of visualization element drilled
-    x?: number; // chart x coordinate (if supported)
-    y?: number; // chart y coordinate (if supported)
-    columnIndex?: number;
-    rowIndex?: number;
-    row?: any[]; // table row data of the drilled row
-    value?: string; // cell or element value drilled
-}
-
-// Drill context for standard vsualization click
-export interface IDrillEventContextSingle extends IDrillEventContextBase {
-    intersection: IDrillEventIntersectionElement[]; // drill headers relevant for current drill element
-}
-
-// Drill context for group clicks (multiple series chart + click on axis value)
-// Every point has own intersection
-export interface IDrillEventContextGroup extends IDrillEventContextBase {
-    points: IDrillEventPoint[]; // a collection of chart series points
-}
-
-export type DrillEventContext = IDrillEventContextSingle | IDrillEventContextGroup;
-
-// IDrillEvent is a parameter of the onFiredDrillEvent is callback
-export interface IDrillEvent {
-    executionContext: AFM.IAfm;
-    drillContext: DrillEventContext;
-}
-
 // Intersection element
-// Can be a measure, attribute or attribute value. Attribute values have only uri.
 export interface IDrillEventIntersectionElement {
     id: string;
     title: string;
@@ -82,4 +40,62 @@ export interface IDrillEventIntersectionElement {
         uri: string;
         identifier: string;
     };
+}
+
+// Drill context for tables
+export interface IDrillEventContextTable {
+    type: TableType;
+    element: TableElementType;
+    columnIndex: number;
+    rowIndex: number;
+    row: any[];
+    intersection: IDrillEventIntersectionElement[];
+}
+
+// Drill context for headline
+export interface IDrillEventContextHeadline {
+    type: HeadlineType;
+    element: HeadlineElementType;
+    value: string;
+    intersection: IDrillEventIntersectionElement[];
+}
+
+// Drill context for chart
+// TODO BB-1318 Expand this to specific chart groups interfaces
+export interface IDrillEventContextPoint {
+    type: ChartType;
+    element: ChartElementType;
+    x?: number;
+    y?: number;
+    z?: number;
+    value?: string;
+    intersection: IDrillEventIntersectionElement[];
+}
+
+// Chart series point with intersection element
+export interface IDrillPoint {
+    x: number;
+    y: number;
+    intersection: IDrillEventIntersectionElement[];
+}
+
+// Drill context for chart element group (multiple series + click on axis value)
+// where every point has own intersection
+export interface IDrillEventContextGroup {
+    type: ChartType;
+    element: ChartElementType;
+    points: IDrillPoint[];
+}
+
+// Drill context for all visualization types
+export type DrillEventContext =
+    IDrillEventContextTable |
+    IDrillEventContextHeadline |
+    IDrillEventContextPoint |
+    IDrillEventContextGroup;
+
+// IDrillEvent is a parameter of the onFiredDrillEvent is callback
+export interface IDrillEvent {
+    executionContext: AFM.IAfm;
+    drillContext: DrillEventContext;
 }


### PR DESCRIPTION
Third volume of drill cleanup:

1. Removed `value` property from `drillContext` of Pivot Table as value can be obtained from `row` array using `columnIndex`.
2. Added `IDrillEventContext*` interfaces. Now each visualization uses own drill context type.
3. Created `*ElementType` for each visualization type. With `VisElementTypes` dictionary.
4. Removed table from `getClickableElementNameByChartType` as table is not chart.
5. Refactored context builders.
6. Added `createDrillIntersectionElement` function used by all visiualization types
7. All chart visualizations now emits drill events with correct intersection containing also non-empty `header.identifier` properties when executed using `uri`.