### PR TITLE
ONE-3610 Support for text filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "devDependencies": {
     "@gooddata/eslint-config": "0.1.0",
-    "@gooddata/mock-js": "1.23.0",
+    "@gooddata/mock-js": "1.24.0",
     "@gooddata/test-storybook": "3.0.1",
     "@gooddata/tslint-config": "0.0.16",
     "@storybook/addon-actions": "3.4.10",
@@ -96,11 +96,11 @@
     "yup": "^0.24.1"
   },
   "dependencies": {
-    "@gooddata/gooddata-js": "11.6.0",
+    "@gooddata/gooddata-js": "11.7.0",
     "@gooddata/goodstrap": "60.2.0",
     "@gooddata/js-utils": "3.4.0",
     "@gooddata/numberjs": "^3.1.2",
-    "@gooddata/typings": "2.8.0",
+    "@gooddata/typings": "2.9.0",
     "@types/highcharts": "4.2.56",
     "ag-grid": "^18.0.1",
     "ag-grid-react": "^18.0.0",

--- a/src/components/AreaChart.tsx
+++ b/src/components/AreaChart.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationObject, VisualizationInput } from '@gooddata/typings';
 
 import { AreaChart as AfmAreaChart } from './afm/AreaChart';
 
@@ -13,11 +13,11 @@ import { MEASURES, ATTRIBUTE, STACK } from '../constants/bucketNames';
 import { verifyBuckets, getBucketsProps, getConfigProps } from '../helpers/optionalStacking/areaChart';
 
 export interface IAreaChartBucketProps {
-    measures: VisualizationObject.BucketItem[];
-    viewBy?: VisualizationObject.IVisualizationAttribute | VisualizationObject.IVisualizationAttribute[];
-    stackBy?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    measures: VisualizationInput.AttributeOrMeasure[];
+    viewBy?: VisualizationInput.IAttribute | VisualizationInput.IAttribute[];
+    stackBy?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface IAreaChartProps extends ICommonChartProps, IAreaChartBucketProps {

--- a/src/components/BarChart.tsx
+++ b/src/components/BarChart.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationObject, VisualizationInput } from '@gooddata/typings';
 
 import { BarChart as AfmBarChart } from './afm/BarChart';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -12,11 +12,11 @@ import { MEASURES, ATTRIBUTE, STACK } from '../constants/bucketNames';
 import { getSanitizedStackingConfig, getViewByTwoAttributes } from '../helpers/optionalStacking/common';
 
 export interface IBarChartBucketProps {
-    measures: VisualizationObject.BucketItem[];
-    viewBy?: VisualizationObject.IVisualizationAttribute | VisualizationObject.IVisualizationAttribute[];
-    stackBy?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    measures: VisualizationInput.AttributeOrMeasure[];
+    viewBy?: VisualizationInput.IAttribute | VisualizationInput.IAttribute[];
+    stackBy?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface IBarChartProps extends ICommonChartProps, IBarChartBucketProps {

--- a/src/components/BubbleChart.tsx
+++ b/src/components/BubbleChart.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
 
-import { AFM, VisualizationObject } from '@gooddata/typings';
+import { VisualizationInput, VisualizationObject } from '@gooddata/typings';
 
 import { ICommonChartProps } from './core/base/BaseChart';
 import { convertBucketsToAFM, convertBucketsToMdObject } from '../helpers/conversion';
@@ -29,12 +29,12 @@ const generateBubbleDimensionsFromBuckets =
     (buckets: VisualizationObject.IBucket[]) => generateDefaultDimensionsForPointsCharts(convertBucketsToAFM(buckets));
 
 export interface IBubbleChartBucketProps {
-    xAxisMeasure?: VisualizationObject.IMeasure;
-    yAxisMeasure?: VisualizationObject.IMeasure;
-    size?: VisualizationObject.IMeasure;
-    viewBy?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    xAxisMeasure?: VisualizationInput.IMeasure;
+    yAxisMeasure?: VisualizationInput.IMeasure;
+    size?: VisualizationInput.IMeasure;
+    viewBy?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface IBubbleChartProps extends ICommonChartProps, IBubbleChartBucketProps {

--- a/src/components/ColumnChart.tsx
+++ b/src/components/ColumnChart.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationInput, VisualizationObject } from '@gooddata/typings';
 
 import { ColumnChart as AfmColumnChart } from './afm/ColumnChart';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -12,11 +12,11 @@ import { MEASURES, ATTRIBUTE, STACK } from '../constants/bucketNames';
 import { getSanitizedStackingConfig, getViewByTwoAttributes } from '../helpers/optionalStacking/common';
 
 export interface IColumnChartBucketProps {
-    measures: VisualizationObject.BucketItem[];
-    viewBy?: VisualizationObject.IVisualizationAttribute | VisualizationObject.IVisualizationAttribute[];
-    stackBy?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    measures: VisualizationInput.AttributeOrMeasure[];
+    viewBy?: VisualizationInput.IAttribute | VisualizationInput.IAttribute[];
+    stackBy?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface IColumnChartProps extends ICommonChartProps, IColumnChartBucketProps {

--- a/src/components/ComboChart.tsx
+++ b/src/components/ComboChart.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationObject, VisualizationInput } from '@gooddata/typings';
 
 import { ComboChart as AfmComboChart } from './afm/ComboChart';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -11,11 +11,11 @@ import { getResultSpec } from '../helpers/resultSpec';
 import { MEASURES, SECONDARY_MEASURES, VIEW } from '../constants/bucketNames';
 
 export interface IComboChartBucketProps {
-    columnMeasures: VisualizationObject.IMeasure[];
-    lineMeasures?: VisualizationObject.IMeasure[];
-    viewBy?: VisualizationObject.IVisualizationAttribute;
+    columnMeasures: VisualizationInput.IMeasure[];
+    lineMeasures?: VisualizationInput.IMeasure[];
+    viewBy?: VisualizationInput.IAttribute;
     filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface IComboChartProps extends ICommonChartProps, IComboChartBucketProps {

--- a/src/components/DonutChart.tsx
+++ b/src/components/DonutChart.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject } from '@gooddata/typings';
+import { VisualizationInput, VisualizationObject } from '@gooddata/typings';
 
 import { DonutChart as AfmDonutChart } from './afm/DonutChart';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -10,9 +10,9 @@ import { convertBucketsToAFM } from '../helpers/conversion';
 import { MEASURES, VIEW } from '../constants/bucketNames';
 
 export interface IDonutChartBucketProps {
-    measures: VisualizationObject.BucketItem[];
-    viewBy?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
+    measures: VisualizationInput.AttributeOrMeasure[];
+    viewBy?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
 }
 
 export interface IDonutChartProps extends ICommonChartProps, IDonutChartBucketProps {

--- a/src/components/FunnelChart.tsx
+++ b/src/components/FunnelChart.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationObject, VisualizationInput } from '@gooddata/typings';
 
 import { FunnelChart as AfmFunnelChart } from './afm/FunnelChart';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -12,10 +12,10 @@ import { generateDefaultDimensionsForRoundChart } from '../helpers/dimensions';
 import { MEASURES, VIEW } from '../constants/bucketNames';
 
 export interface IFunnelChartBucketProps {
-    measures: VisualizationObject.BucketItem[];
-    viewBy?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    measures: VisualizationInput.AttributeOrMeasure[];
+    viewBy?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface IFunnelChartProps extends ICommonChartProps, IFunnelChartBucketProps {

--- a/src/components/Headline.tsx
+++ b/src/components/Headline.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject } from '@gooddata/typings';
+import { VisualizationInput } from '@gooddata/typings';
 
 import { Headline as AfmHeadline } from './afm/Headline';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -10,9 +10,9 @@ import { convertBucketsToAFM } from '../helpers/conversion';
 import { MEASURES } from '../constants/bucketNames';
 
 export interface IHeadlineBucketProps {
-    primaryMeasure: VisualizationObject.IMeasure;
-    secondaryMeasure?: VisualizationObject.IMeasure;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
+    primaryMeasure: VisualizationInput.IMeasure;
+    secondaryMeasure?: VisualizationInput.IMeasure;
+    filters?: VisualizationInput.IFilter[];
 }
 
 export interface IHeadlineProps extends ICommonChartProps, IHeadlineBucketProps {

--- a/src/components/Heatmap.tsx
+++ b/src/components/Heatmap.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationObject, VisualizationInput } from '@gooddata/typings';
 
 import { Heatmap as AfmHeatmap } from './afm/Heatmap';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -12,11 +12,11 @@ import { getHeatmapDimensionsFromBuckets } from '../helpers/dimensions';
 import { MEASURES, VIEW, STACK } from '../constants/bucketNames';
 
 export interface IHeatmapBucketProps {
-    measure: VisualizationObject.BucketItem;
-    rows?: VisualizationObject.IVisualizationAttribute;
-    columns?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    measure: VisualizationInput.AttributeOrMeasure;
+    rows?: VisualizationInput.IAttribute;
+    columns?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface IHeatmapProps extends ICommonChartProps, IHeatmapBucketProps {

--- a/src/components/LineChart.tsx
+++ b/src/components/LineChart.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationObject, VisualizationInput } from '@gooddata/typings';
 
 import { LineChart as AfmLineChart } from './afm/LineChart';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -11,11 +11,11 @@ import { getStackingResultSpec } from '../helpers/resultSpec';
 import { MEASURES, ATTRIBUTE, STACK } from '../constants/bucketNames';
 
 export interface ILineChartBucketProps {
-    measures: VisualizationObject.BucketItem[];
-    trendBy?: VisualizationObject.IVisualizationAttribute;
-    segmentBy?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    measures: VisualizationInput.AttributeOrMeasure[];
+    trendBy?: VisualizationInput.IAttribute;
+    segmentBy?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface ILineChartProps extends ICommonChartProps, ILineChartBucketProps {

--- a/src/components/PieChart.tsx
+++ b/src/components/PieChart.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationObject, VisualizationInput } from '@gooddata/typings';
 
 import { PieChart as AfmPieChart } from './afm/PieChart';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -12,10 +12,10 @@ import { generateDefaultDimensionsForRoundChart } from '../helpers/dimensions';
 import { MEASURES, VIEW } from '../constants/bucketNames';
 
 export interface IPieChartBucketProps {
-    measures: VisualizationObject.BucketItem[];
-    viewBy?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    measures: VisualizationInput.AttributeOrMeasure[];
+    viewBy?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface IPieChartProps extends ICommonChartProps, IPieChartBucketProps {

--- a/src/components/PivotTable.tsx
+++ b/src/components/PivotTable.tsx
@@ -1,6 +1,6 @@
 // (C) 2007-2018 GoodData Corporation
 import * as React from 'react';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationObject, VisualizationInput } from '@gooddata/typings';
 import omit = require('lodash/omit');
 import noop = require('lodash/noop');
 import { Subtract } from 'utility-types';
@@ -21,12 +21,12 @@ import {
 import { hasDuplicateIdentifiers } from '../helpers/errorHandlers';
 
 export interface IPivotTableBucketProps {
-    measures?: VisualizationObject.BucketItem[];
-    rows?: VisualizationObject.IVisualizationAttribute[];
-    columns?: VisualizationObject.IVisualizationAttribute[];
-    totals?: VisualizationObject.IVisualizationTotal[];
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    measures?: VisualizationInput.AttributeOrMeasure[];
+    rows?: VisualizationInput.IAttribute[];
+    columns?: VisualizationInput.IAttribute[];
+    totals?: VisualizationInput.ITotal[];
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface IPivotTableProps extends ICommonChartProps, IPivotTableBucketProps {

--- a/src/components/ScatterPlot.tsx
+++ b/src/components/ScatterPlot.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationObject, VisualizationInput } from '@gooddata/typings';
 import { ScatterPlot as AfmScatterPlot } from './afm/ScatterPlot';
 import { ICommonChartProps } from './core/base/BaseChart';
 import { convertBucketsToAFM, convertBucketsToMdObject } from '../helpers/conversion';
@@ -11,11 +11,11 @@ import { getResultSpec } from '../helpers/resultSpec';
 import { MEASURES, SECONDARY_MEASURES, ATTRIBUTE } from '../constants/bucketNames';
 
 export interface IScatterPlotBucketProps {
-    xAxisMeasure?: VisualizationObject.IMeasure;
-    yAxisMeasure?: VisualizationObject.IMeasure;
-    attribute?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[]; // TODO would it be removed? if not dont forget to test
+    xAxisMeasure?: VisualizationInput.IMeasure;
+    yAxisMeasure?: VisualizationInput.IMeasure;
+    attribute?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[]; // TODO would it be removed? if not dont forget to test
 }
 
 export interface IScatterPlotProps extends ICommonChartProps, IScatterPlotBucketProps {

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject, AFM } from '@gooddata/typings';
+import { VisualizationObject, VisualizationInput } from '@gooddata/typings';
 
 import { Table as AfmTable } from './afm/Table';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -12,12 +12,12 @@ import { getResultSpec } from '../helpers/resultSpec';
 import { MEASURES, ATTRIBUTE } from '../constants/bucketNames';
 
 export interface ITableBucketProps {
-    measures?: VisualizationObject.BucketItem[];
-    attributes?: VisualizationObject.IVisualizationAttribute[];
-    totals?: VisualizationObject.IVisualizationTotal[];
+    measures?: VisualizationInput.AttributeOrMeasure[];
+    attributes?: VisualizationInput.IAttribute[];
+    totals?: VisualizationInput.ITotal[];
     totalsEditAllowed?: boolean;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
-    sortBy?: AFM.SortItem[];
+    filters?: VisualizationInput.IFilter[];
+    sortBy?: VisualizationInput.ISort[];
 }
 
 export interface ITableProps extends ICommonChartProps, ITableBucketProps {

--- a/src/components/Treemap.tsx
+++ b/src/components/Treemap.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { omit } from 'lodash';
 import { Subtract } from 'utility-types';
-import { VisualizationObject } from '@gooddata/typings';
+import { VisualizationInput, VisualizationObject } from '@gooddata/typings';
 
 import { Treemap as AfmTreemap } from './afm/Treemap';
 import { ICommonChartProps } from './core/base/BaseChart';
@@ -12,10 +12,10 @@ import { getResultSpec } from '../helpers/resultSpec';
 import { MEASURES, VIEW, SEGMENT } from '../constants/bucketNames';
 
 export interface ITreemapBucketProps {
-    measures: VisualizationObject.BucketItem[];
-    viewBy?: VisualizationObject.IVisualizationAttribute;
-    segmentBy?: VisualizationObject.IVisualizationAttribute;
-    filters?: VisualizationObject.VisualizationObjectFilter[];
+    measures: VisualizationInput.AttributeOrMeasure[];
+    viewBy?: VisualizationInput.IAttribute;
+    segmentBy?: VisualizationInput.IAttribute;
+    filters?: VisualizationInput.IFilter[];
 }
 
 export interface ITreemapProps extends ICommonChartProps, ITreemapBucketProps {

--- a/src/helpers/model/filters.ts
+++ b/src/helpers/model/filters.ts
@@ -1,49 +1,140 @@
 // (C) 2018 GoodData Corporation
-import { VisualizationObject } from '@gooddata/typings';
+import { VisualizationInput } from '@gooddata/typings';
 import { getQualifierObject } from './utils';
 
-export const positiveAttributeFilter = (
+export function positiveAttributeFilter(
     qualifier: string,
-    inValues: string[]
-): VisualizationObject.IVisualizationObjectPositiveAttributeFilter => ({
-    positiveAttributeFilter: {
-        displayForm: getQualifierObject(qualifier),
-        in: inValues
-    }
-});
+    inValues: string[],
+    textFilter?: boolean
+): VisualizationInput.IPositiveAttributeFilter {
+    return {
+        positiveAttributeFilter: {
+            displayForm: getQualifierObject(qualifier),
+            in: inValues,
+            textFilter
+        }
+    };
+}
 
-export const negativeAttributeFilter = (
+export function negativeAttributeFilter(
     qualifier: string,
-    notInValues: string[]
-): VisualizationObject.IVisualizationObjectNegativeAttributeFilter => ({
-    negativeAttributeFilter: {
-        displayForm: getQualifierObject(qualifier),
-        notIn: notInValues
-    }
-});
+    notInValues: string[],
+    textFilter?: boolean
+): VisualizationInput.INegativeAttributeFilter {
+    return {
+        negativeAttributeFilter: {
+            displayForm: getQualifierObject(qualifier),
+            notIn: notInValues,
+            textFilter
+        }
+    };
+}
 
-export const absoluteDateFilter = (
+export function absoluteDateFilter(
     dataSet: string,
     from?: string,
     to?: string
-): VisualizationObject.IVisualizationObjectAbsoluteDateFilter => ({
-    absoluteDateFilter: {
-        dataSet: getQualifierObject(dataSet),
-        from,
-        to
-    }
-});
+): VisualizationInput.IAbsoluteDateFilter {
+    return {
+        absoluteDateFilter: {
+            dataSet: getQualifierObject(dataSet),
+            from,
+            to
+        }
+    };
+}
 
-export const relativeDateFilter = (
+export function relativeDateFilter(
     dataSet: string,
     granularity: string,
     from?: number,
     to?: number
-): VisualizationObject.IVisualizationObjectRelativeDateFilter => ({
-    relativeDateFilter: {
-        dataSet: getQualifierObject(dataSet),
-        granularity,
-        from,
-        to
+): VisualizationInput.IRelativeDateFilter {
+    return {
+        relativeDateFilter: {
+            dataSet: getQualifierObject(dataSet),
+            granularity,
+            from,
+            to
+        }
+    };
+}
+
+export class AttributeFilterBuilder {
+    constructor(private readonly qualifier: string) {
+        this.qualifier = qualifier;
     }
-});
+
+    /**
+     * Creates a new positive attribute value filter for the specified display form. Only attribute elements
+     * matching the specified values will be included in the results.
+     *
+     * @param values textual values of the attribute elements
+     */
+    public in(...values: string[]): VisualizationInput.IPositiveAttributeFilter {
+        return {
+            positiveAttributeFilter: {
+                displayForm: getQualifierObject(this.qualifier),
+                in: values,
+                textFilter: true
+            }
+        };
+    }
+
+    /**
+     * Creates a new negative attribute value filter for the specified display form. Attribute elements matching
+     * the specified values will be excluded from the results.
+     *
+     * @param values textual values of the attribute elements
+     */
+    public notIn(...values: string[]): VisualizationInput.INegativeAttributeFilter {
+        return {
+            negativeAttributeFilter: {
+                displayForm: getQualifierObject(this.qualifier),
+                notIn: values,
+                textFilter: true
+            }
+        };
+    }
+
+    /**
+     * Creates a new positive attribute URI filter for the specified display form. Attribute elements with the
+     * specified URIs will be included in the results.
+     *
+     * @param uris URIs of attribute elements
+     */
+    public inUris(...uris: string[]): VisualizationInput.IPositiveAttributeFilter {
+        return {
+            positiveAttributeFilter: {
+                displayForm: getQualifierObject(this.qualifier),
+                in: uris,
+                textFilter: false
+            }
+        };
+    }
+
+    /**
+     * Creates a new negative attribute URI filter for the specified display form. Attribute elements matching
+     * the specified URIs will be excluded from the results.
+     *
+     * @param uris URIs of attribute elements
+     */
+    public notInUris(...uris: string[]): VisualizationInput.INegativeAttributeFilter {
+        return {
+            negativeAttributeFilter: {
+                displayForm: getQualifierObject(this.qualifier),
+                notIn: uris,
+                textFilter: false
+            }
+        };
+    }
+}
+
+/**
+ * Starts building a new attribute filter for the display for with the provided qualifier.
+ *
+ * @param qualifier URI or identifier of display form to filter on
+ */
+export function attributeFilter(qualifier: string): AttributeFilterBuilder {
+    return new AttributeFilterBuilder(qualifier);
+}

--- a/src/helpers/model/tests/filters.spec.ts
+++ b/src/helpers/model/tests/filters.spec.ts
@@ -1,5 +1,11 @@
 // (C) 2018 GoodData Corporation
-import { absoluteDateFilter, negativeAttributeFilter, positiveAttributeFilter, relativeDateFilter } from '../filters';
+import {
+    absoluteDateFilter,
+    attributeFilter,
+    negativeAttributeFilter,
+    positiveAttributeFilter,
+    relativeDateFilter
+} from '../filters';
 
 describe('Filters', () => {
     describe('positiveAttributeFilter', () => {
@@ -13,6 +19,18 @@ describe('Filters', () => {
                 }
             });
         });
+
+        it('should generate correct textual filter', () => {
+            expect(positiveAttributeFilter('foo', ['bar', 'baz'], true)).toEqual({
+                positiveAttributeFilter: {
+                    displayForm: {
+                        identifier: 'foo'
+                    },
+                    in: ['bar', 'baz'],
+                    textFilter: true
+                }
+            });
+        });
     });
 
     describe('negativeAttributeFilter', () => {
@@ -23,6 +41,64 @@ describe('Filters', () => {
                         identifier: 'foo'
                     },
                     notIn: ['bar', 'baz']
+                }
+            });
+        });
+        it('should generate correct textual filter', () => {
+            expect(negativeAttributeFilter('foo', ['bar', 'baz'], true)).toEqual({
+                negativeAttributeFilter: {
+                    displayForm: {
+                        identifier: 'foo'
+                    },
+                    notIn: ['bar', 'baz'],
+                    textFilter: true
+                }
+            });
+        });
+    });
+
+    describe('attributeFilter', () => {
+        it('should generate correct positive filter', () => {
+            expect(attributeFilter('foo').inUris('uri1', 'uri2')).toEqual({
+                positiveAttributeFilter: {
+                    displayForm: {
+                        identifier: 'foo'
+                    },
+                    in: ['uri1', 'uri2'],
+                    textFilter: false
+                }
+            });
+        });
+        it('should generate correct positive textual filter', () => {
+            expect(attributeFilter('foo').in('value1', 'value2')).toEqual({
+                positiveAttributeFilter: {
+                    displayForm: {
+                        identifier: 'foo'
+                    },
+                    in: ['value1', 'value2'],
+                    textFilter: true
+                }
+            });
+        });
+        it('should generate correct negative positive filter', () => {
+            expect(attributeFilter('foo').notInUris('uri1', 'uri2')).toEqual({
+                negativeAttributeFilter: {
+                    displayForm: {
+                        identifier: 'foo'
+                    },
+                    notIn: ['uri1', 'uri2'],
+                    textFilter: false
+                }
+            });
+        });
+        it('should generate correct negative textual filter', () => {
+            expect(attributeFilter('foo').notIn('value1', 'value2')).toEqual({
+                negativeAttributeFilter: {
+                    displayForm: {
+                        identifier: 'foo'
+                    },
+                    notIn: ['value1', 'value2'],
+                    textFilter: true
                 }
             });
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,12 +32,12 @@
     eslint-plugin-jsx-a11y "6.0.3"
     eslint-plugin-react "7.6.1"
 
-"@gooddata/gooddata-js@11.6.0":
-  version "11.6.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-11.6.0.tgz#e51b9f657c5f22ca5a90142ec99e9b26cdeb7d1b"
-  integrity sha512-doBlv8xGvrv8L4C4wwVkZxwE/qEt5Lfe02KS8t4Q76aT/mknHYlRkMasE4+EjrDN7bz4s1jMu55VOYhh+j9NnA==
+"@gooddata/gooddata-js@11.7.0":
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-11.7.0.tgz#955afc728619551c1d57722ccfa45a84b38b6376"
+  integrity sha512-mqC2adUjG2mJ31XpJQTa4Sy+aLdwMLd/VBz0atYOgAHfmCgs+FUIyBr/HS6mJ1cQwoLZ2TTsnQpEd+ZceTAvHw==
   dependencies:
-    "@gooddata/typings" "2.8.0"
+    "@gooddata/typings" "2.9.0"
     es6-promise "3.0.2"
     fetch-cookie "0.7.0"
     invariant "2.2.2"
@@ -90,12 +90,12 @@
     lodash "4.17.11"
     lodash-es "4.17.11"
 
-"@gooddata/mock-js@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/mock-js/-/mock-js-1.23.0.tgz#f31b38b55650f918784025672625df22e0409cc5"
-  integrity sha512-gC3ZmqVxLgWTHwI/NLhFmzZ6O9SLeZSM5NtCrmnNTunGeDSux7S22EQ5kTinLk3JwDShKoYS+RdoZYTWNB/STA==
+"@gooddata/mock-js@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/mock-js/-/mock-js-1.24.0.tgz#2affe9e1ad5f41115b1018fb274d758372077946"
+  integrity sha512-c6rvUnzRnNomVYWLljVf2Bped7WxcP7HsBWPGztw8nV84G03vZNZj1nOAqRlRXHMorPBYtR8PM8LyV27okhW/A==
   dependencies:
-    "@gooddata/typings" "2.8.0"
+    "@gooddata/typings" "2.9.0"
     "@types/seedrandom" "2.4.27"
     "@types/uuid" "3.4.3"
     body-parser "1.17.1"
@@ -135,10 +135,10 @@
     tslint-microsoft-contrib "6.1.0"
     tslint-react "3.6.0"
 
-"@gooddata/typings@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/typings/-/typings-2.8.0.tgz#1138172b286e040609f7fd4901de2160b5279789"
-  integrity sha512-cu+Wt+Saq4ThP2o/zV4TAfL/IoOEUjWEpCiHUPeRUnO36ijFhgQqYRb70CAnLht6KZG9f1i0eWpUXkVahAjQ4Q==
+"@gooddata/typings@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/typings/-/typings-2.9.0.tgz#9ce6497aa867542768c88041d1f4cf0320adf45f"
+  integrity sha512-8s644Jcfl7j03GHBItrgEOKAjo/KpVN8SP7pBw7zwH1aPxYq9THMvpBhRlKw6UewOzGIZb3ocudkx4I7mytU4w==
   dependencies:
     lodash "4.17.11"
 


### PR DESCRIPTION
- Changed input types for all visualization components; instead of using mix of VisualizationObject and AFM types, we now use unified VisualizationInput types; these eventually alias to effective types from VO or AFM
- The VisualizationInput types define filters as mix of date filters from VO and attribute filters from AFM; attribute filters from AFM allow to optionally indicate whether filter is a text filter or not; this change is backward compatible
- Updated filter helpers so that they allow creation of text filters

