### PR TITLE
BIGFIX: RAIL-1120 Double execution during table initialization

### DIFF
--- a/src/components/core/tests/PivotTable.spec.tsx
+++ b/src/components/core/tests/PivotTable.spec.tsx
@@ -75,9 +75,10 @@ describe('PivotTable', () => {
                 onSuccess,
                 getGridApi,
                 intl,
-                {},
                 [],
-                () => groupingProvider
+                [],
+                () => groupingProvider,
+                {}
             );
             await gridDataSource.getRows({ startRow, endRow, successCallback, sortModel } as any);
             expect(getPage).toHaveBeenCalledWith(resultSpec, [0, undefined], [0, undefined]);


### PR DESCRIPTION
- gooddata-react-components: https://github.com/gooddata/gooddata-react-components/pull/846
- gdc-app-components: https://github.com/gooddata/gdc-app-components/pull/515
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2091
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/1728