### PR TITLE
SD-273: handle exponential number case

### DIFF
--- a/src/components/visualizations/chart/highcharts/plugins/dualAxesLabelFormatter.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/dualAxesLabelFormatter.ts
@@ -7,13 +7,14 @@ import { formatAsPercent, isInPercent } from '../customConfiguration';
 const DEFAULT_LIMIT_LENGTH = 4; // length of '0.00' is 4
 const DEFAULT_PADDING = 2;
 const DEFAULT_SHALLOW_RANGE = 10;
+const DEFAULT_FRACTION_DIGITS = 16;
 
 /**
  * Get limit length to cut off value less than one
  * @param value
  */
 function getLimitLength(value: number): number {
-    const valueStr = value.toString();
+    const valueStr = convertNumberToString(value);
     const isFloat = valueStr.indexOf('.') > 0;
     const length = isFloat ? valueStr.length : valueStr.length + 1;
     return length + DEFAULT_PADDING;
@@ -21,6 +22,26 @@ function getLimitLength(value: number): number {
 
 function isValueInShallowRange(min: number, max: number): boolean {
     return min !== max && Math.abs(max - min) < DEFAULT_SHALLOW_RANGE;
+}
+
+/**
+ * Number: 1234567
+ * Exponential number: 1.234567e+6 or 1.234567E+6
+ * @param num
+ */
+function isExponentialNumber(num: number): boolean {
+    return num.toString().split(/[eE]/).length > 1;
+}
+
+/**
+ * Convert number to string
+ * 0.1      -> '0.1'
+ * 1e-5     -> '0.00001' (not '1e-5')
+ * 1e+5     -> '100000'  (not '1e+5')
+ * @param num
+ */
+function convertNumberToString(num: number): string {
+    return isExponentialNumber(num) ? num.toFixed(DEFAULT_FRACTION_DIGITS) : num.toString();
 }
 
 /**
@@ -36,7 +57,7 @@ function isValueInShallowRange(min: number, max: number): boolean {
  */
 export function formatValueInShallowRange(value: number, min: number, max: number): number {
     const limitLength = Math.max(getLimitLength(min), getLimitLength(max), DEFAULT_LIMIT_LENGTH);
-    const newValue = value.toString().substr(0, limitLength);
+    const newValue = convertNumberToString(value).substr(0, limitLength);
     return parseFloat(newValue);
 }
 
@@ -93,7 +114,7 @@ function formatLabel(value: number, tickPositions: number[]): number {
     if (isValueInShallowRange(min, max)) {
         return formatValueInShallowRange(value, min, max);
     }
-    const numberStr = removeDecimal(value.toString());
+    const numberStr = removeDecimal(convertNumberToString(value));
     return roundNumber(numberStr, min, max);
 }
 

--- a/src/components/visualizations/chart/highcharts/plugins/test/dualAxesLabelFormatter.spec.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/test/dualAxesLabelFormatter.spec.ts
@@ -75,6 +75,35 @@ describe('dual axes label format', () => {
             value = formatValueInShallowRange(11.7, min , max);
             expect(value).toEqual(11.7);
         });
+
+        it('should format number lower than 1 in exponential notation', () => {
+            const min = 0;
+            const max = 1;
+
+            let value = formatValueInShallowRange(1.3877787807814457e-16, min, max);
+            expect(value).toEqual(0);
+
+            value = formatValueInShallowRange(1.3877787807814457E-16, min, max);
+            expect(value).toEqual(0);
+        });
+
+        it('should format number greater than 1 in exponential notation', () => {
+            const exponentialNumber = 1.3877787807814457e+16;
+            const min = exponentialNumber - 1;
+            const max = exponentialNumber + 1;
+
+            let value = formatValueInShallowRange(exponentialNumber, min, max);
+            expect(value).toEqual(13877787807814456);
+
+            value = formatValueInShallowRange(exponentialNumber, min, max);
+            expect(value).toEqual(13877787807814456);
+
+            value = formatValueInShallowRange(exponentialNumber + 0.001, min, max);
+            expect(value).toEqual(13877787807814456);
+
+            value = formatValueInShallowRange(1.3877787807814457e+10 + 0.001, min, max);
+            expect(value).toEqual(13877787807.815456);
+        });
     });
 
     describe('test round number', () => {


### PR DESCRIPTION
Handle exponential number case.
Convert `1e-5` to `0.00001` by using 'Number.toFixed()', while 'Number.toString()' converts it to unexpected `1e-5` as as-is.