### PR TITLE
RELATED: SD-311 SD-312 disable stacking config at high level when there is one measure

### DIFF
--- a/src/components/BarChart.tsx
+++ b/src/components/BarChart.tsx
@@ -9,7 +9,7 @@ import { ICommonChartProps } from './core/base/BaseChart';
 import { convertBucketsToAFM } from '../helpers/conversion';
 import { getStackingResultSpec } from '../helpers/resultSpec';
 import { MEASURES, ATTRIBUTE, STACK } from '../constants/bucketNames';
-import { getViewByTwoAttributes } from '../helpers/optionalStacking/common';
+import { getSanitizedStackingConfig, getViewByTwoAttributes } from '../helpers/optionalStacking/common';
 
 export interface IBarChartBucketProps {
     measures: VisualizationObject.BucketItem[];
@@ -46,7 +46,9 @@ export function BarChart(props: IBarChartProps): JSX.Element {
     ];
 
     const newProps
-        = omit<IBarChartBucketProps, IBarChartNonBucketProps>(props, ['measures', 'viewBy', 'stackBy', 'filters']);
+        = omit<IBarChartProps, IBarChartNonBucketProps>(props, ['measures', 'viewBy', 'stackBy', 'filters']);
+
+    newProps.config = getSanitizedStackingConfig(props);
 
     return (
         <AfmBarChart

--- a/src/components/ColumnChart.tsx
+++ b/src/components/ColumnChart.tsx
@@ -9,7 +9,7 @@ import { ICommonChartProps } from './core/base/BaseChart';
 import { convertBucketsToAFM } from '../helpers/conversion';
 import { getStackingResultSpec } from '../helpers/resultSpec';
 import { MEASURES, ATTRIBUTE, STACK } from '../constants/bucketNames';
-import { getViewByTwoAttributes } from '../helpers/optionalStacking/common';
+import { getSanitizedStackingConfig, getViewByTwoAttributes } from '../helpers/optionalStacking/common';
 
 export interface IColumnChartBucketProps {
     measures: VisualizationObject.BucketItem[];
@@ -47,6 +47,8 @@ export function ColumnChart(props: IColumnChartProps): JSX.Element {
 
     const newProps
         = omit<IColumnChartProps, IColumnChartNonBucketProps>(props, ['measures', 'viewBy', 'stackBy', 'filters']);
+
+    newProps.config = getSanitizedStackingConfig(props);
 
     return (
         <AfmColumnChart

--- a/src/components/visualizations/chart/highcharts/getOptionalStackingConfiguration.ts
+++ b/src/components/visualizations/chart/highcharts/getOptionalStackingConfiguration.ts
@@ -94,10 +94,9 @@ function getYAxisConfiguration(
  * @param chartConfig
  */
 export function getStackMeasuresConfiguration(chartOptions: any, config: any, chartConfig: IChartConfig) {
-    const series = config.series || [];
     const { stackMeasures = false, stackMeasuresToPercent = false } = chartConfig;
-    // disable stacking measure config when there is no stacking setting or one measure/series
-    if ((!stackMeasures && !stackMeasuresToPercent) || series.length <= 1) {
+
+    if ((!stackMeasures && !stackMeasuresToPercent)) {
         return {};
     }
 

--- a/src/components/visualizations/chart/highcharts/test/getOptionalStackingConfiguration.spec.ts
+++ b/src/components/visualizations/chart/highcharts/test/getOptionalStackingConfiguration.spec.ts
@@ -79,15 +79,6 @@ describe('getOptionalStackingConfiguration', () => {
             });
         });
 
-        it('should return empty series config with single metric', () => {
-            const chartOptions = { yAxes: [{}] };
-            const config = { series: [{}] };
-            const chartConfig = { stackMeasures: true };
-
-            const result = getStackMeasuresConfiguration(chartOptions, config, chartConfig);
-            expect(result).toEqual({});
-        });
-
         it('should \'stackMeasuresToPercent\' always overwrite \'stackMeasures\' setting', () => {
             const chartOptions = { yAxes: [{}] };
             const config = { series: Array(2).fill({ yAxis: 0 }) };

--- a/src/helpers/optionalStacking/common.ts
+++ b/src/helpers/optionalStacking/common.ts
@@ -3,6 +3,9 @@ import isArray = require('lodash/isArray');
 import { VisualizationObject } from '@gooddata/typings';
 import { VIEW_BY_ATTRIBUTES_LIMIT } from '../../components/visualizations/chart/constants';
 import IVisualizationAttribute = VisualizationObject.IVisualizationAttribute;
+import { IColumnChartProps } from '../../components/ColumnChart';
+import { IBarChartProps } from '../../components/BarChart';
+import { IChartConfig } from '../..';
 
 export function getViewByTwoAttributes(
     viewBy: IVisualizationAttribute | IVisualizationAttribute[]
@@ -15,4 +18,14 @@ export function getViewByTwoAttributes(
         return viewBy.slice(0, VIEW_BY_ATTRIBUTES_LIMIT);
     }
     return [viewBy] as VisualizationObject.IVisualizationAttribute[];
+}
+
+export function getSanitizedStackingConfig(props: IColumnChartProps | IBarChartProps): IChartConfig {
+    const { measures = [], stackBy, config } = props;
+    // ignore stacking config when there is no stackBy and zero/one measure
+    if (config && measures.length <= 1 && !stackBy) {
+        config.stackMeasures = false;
+        config.stackMeasuresToPercent = false;
+    }
+    return config;
 }

--- a/src/helpers/optionalStacking/test/optionalStacking.spec.ts
+++ b/src/helpers/optionalStacking/test/optionalStacking.spec.ts
@@ -3,7 +3,7 @@ import { getBucketsProps, getConfigProps } from '../areaChart';
 import { VisualizationObject } from '@gooddata/typings';
 import { IAreaChartProps } from '../../../components/AreaChart';
 import { IChartConfig } from '../../..';
-import { getViewByTwoAttributes } from '../common';
+import { getViewByTwoAttributes, getSanitizedStackingConfig } from '../common';
 import BucketItem = VisualizationObject.BucketItem;
 import IVisualizationAttribute = VisualizationObject.IVisualizationAttribute;
 
@@ -63,6 +63,47 @@ describe('getViewByTwoAttributes', () => {
     }) => {
         const result = getViewByTwoAttributes(viewBy);
         expect(result).toEqual(expectation);
+    });
+});
+
+describe('getSanitizedStackingConfig', () => {
+    it('should return undefined when config is not input', () => {
+        const config = getSanitizedStackingConfig({
+            projectId: 'testProject',
+            measures: [MEASURE_1]
+        });
+        expect(config).toBeFalsy();
+    });
+
+    it('should ignore stacking setting with one measure', () => {
+        const props = {
+            projectId: 'testProject',
+            measures: [MEASURE_1],
+            config: {
+                stackMeasures: true,
+                stackMeasuresToPercent: true
+            }
+        };
+        const config = getSanitizedStackingConfig(props);
+        expect(config).toEqual({
+            stackMeasures: false,
+            stackMeasuresToPercent: false
+        });
+    });
+
+    it('should not ignore stacking setting with one measure and one stackBy', () => {
+        const props = {
+            projectId: 'testProject',
+            measures: [MEASURE_1],
+            stackBy: ATTRIBUTE_1,
+            config: {
+                stackMeasuresToPercent: true
+            }
+        };
+        const config = getSanitizedStackingConfig(props);
+        expect(config).toEqual({
+            stackMeasuresToPercent: true
+        });
     });
 });
 


### PR DESCRIPTION
## PR Checklists
- [x] Squash commits
- [x] Unit test is green
- [x] Storybook is green
- [x] AD test cafe is green
- [x] KD test cafe is green
---
## Related PRs
AD: https://github.com/gooddata/gdc-analytical-designer/pull/2098
KD: https://github.com/gooddata/gdc-dashboards/pull/1740