### PR TITLE
BUGFIX: SD-359 escape both parent and child attributes

### DIFF
--- a/src/components/visualizations/chart/highcharts/customConfiguration.ts
+++ b/src/components/visualizations/chart/highcharts/customConfiguration.ts
@@ -733,7 +733,7 @@ function getHeatmapDataConfiguration(chartOptions: IChartOptions) {
 export function escapeCategories(dataCategories: any) {
     return map(dataCategories, (category: any) => {
         return isString(category) ? escapeAngleBrackets(category) : {
-            ...category,
+            name: escapeAngleBrackets(category.name),
             categories: map(category.categories, escapeAngleBrackets)
         };
     });

--- a/src/components/visualizations/chart/highcharts/test/customConfiguration.spec.ts
+++ b/src/components/visualizations/chart/highcharts/test/customConfiguration.spec.ts
@@ -699,6 +699,9 @@ describe('escapeCategories', () => {
         const categories = escapeCategories([{
             name: 'Status',
             categories: ['cat1', '<cat2/>', '<cat3></cat3>']
+        }, {
+            name: '<span>Sales</span>',
+            categories: ['<div>sale1</div>', '<sale2/>', '<sale3></sale3>']
         }]);
         expect(categories).toEqual([{
             name: 'Status',
@@ -706,6 +709,13 @@ describe('escapeCategories', () => {
                 'cat1',
                 '&lt;cat2/&gt;',
                 '&lt;cat3&gt;&lt;/cat3&gt;'
+            ]
+        }, {
+            name: '&lt;span&gt;Sales&lt;/span&gt;',
+            categories: [
+                '&lt;div&gt;sale1&lt;/div&gt;',
+                '&lt;sale2/&gt;',
+                '&lt;sale3&gt;&lt;/sale3&gt;'
             ]
         }]);
     });


### PR DESCRIPTION
# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by running `extended test - cafe` in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards)
- [x] Successful `extended test - storybook`


# Related PRs
- gdc-analytical-designer:  https://github.com/gooddata/gdc-analytical-designer/pull/2126
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/1790

# Related Jira tasks
- SD-359: https://jira.intgdc.com/browse/SD-359