### PR TITLE
FEATURE: ONE-3610 Support text filters in simple measure

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "devDependencies": {
     "@gooddata/eslint-config": "0.1.0",
-    "@gooddata/mock-js": "1.24.0",
+    "@gooddata/mock-js": "1.25.0",
     "@gooddata/test-storybook": "3.0.1",
     "@gooddata/tslint-config": "0.0.16",
     "@storybook/addon-actions": "3.4.10",
@@ -96,11 +96,11 @@
     "yup": "^0.24.1"
   },
   "dependencies": {
-    "@gooddata/gooddata-js": "11.7.0",
+    "@gooddata/gooddata-js": "11.8.0",
     "@gooddata/goodstrap": "60.3.0",
     "@gooddata/js-utils": "3.4.0",
     "@gooddata/numberjs": "^3.1.2",
-    "@gooddata/typings": "2.9.0",
+    "@gooddata/typings": "2.10.0",
     "@types/highcharts": "4.2.56",
     "ag-grid": "^18.0.1",
     "ag-grid-react": "^18.0.0",

--- a/src/helpers/model/measures.ts
+++ b/src/helpers/model/measures.ts
@@ -1,23 +1,23 @@
 // (C) 2018 GoodData Corporation
-import { VisualizationObject } from '@gooddata/typings';
+import { VisualizationInput } from '@gooddata/typings';
 import { getQualifierObject } from './utils';
 
 export interface IPreviousPeriodDateDataSetSimple {
-    dataSet: VisualizationObject.ObjQualifier | string;
+    dataSet: VisualizationInput.ObjQualifier | string;
     periodsAgo: number;
 }
 
-export interface IMeasureAux<T extends VisualizationObject.IMeasureDefinitionType> {
+export interface IMeasureAux<T extends VisualizationInput.IMeasureDefinitionType> {
     measure: {
         definition: T;
-        localIdentifier: VisualizationObject.IMeasure['measure']['localIdentifier'];
-        alias: VisualizationObject.IMeasure['measure']['alias'];
-        format: VisualizationObject.IMeasure['measure']['format'];
-        title: VisualizationObject.IMeasure['measure']['title'];
+        localIdentifier: VisualizationInput.IMeasure['measure']['localIdentifier'];
+        alias: VisualizationInput.IMeasure['measure']['alias'];
+        format: VisualizationInput.IMeasure['measure']['format'];
+        title: VisualizationInput.IMeasure['measure']['title'];
     };
 }
 
-export class MeasureBuilderBase<T extends VisualizationObject.IMeasureDefinitionType> implements IMeasureAux<T> {
+export class MeasureBuilderBase<T extends VisualizationInput.IMeasureDefinitionType> implements IMeasureAux<T> {
     private static lastMeasureId = 0;
     public measure: IMeasureAux<T>['measure'];
     constructor() {
@@ -47,7 +47,7 @@ export class MeasureBuilderBase<T extends VisualizationObject.IMeasureDefinition
     }
 }
 
-export class MeasureBuilder extends MeasureBuilderBase<VisualizationObject.IMeasureDefinition> {
+export class MeasureBuilder extends MeasureBuilderBase<VisualizationInput.IMeasureDefinition> {
     constructor(identifier: string) {
         super();
         this.measure.definition = {
@@ -57,7 +57,7 @@ export class MeasureBuilder extends MeasureBuilderBase<VisualizationObject.IMeas
         };
     }
 
-    public aggregation = (aggregation: VisualizationObject.MeasureAggregation) => {
+    public aggregation = (aggregation: VisualizationInput.MeasureAggregation) => {
         this.measure.definition.measureDefinition.aggregation = aggregation;
         return this;
     }
@@ -67,14 +67,14 @@ export class MeasureBuilder extends MeasureBuilderBase<VisualizationObject.IMeas
         return this;
     }
 
-    public filters = (...filters: VisualizationObject.VisualizationObjectFilter[]) => {
+    public filters = (...filters: VisualizationInput.IFilter[]) => {
         this.measure.definition.measureDefinition.filters = filters;
         return this;
     }
 }
 
-export class ArithmeticMeasureBuilder extends MeasureBuilderBase<VisualizationObject.IArithmeticMeasureDefinition> {
-    constructor(measureIdentifiers: string[], operator: VisualizationObject.ArithmeticMeasureOperator) {
+export class ArithmeticMeasureBuilder extends MeasureBuilderBase<VisualizationInput.IArithmeticMeasureDefinition> {
+    constructor(measureIdentifiers: string[], operator: VisualizationInput.ArithmeticMeasureOperator) {
         super();
         this.measure.definition = {
             arithmeticMeasure: {
@@ -85,7 +85,7 @@ export class ArithmeticMeasureBuilder extends MeasureBuilderBase<VisualizationOb
     }
 }
 
-export class PoPMeasureBuilder extends MeasureBuilderBase<VisualizationObject.IPoPMeasureDefinition> {
+export class PoPMeasureBuilder extends MeasureBuilderBase<VisualizationInput.IPoPMeasureDefinition> {
     constructor(measureIdentifier: string, popAttribute: string) {
         super();
         this.measure.definition = {
@@ -98,13 +98,13 @@ export class PoPMeasureBuilder extends MeasureBuilderBase<VisualizationObject.IP
 }
 
 export class PreviousPeriodMeasureBuilder
-    extends MeasureBuilderBase<VisualizationObject.IPreviousPeriodMeasureDefinition> {
+    extends MeasureBuilderBase<VisualizationInput.IPreviousPeriodMeasureDefinition> {
     constructor(measureIdentifier: string, dateDataSets: IPreviousPeriodDateDataSetSimple[]) {
         super();
         this.measure.definition = {
             previousPeriodMeasure: {
                 measureIdentifier,
-                dateDataSets: dateDataSets.map((d): VisualizationObject.IPreviousPeriodDateDataSet =>
+                dateDataSets: dateDataSets.map((d): VisualizationInput.IPreviousPeriodDateDataSet =>
                     ({
                         ...d,
                         dataSet: typeof (d.dataSet) === 'string'
@@ -120,7 +120,7 @@ export const measure = (identifier: string) => new MeasureBuilder(identifier);
 
 export const arithmeticMeasure = (
     measureIdentifiers: string[],
-    operator: VisualizationObject.ArithmeticMeasureOperator
+    operator: VisualizationInput.ArithmeticMeasureOperator
 ) => new ArithmeticMeasureBuilder(measureIdentifiers, operator);
 
 export const popMeasure = (measureIdentifier: string, popAttribute: string) =>

--- a/src/helpers/model/tests/measures.spec.ts
+++ b/src/helpers/model/tests/measures.spec.ts
@@ -1,5 +1,5 @@
 // (C) 2018 GoodData Corporation
-import { positiveAttributeFilter } from '../filters';
+import { positiveAttributeFilter, attributeFilter } from '../filters';
 import { measure, arithmeticMeasure, popMeasure, previousPeriodMeasure } from '../measures';
 
 describe('Measures', () => {
@@ -84,6 +84,30 @@ describe('Measures', () => {
                 }
             };
             expect(measure('foo').filters(positiveAttributeFilter('filter', ['baz']))).toMatchObject(expected);
+        });
+
+        it('should return a measure with a text filter', () => {
+            const expected = {
+                measure: {
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                identifier: 'foo'
+                            },
+                            filters: [{
+                                positiveAttributeFilter: {
+                                    displayForm: {
+                                        identifier: 'filter'
+                                    },
+                                    in: ['val1'],
+                                    textFilter: true
+                                }
+                            }]
+                        }
+                    }
+                }
+            };
+            expect(measure('foo').filters(attributeFilter('filter').in('val1'))).toMatchObject(expected);
         });
     });
 

--- a/src/helpers/tests/conversion.spec.ts
+++ b/src/helpers/tests/conversion.spec.ts
@@ -1,0 +1,100 @@
+// (C) 2019 GoodData Corporation
+import { VisualizationInput } from '@gooddata/typings';
+import { convertBucketsToAFM } from '../conversion';
+
+const PositiveTextFilter: VisualizationInput.IFilter = {
+    positiveAttributeFilter: {
+        displayForm: { identifier: 'foo' },
+        in: ['val1', 'val2'],
+        textFilter: true
+    }
+};
+
+const NegativeTextFilter: VisualizationInput.IFilter = {
+    negativeAttributeFilter: {
+        displayForm: { identifier: 'foo' },
+        notIn: ['val1', 'val2'],
+        textFilter: true
+    }
+};
+
+/**
+ * Tests here solidify the contract of text filters:
+ *
+ * - text filter indicator is optional property added on top of existing visualization object structures accepted
+ *   by convertBucketsToAFM
+ * - if present, the textFilter property MUST be returned in the resulting AFM structures
+ * - the textFilter property MAY occur in positive or negative attribute filters included in global filters or
+ *   in simple measure definition
+ */
+describe('convertBucketsToAFM', () => {
+    it('should retain textFilter indicator for positive filter in global filters', () => {
+
+        expect(convertBucketsToAFM([], [PositiveTextFilter]))
+            .toEqual({ filters: [PositiveTextFilter] });
+    });
+
+    it('should retain textFilter indicator for negative filter in global filters', () => {
+
+        expect(convertBucketsToAFM([], [NegativeTextFilter]))
+            .toEqual({ filters: [NegativeTextFilter] });
+    });
+
+    it('should retain textFilter indicator for positive filter in simple measure filters', () => {
+        const simpleMeasure: VisualizationInput.IMeasure = {
+            measure: {
+                localIdentifier: 'm1',
+                definition: {
+                    measureDefinition: {
+                        item: { identifier: 'm1Id' },
+                        aggregation: 'sum',
+                        filters: [ PositiveTextFilter ]
+                    }
+                }
+            }
+        };
+
+        expect(convertBucketsToAFM([{ localIdentifier: 'bucket', items: [simpleMeasure] }]))
+            .toEqual({
+                measures: [{
+                    localIdentifier: 'm1',
+                    definition: {
+                        measure: {
+                            item: { identifier: 'm1Id' },
+                            aggregation: 'sum',
+                            filters: [ PositiveTextFilter ]
+                        }
+                    }
+                }]
+            });
+    });
+
+    it('should retain textFilter indicator for negative filter in simple measure filters', () => {
+        const simpleMeasure: VisualizationInput.IMeasure = {
+            measure: {
+                localIdentifier: 'm1',
+                definition: {
+                    measureDefinition: {
+                        item: { identifier: 'm1Id' },
+                        aggregation: 'sum',
+                        filters: [ NegativeTextFilter ]
+                    }
+                }
+            }
+        };
+
+        expect(convertBucketsToAFM([{ localIdentifier: 'bucket', items: [simpleMeasure] }]))
+            .toEqual({
+                measures: [{
+                    localIdentifier: 'm1',
+                    definition: {
+                        measure: {
+                            item: { identifier: 'm1Id' },
+                            aggregation: 'sum',
+                            filters: [ NegativeTextFilter ]
+                        }
+                    }
+                }]
+            });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,12 +32,12 @@
     eslint-plugin-jsx-a11y "6.0.3"
     eslint-plugin-react "7.6.1"
 
-"@gooddata/gooddata-js@11.7.0":
-  version "11.7.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-11.7.0.tgz#955afc728619551c1d57722ccfa45a84b38b6376"
-  integrity sha512-mqC2adUjG2mJ31XpJQTa4Sy+aLdwMLd/VBz0atYOgAHfmCgs+FUIyBr/HS6mJ1cQwoLZ2TTsnQpEd+ZceTAvHw==
+"@gooddata/gooddata-js@11.8.0":
+  version "11.8.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-11.8.0.tgz#c8355c42b118c7afe85233e8576e123c8a74ce90"
+  integrity sha512-wI3WVinmn8rpU5848E+W0TXhXfqPwrIZKL1j6+HI/dFGooiVaCMdK1h1krUk48wis1T5QlHnOsVODkMUe0QCMg==
   dependencies:
-    "@gooddata/typings" "2.9.0"
+    "@gooddata/typings" "2.10.0"
     es6-promise "3.0.2"
     fetch-cookie "0.7.0"
     invariant "2.2.2"
@@ -89,12 +89,12 @@
     lodash "4.17.11"
     lodash-es "4.17.11"
 
-"@gooddata/mock-js@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/mock-js/-/mock-js-1.24.0.tgz#2affe9e1ad5f41115b1018fb274d758372077946"
-  integrity sha512-c6rvUnzRnNomVYWLljVf2Bped7WxcP7HsBWPGztw8nV84G03vZNZj1nOAqRlRXHMorPBYtR8PM8LyV27okhW/A==
+"@gooddata/mock-js@1.25.0":
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/mock-js/-/mock-js-1.25.0.tgz#d32946da8dec23a1b7059ad68148e1bac5f9d4bb"
+  integrity sha512-OUCXOfpjHjlW0XINidnDaj0eEvladXNjk7gJAJyJ9FN0bYfyRfVNs1duR4QIxgzq8hrvUeeiL9UGu8wXwf9chQ==
   dependencies:
-    "@gooddata/typings" "2.9.0"
+    "@gooddata/typings" "2.10.0"
     "@types/seedrandom" "2.4.27"
     "@types/uuid" "3.4.3"
     body-parser "1.17.1"
@@ -134,10 +134,10 @@
     tslint-microsoft-contrib "6.1.0"
     tslint-react "3.6.0"
 
-"@gooddata/typings@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/typings/-/typings-2.9.0.tgz#9ce6497aa867542768c88041d1f4cf0320adf45f"
-  integrity sha512-8s644Jcfl7j03GHBItrgEOKAjo/KpVN8SP7pBw7zwH1aPxYq9THMvpBhRlKw6UewOzGIZb3ocudkx4I7mytU4w==
+"@gooddata/typings@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/typings/-/typings-2.10.0.tgz#7ce8ccaabb4125af8af8a1db07c5a95a5de12a65"
+  integrity sha512-5A+4X1e7M18PppAzUcSsPAR2mvdEwqLB6jfldL0a97d0Mabgp4S1/cFPbGDNh6pqeCEASugE2Zcl070ObtEHGg==
   dependencies:
     lodash "4.17.11"
 


### PR DESCRIPTION
Changes included in this PR complete the text filters story by supporting text filters in simple measure definitions (which can include attribute filters that can be textual). I did not catch this 'nuance' in my first PR 😞 

Majority of the work is done in gooddata-typings, where I overridden VisualizationInput.IMeasure definition with a mix of aliases to visualizaiton object measure definitions and custom simple measure definition which can accept filters in AFM format - same as with regular filters, these will be converted to ExecuteAFM type system and sent to backend in correct notation.