### PR TITLE
BUGFIX: SD-345 - Show percent values when stackMeasuresToPercent is true

### DIFF
--- a/src/components/visualizations/chart/highcharts/customConfiguration.ts
+++ b/src/components/visualizations/chart/highcharts/customConfiguration.ts
@@ -19,6 +19,7 @@ import { styleVariables } from "../../styles/variables";
 import { IChartOptions, supportedDualAxesChartTypes } from "../chartOptionsBuilder";
 import { VisualizationTypes, ChartType } from "../../../../constants/visualizationTypes";
 import { IDataLabelsVisible, IChartConfig, IAxis } from "../../../../interfaces/Config";
+import { percentFormatter } from "../../../../helpers/utils";
 import { getShapeVisiblePart } from "../highcharts/dataLabelsHelpers";
 import { HOVER_BRIGHTNESS, MINIMUM_HC_SAFE_BRIGHTNESS } from "./commonConfiguration";
 import { AXIS_LINE_COLOR, getLighterColor } from "../../utils/color";
@@ -315,7 +316,7 @@ function formatTooltip(chartType: any, stacking: any, tooltipCallback: any) {
         });
     };
 
-    const tooltipContent = tooltipCallback(this.point); // null disables whole tooltip
+    const tooltipContent = tooltipCallback(this.point, this.percentage); // null disables whole tooltip
 
     return tooltipContent !== null
         ? `<div class="hc-tooltip gd-viz-tooltip">
@@ -361,7 +362,7 @@ function labelFormatter(config?: IChartConfig) {
     return formatLabel(this.y, get(this, "point.format"), config);
 }
 
-export function percentageDataLabelFormatter(config?: IChartConfig) {
+export function percentageDataLabelFormatter(config?: IChartConfig): string {
     // suppose that chart has one Y axis by default
     const isSingleAxis = get(this, "series.chart.yAxis.length", 1) === 1;
     const isPrimaryAxis = !get(this, "series.yAxis.opposite", false);
@@ -373,8 +374,7 @@ export function percentageDataLabelFormatter(config?: IChartConfig) {
     //  * left or right axis on single axis chart, or
     //  * primary axis on dual axis chart
     if (isSingleAxis || isPrimaryAxis) {
-        const val = parseFloat(this.percentage.toFixed(2));
-        return `${val}%`;
+        return percentFormatter(this.percentage);
     }
     return labelFormatter.call(this, config);
 }

--- a/src/components/visualizations/chart/test/tooltip.spec.ts
+++ b/src/components/visualizations/chart/test/tooltip.spec.ts
@@ -1,0 +1,61 @@
+// (C) 2007-2019 GoodData Corporation
+import { ISeparators } from "@gooddata/numberjs";
+import { formatValueForTooltip, getFormattedValueForTooltip } from "../tooltip";
+
+const testFormat: string = "#,##0.00";
+const testPointData = {
+    y: 1,
+    format: "# ###",
+    name: "point",
+    category: {
+        name: "category",
+        parent: {
+            name: "parent category",
+        },
+    },
+    series: {
+        name: "series",
+    },
+};
+const testSeparators: ISeparators = { decimal: "_", thousand: "=" };
+
+describe("tooltip", () => {
+    describe("formatValueForTooltip()", () => {
+        it("should return formatted value with no separators", () => {
+            const formattedValue = formatValueForTooltip(36525, testFormat);
+            expect(formattedValue).toEqual("36,525.00");
+        });
+
+        it("should return formatted value with separators", () => {
+            const formattedValue = formatValueForTooltip(858, testFormat, testSeparators);
+            expect(formattedValue).toEqual("858_00");
+        });
+    });
+
+    describe("getFormattedValueForTooltip()", () => {
+        it.each([[false, 45.2490089197225], [true, null]])(
+            "should return formatted number if stackMeasuresToPercent is %s and percentageValue is %s",
+            (stackMeasuresToPercent: boolean, percentageValue: number) => {
+                const formattedValue = getFormattedValueForTooltip(
+                    stackMeasuresToPercent,
+                    testPointData,
+                    testSeparators,
+                    percentageValue,
+                );
+                expect(formattedValue).toEqual(" 1");
+            },
+        );
+        it.each([["0%", 0], ["45.25%", 45.2490089197225], ["100%", 100]])(
+            "should return %s if stackMeasuresToPercent is true and percentageValue is %s",
+            (formattedValue: string, percentageValue: number) => {
+                const tooltip = getFormattedValueForTooltip(
+                    true,
+                    testPointData,
+                    testSeparators,
+                    percentageValue,
+                );
+                expect(tooltip).toEqual(formattedValue);
+            },
+        );
+    });
+});

--- a/src/components/visualizations/chart/tooltip.ts
+++ b/src/components/visualizations/chart/tooltip.ts
@@ -1,0 +1,26 @@
+// (C) 2007-2019 GoodData Corporation
+import { colors2Object, INumberObject, ISeparators, numberFormat } from "@gooddata/numberjs";
+import isNil = require("lodash/isNil");
+import { customEscape, IPoint } from "./chartOptionsBuilder";
+import { percentFormatter } from "../../../helpers/utils";
+
+export function formatValueForTooltip(
+    val: string | number,
+    format: string,
+    separators?: ISeparators,
+): string {
+    const formattedObject: INumberObject = colors2Object(numberFormat(val, format, undefined, separators));
+    return customEscape(formattedObject.label);
+}
+
+export function getFormattedValueForTooltip(
+    stackMeasuresToPercent: boolean,
+    point: IPoint,
+    separators?: ISeparators,
+    percentageValue?: number,
+): string {
+    const isNotStackToPercent = stackMeasuresToPercent === false || isNil(percentageValue);
+    return isNotStackToPercent
+        ? formatValueForTooltip(point.y, point.format, separators)
+        : percentFormatter(percentageValue);
+}

--- a/src/helpers/tests/utils.spec.ts
+++ b/src/helpers/tests/utils.spec.ts
@@ -1,5 +1,5 @@
-// (C) 2007-2018 GoodData Corporation
-import { getObjectIdFromUri, setTelemetryHeaders, unwrap } from "../utils";
+// (C) 2007-2019 GoodData Corporation
+import { getObjectIdFromUri, setTelemetryHeaders, percentFormatter, unwrap } from "../utils";
 import { factory as createSdk } from "@gooddata/gooddata-js";
 
 describe("getObjectIdFromUri", () => {
@@ -27,6 +27,15 @@ describe("setTelemetryHeaders", () => {
         expect(sdk.config.getRequestHeader("X-GDC-JS-SDK-COMP")).toEqual("componentName");
         expect(sdk.config.getRequestHeader("X-GDC-JS-SDK-COMP-PROPS")).toEqual("prop");
     });
+});
+
+describe("percentFormatter", () => {
+    it.each([["0%", 0], ["49.01%", 49.01], ["100%", 100], ["", null]])(
+        'should return "%s" when input is %s',
+        (formattedValue: string, value: number) => {
+            expect(percentFormatter(value)).toEqual(formattedValue);
+        },
+    );
 });
 
 describe("unwrap", () => {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,6 +1,7 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import { isObject } from "lodash";
 import { SDK } from "@gooddata/gooddata-js";
+import isNil = require("lodash/isNil");
 import { name as pkgName, version as pkgVersion } from "../../package.json";
 
 export function setTelemetryHeaders(sdk: SDK, componentName: string, props: object) {
@@ -22,6 +23,10 @@ export function visualizationIsBetaWarning() {
     console.warn(
         "This chart is not production-ready and may not provide the full functionality. Use it at your own risk.",
     );
+}
+
+export function percentFormatter(value: number): string {
+    return isNil(value) ? "" : `${parseFloat(value.toFixed(2))}%`;
 }
 
 export const unwrap = (wrappedObject: any) => {


### PR DESCRIPTION
PR for [SD-345](https://jira.intgdc.com/browse/SD-345)
---
## Changes:
- Show percent values in tooltip when stackMeasuresToPercent is true
- Pass percentage value into tooltip builder
- Add new function percentFormatter into utils helper
- Add Unit tests
---
## PR Checklists
- [x] Successful unit test
- [x] Successful extended test - examples
- [x] Successful extended test - storybook
- [x] Successful AD test - https://github.com/gooddata/gdc-analytical-designer/pull/2143
- [x] Successful KD test - https://github.com/gooddata/gdc-dashboards/pull/1829
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)
- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Squash commits
