### PR TITLE
BUGFIX: BB-1463 Hide blank space on pivot table

### DIFF
--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -363,6 +363,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
     private containerRef: HTMLDivElement;
     private groupingProvider: IGroupingProvider;
     private lastScrollTop: number = 0;
+    private lastScrollLeft: number = 0;
 
     constructor(props: IPivotTableInnerProps) {
         super(props);
@@ -554,8 +555,10 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
             updateStickyHeadersPosition(this.gridApi);
         }
         const scrollTop = this.lastScrollTop;
+        const scrollLeft = this.lastScrollLeft;
         this.lastScrollTop = 0;
-        this.updateStickyRow(scrollTop);
+        this.lastScrollLeft = 0;
+        this.updateStickyRow(scrollTop, scrollLeft);
     }
 
     public setGridDataSource() {
@@ -683,9 +686,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
     }
 
     public onBodyScroll = (event: BodyScrollEvent) => {
-        if (event.direction === 'vertical') {
-            this.updateStickyRow(event.top);
-        }
+        this.updateStickyRow(Math.max(event.top, 0), event.left);
     }
 
     public renderVisualization() {
@@ -930,11 +931,13 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
         this.setGridDataSource();
     }
 
-    private updateStickyRow(scrollTop: number): void {
+    private updateStickyRow(scrollTop: number, scrollLeft: number): void {
         if (this.props.groupRows && this.gridApi) {
             updateStickyHeaders(
                 scrollTop,
+                scrollLeft,
                 this.lastScrollTop,
+                this.lastScrollLeft,
                 DEFAULT_ROW_HEIGHT,
                 this.gridApi,
                 this.groupingProvider,
@@ -942,6 +945,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
             );
         }
         this.lastScrollTop = scrollTop;
+        this.lastScrollLeft = scrollLeft;
     }
 
     private getTotalBodyHeight(executionResult: Execution.IExecutionResult): number {

--- a/src/components/core/pivotTable/stickyGroupHandler.ts
+++ b/src/components/core/pivotTable/stickyGroupHandler.ts
@@ -1,7 +1,7 @@
 // (C) 2007-2019 GoodData Corporation
 import { GridApi, RowNode } from 'ag-grid';
 import { IGroupingProvider } from './GroupingProvider';
-import { colIdIsSimpleAttribute, getRowIndexByScrollTop } from '../../../helpers/agGrid';
+import { colIdIsSimpleAttribute, getGridIndex } from '../../../helpers/agGrid';
 import ApiWrapper from './agGridApiWrapper';
 
 export const initStickyHeaders = (gridApi: GridApi) => {
@@ -13,21 +13,41 @@ export const updateStickyHeadersPosition = (gridApi: GridApi) => {
     ApiWrapper.setPinnedTopRowStyle(gridApi, 'top', `${headerHeight}px`);
 };
 
+function shouldUpdate(
+    currentScrollTop: number,
+    currentScrollLeft: number,
+    lastScrollTop: number,
+    lastScrollLeft: number,
+    rowHeight: number
+) {
+    const initialUpdate = currentScrollTop === 0;
+    const currentRowIndex = getGridIndex(currentScrollTop, rowHeight);
+    const lastRowIndex = getGridIndex(lastScrollTop, rowHeight);
+    const differentRow = currentRowIndex !== lastRowIndex;
+    // when scrolling horizontally update with the same cadence as rows as we don't know where the column borders are
+    const horizontalBreakpointDistance = rowHeight;
+    const currentHorizontalBreakpoint = getGridIndex(currentScrollLeft, horizontalBreakpointDistance);
+    const lastHorizontalBreakpoint = getGridIndex(lastScrollLeft, horizontalBreakpointDistance);
+    const differentHorizontalBreakpoint = currentHorizontalBreakpoint !== lastHorizontalBreakpoint;
+
+    return initialUpdate || differentRow || differentHorizontalBreakpoint;
+}
+
 export const updateStickyHeaders = (
     currentScrollTop: number,
+    currentScrollLeft: number,
     lastScrollTop: number,
+    lastScrollLeft: number,
     rowHeight: number,
     gridApi: GridApi,
     groupingProvider: IGroupingProvider,
     apiWrapper: any
 ) => {
-    const currentRowIndex = getRowIndexByScrollTop(currentScrollTop, rowHeight);
-    const lastRowIndex = getRowIndexByScrollTop(lastScrollTop, rowHeight);
-    if ((lastRowIndex === currentRowIndex) && currentScrollTop !== 0) {
+    if (!shouldUpdate(currentScrollTop, currentScrollLeft, lastScrollTop, lastScrollLeft, rowHeight)) {
         return;
     }
 
-    const firstVisibleRowIndex = getRowIndexByScrollTop(currentScrollTop, rowHeight);
+    const firstVisibleRowIndex = getGridIndex(currentScrollTop, rowHeight);
     const firstVisibleRow: RowNode = gridApi.getDisplayedRowAtIndex(firstVisibleRowIndex);
     const firstVisibleNodeData = firstVisibleRow && firstVisibleRow.data ? firstVisibleRow.data : null;
 
@@ -35,10 +55,9 @@ export const updateStickyHeaders = (
         apiWrapper.removePinnedTopRowClass(gridApi, 'gd-visible-sticky-row');
         return;
     }
-
-    // show the pinned row for sticky column headers
     apiWrapper.addPinnedTopRowClass(gridApi, 'gd-visible-sticky-row');
 
+    const lastRowIndex = getGridIndex(lastScrollTop, rowHeight);
     const attributeKeys = Object.keys(firstVisibleNodeData).filter(colIdIsSimpleAttribute);
 
     attributeKeys.forEach((columnId: string) => {
@@ -56,6 +75,7 @@ export const updateStickyHeaders = (
             // if the column has some groups
             if (groupingProvider.isColumnWithGrouping(columnId)) {
                 // show the last cell of the froup temporarily so it scrolls out of the viewport nicely
+                const currentRowIndex = getGridIndex(currentScrollTop, rowHeight);
                 apiWrapper.addCellClass(gridApi, columnId, currentRowIndex, 'gd-cell-show-hidden');
             }
         }

--- a/src/components/core/pivotTable/tests/stickyGroupHandler.spec.ts
+++ b/src/components/core/pivotTable/tests/stickyGroupHandler.spec.ts
@@ -53,22 +53,48 @@ describe('updateStickyHeaders', () => {
 
     const TEST_ROW_HEIGHT = 10;
 
-    it('should do nothing when scroll top has not changed from last time', () => {
+    it('should do nothing when scroll top and scroll left has not changed from last time', () => {
         const fakeGridApi = getFakeGridApi();
         const fakeGridApiWrapper = getFakeGridApiWrapper();
         const fakeGroupingProvider = getFakeGroupingProvider();
+        const currentScrollTop = 5;
+        const lastScrollTop = 5;
+        const currentScrollLeft = 0;
+        const lastScrollLeft = 0;
 
-        updateStickyHeaders(5, 5, TEST_ROW_HEIGHT, fakeGridApi, fakeGroupingProvider, fakeGridApiWrapper);
+        updateStickyHeaders(
+            currentScrollTop,
+            currentScrollLeft,
+            lastScrollTop,
+            lastScrollLeft,
+            TEST_ROW_HEIGHT,
+            fakeGridApi,
+            fakeGroupingProvider,
+            fakeGridApiWrapper
+        );
 
         assertOnlyListedMethodsHaveBeenCalled(fakeGridApiWrapper, []);
     });
 
-    it('should do nothing when scroll change has not crossed row line', () => {
+    it('should do nothing when scroll top change has not crossed row line', () => {
         const fakeGridApi = getFakeGridApi();
         const fakeGridApiWrapper = getFakeGridApiWrapper();
         const fakeGroupingProvider = getFakeGroupingProvider();
+        const currentScrollTop = 6;
+        const lastScrollTop = 5;
+        const currentScrollLeft = 0;
+        const lastScrollLeft = 0;
 
-        updateStickyHeaders(6, 5, TEST_ROW_HEIGHT, fakeGridApi, fakeGroupingProvider, fakeGridApiWrapper);
+        updateStickyHeaders(
+            currentScrollTop,
+            currentScrollLeft,
+            lastScrollTop,
+            lastScrollLeft,
+            TEST_ROW_HEIGHT,
+            fakeGridApi,
+            fakeGroupingProvider,
+            fakeGridApiWrapper
+        );
 
         assertOnlyListedMethodsHaveBeenCalled(fakeGridApiWrapper, []);
     });
@@ -78,20 +104,46 @@ describe('updateStickyHeaders', () => {
         const fakeGridApi = getFakeGridApi(fakeGetDisplayedRowAtIndex);
         const fakeGridApiWrapper = getFakeGridApiWrapper();
         const fakeGroupingProvider = getFakeGroupingProvider();
+        const currentScrollTop = 5000;
+        const lastScrollTop = 5500;
+        const currentScrollLeft = 0;
+        const lastScrollLeft = 0;
 
-        updateStickyHeaders(5000, 5500, TEST_ROW_HEIGHT, fakeGridApi, fakeGroupingProvider, fakeGridApiWrapper);
+        updateStickyHeaders(
+            currentScrollTop,
+            currentScrollLeft,
+            lastScrollTop,
+            lastScrollLeft,
+            TEST_ROW_HEIGHT,
+            fakeGridApi,
+            fakeGroupingProvider,
+            fakeGridApiWrapper
+        );
 
         expect(fakeGridApiWrapper.removePinnedTopRowClass).toHaveBeenCalledWith(fakeGridApi, 'gd-visible-sticky-row');
         assertOnlyListedMethodsHaveBeenCalled(fakeGridApiWrapper, ['removePinnedTopRowClass']);
     });
 
-    describe('current scroll position belongs to different line than the last one', () => {
+    describe('current scroll top belongs to different line than the last one', () => {
         const fakeGetDisplayedRowAtIndex = (): any => ({ data: { a_123: '123' } });
         const fakeGridApi = getFakeGridApi(fakeGetDisplayedRowAtIndex);
         const fakeGridApiWrapper = getFakeGridApiWrapper();
         const fakeGroupingProvider = getFakeGroupingProvider(false, false);
+        const currentScrollTop = 100;
+        const lastScrollTop = 50;
+        const currentScrollLeft = 0;
+        const lastScrollLeft = 0;
 
-        updateStickyHeaders(100, 50, TEST_ROW_HEIGHT, fakeGridApi, fakeGroupingProvider, fakeGridApiWrapper);
+        updateStickyHeaders(
+            currentScrollTop,
+            currentScrollLeft,
+            lastScrollTop,
+            lastScrollLeft,
+            TEST_ROW_HEIGHT,
+            fakeGridApi,
+            fakeGroupingProvider,
+            fakeGridApiWrapper
+        );
 
         it('should show the sticky row', () => {
             expect(fakeGridApiWrapper.addPinnedTopRowClass)
@@ -104,13 +156,58 @@ describe('updateStickyHeaders', () => {
         });
     });
 
+    describe('current scroll left change reached update threshold', () => {
+        const fakeGetDisplayedRowAtIndex = (): any => ({ data: { a_123: '123' } });
+        const fakeGridApi = getFakeGridApi(fakeGetDisplayedRowAtIndex);
+        const fakeGridApiWrapper = getFakeGridApiWrapper();
+        const fakeGroupingProvider = getFakeGroupingProvider(false, false);
+        const currentScrollTop = 100;
+        const lastScrollTop = 100;
+        const currentScrollLeft = 50;
+        const lastScrollLeft = 70;
+
+        updateStickyHeaders(
+            currentScrollTop,
+            currentScrollLeft,
+            lastScrollTop,
+            lastScrollLeft,
+            TEST_ROW_HEIGHT,
+            fakeGridApi,
+            fakeGroupingProvider,
+            fakeGridApiWrapper
+        );
+
+        it('should show the sticky row', () => {
+            expect(fakeGridApiWrapper.addPinnedTopRowClass)
+                .toHaveBeenCalledWith(fakeGridApi, 'gd-visible-sticky-row');
+        });
+
+        it('should hide temporarily shown cell from previous scroll position', () => {
+            expect(fakeGridApiWrapper.removeCellClass)
+                .toHaveBeenCalledWith(fakeGridApi, 'a_123', 10, 'gd-cell-show-hidden');
+        });
+    });
+
     describe('column without repetitions i.e. without grouping', () => {
         const fakeGetDisplayedRowAtIndex = (): any => ({ data: { a_123: '123' } });
         const fakeGridApi = getFakeGridApi(fakeGetDisplayedRowAtIndex);
         const fakeGridApiWrapper = getFakeGridApiWrapper();
         const fakeGroupingProvider = getFakeGroupingProvider(false, false);
+        const currentScrollTop = 50;
+        const lastScrollTop = 100;
+        const currentScrollLeft = 0;
+        const lastScrollLeft = 0;
 
-        updateStickyHeaders(50, 100, TEST_ROW_HEIGHT, fakeGridApi, fakeGroupingProvider, fakeGridApiWrapper);
+        updateStickyHeaders(
+            currentScrollTop,
+            currentScrollLeft,
+            lastScrollTop,
+            lastScrollLeft,
+            TEST_ROW_HEIGHT,
+            fakeGridApi,
+            fakeGroupingProvider,
+            fakeGridApiWrapper
+        );
 
         it('should hide sticky column header', () => {
             expect(fakeGridApiWrapper.addPinnedTopRowCellClass)
@@ -133,8 +230,21 @@ describe('updateStickyHeaders', () => {
         const fakeGridApi = getFakeGridApi(fakeGetDisplayedRowAtIndex);
         const fakeGridApiWrapper = getFakeGridApiWrapper();
         const fakeGroupingProvider = getFakeGroupingProvider(false, true);
+        const currentScrollTop = 100;
+        const lastScrollTop = 50;
+        const currentScrollLeft = 0;
+        const lastScrollLeft = 0;
 
-        updateStickyHeaders(100, 50, TEST_ROW_HEIGHT, fakeGridApi, fakeGroupingProvider, fakeGridApiWrapper);
+        updateStickyHeaders(
+            currentScrollTop,
+            currentScrollLeft,
+            lastScrollTop,
+            lastScrollLeft,
+            TEST_ROW_HEIGHT,
+            fakeGridApi,
+            fakeGroupingProvider,
+            fakeGridApiWrapper
+        );
 
         it('should hide sticky column header', () => {
             expect(fakeGridApiWrapper.addPinnedTopRowCellClass)
@@ -157,8 +267,21 @@ describe('updateStickyHeaders', () => {
         const fakeGridApi = getFakeGridApi(fakeGetDisplayedRowAtIndex);
         const fakeGridApiWrapper = getFakeGridApiWrapper();
         const fakeGroupingProvider = getFakeGroupingProvider(true, true);
+        const currentScrollTop = 100;
+        const lastScrollTop = 50;
+        const currentScrollLeft = 0;
+        const lastScrollLeft = 0;
 
-        updateStickyHeaders(100, 50, TEST_ROW_HEIGHT, fakeGridApi, fakeGroupingProvider, fakeGridApiWrapper);
+        updateStickyHeaders(
+            currentScrollTop,
+            currentScrollLeft,
+            lastScrollTop,
+            lastScrollLeft,
+            TEST_ROW_HEIGHT,
+            fakeGridApi,
+            fakeGroupingProvider,
+            fakeGridApiWrapper
+        );
 
         it('should show sticky column header', () => {
             expect(fakeGridApiWrapper.removePinnedTopRowCellClass)

--- a/src/helpers/agGrid.ts
+++ b/src/helpers/agGrid.ts
@@ -571,6 +571,6 @@ export const getRowNodeId = (item: any) => {
     }).join(FIELD_SEPARATOR);
 };
 
-export const getRowIndexByScrollTop = (scrollTop: number, rowHeight: number) => {
-    return Math.floor(scrollTop / rowHeight);
+export const getGridIndex = (position: number, gridDistance: number) => {
+    return Math.floor(position / gridDistance);
 };

--- a/src/helpers/tests/agGrid.spec.ts
+++ b/src/helpers/tests/agGrid.spec.ts
@@ -21,7 +21,7 @@ import {
     shouldMergeHeaders,
     mergeHeaderEndIndex,
     getRowNodeId,
-    getRowIndexByScrollTop
+    getGridIndex
 } from '../agGrid';
 
 import * as fixtures from '../../../stories/test_data/fixtures';
@@ -866,8 +866,8 @@ describe('getRowNodeId', () => {
     });
 });
 
-describe('getRowIndexByScrollTop', () => {
-    const rowHeight = 20;
+describe('getGridIndex', () => {
+    const gridDistance = 20;
 
     it.each([
         ['100', 100, 5],
@@ -876,7 +876,7 @@ describe('getRowIndexByScrollTop', () => {
     ])(
         'should return correct row index when scrolltop is %s',
         (_: string, scrollTop: number, expectedRowIndex: number) => {
-            expect(getRowIndexByScrollTop(scrollTop, rowHeight)).toEqual(expectedRowIndex);
+            expect(getGridIndex(scrollTop, gridDistance)).toEqual(expectedRowIndex);
         }
     );
 });

--- a/styles/scss/pivotTable.scss
+++ b/styles/scss/pivotTable.scss
@@ -402,7 +402,8 @@ $header-cell-resize-width: 20px;
             border-top-color: white;
 
             &.gd-hidden-sticky-column,
-            &.gd-measure-column {
+            &.gd-measure-column,
+            &.gd-column-attribute-column{
                 background-color: transparent;
                 color: transparent;
             }


### PR DESCRIPTION
Happens on table with only columns and rows but no measures. This should also fix disappearing sticky header when scrolling horizontally.