### PR TITLE
FEATURE: BB-1479 pivot table grouping performance optimizations

### DIFF
--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -283,9 +283,13 @@ export const getSortsFromModel = (
 };
 
 export const RowLoadingElement = (props: ICellRendererParams) => {
+    if (props.node.rowPinned === "top") {
+        return <span className={"gd-sticky-header-value"}>{props.formatValue(props.value)}</span>;
+    }
+
     // rows that are still loading do not have node.id
     // pinned rows (totals) do not have node.id as well, but we want to render them using the default renderer anyway
-    if (props.node.id !== undefined || props.node.rowPinned) {
+    if (props.node.id !== undefined || props.node.rowPinned === "bottom") {
         // props.value is always unformatted
         // there is props.formattedValue, but this is null for row attributes for some reason
         return <span className={"s-value"}>{props.formatValue(props.value)}</span>;
@@ -735,6 +739,12 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
             intl: this.props.intl,
         };
 
+        const cellRenderer = (params: ICellRendererParams) => {
+            const formattedValue = params.formatValue(params.value);
+            const className = params.node.rowPinned === "top" ? "gd-sticky-header-value" : "s-value";
+            return `<span class="${className}">${formattedValue || ""}</span>`;
+        };
+
         const gridOptions: ICustomGridOptions = {
             // Initial data
             columnDefs,
@@ -805,6 +815,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
                     valueFormatter: params => {
                         return params.value === undefined ? null : params.value;
                     },
+                    cellRenderer,
                 },
                 [COLUMN_ATTRIBUTE_COLUMN]: {
                     cellClass: this.getCellClass("gd-column-attribute-column"),
@@ -835,6 +846,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
                               )
                             : null;
                     },
+                    cellRenderer,
                 },
             },
 

--- a/src/components/core/pivotTable/agGridApiWrapper.ts
+++ b/src/components/core/pivotTable/agGridApiWrapper.ts
@@ -49,24 +49,37 @@ function setPinnedTopRowStyle(gridApi: GridApi, propertyName: string, propertyVa
     rowElement.style[propertyName] = propertyValue;
 }
 
-function getPinnedTopRowCellElement(gridApi: GridApi, attributeId: string): HTMLElement | null {
+function getPinnedTopRowCellElementWrapper(gridApi: GridApi, attributeId: string): HTMLElement | null {
     const pinnedTopRow = getPinnedTopRow(gridApi);
     return pinnedTopRow && pinnedTopRow.cellComps[attributeId]
         ? pinnedTopRow.cellComps[attributeId].eGui
         : null;
 }
 
+function getPinnedTopRowCellElement(gridApi: GridApi, attributeId: string): HTMLElement | null {
+    const pinnedTopRowCellElementWrapper = getPinnedTopRowCellElementWrapper(gridApi, attributeId);
+    return pinnedTopRowCellElementWrapper ? pinnedTopRowCellElementWrapper.querySelector("span") : null;
+}
+
 function addPinnedTopRowCellClass(gridApi: GridApi, attributeId: string, className: string) {
-    const cellElement = getPinnedTopRowCellElement(gridApi, attributeId);
+    const cellElement = getPinnedTopRowCellElementWrapper(gridApi, attributeId);
     if (cellElement !== null) {
         cellElement.classList.add(className);
     }
 }
 
 function removePinnedTopRowCellClass(gridApi: GridApi, attributeId: string, className: string) {
-    const cellElement = getPinnedTopRowCellElement(gridApi, attributeId);
+    const cellElement = getPinnedTopRowCellElementWrapper(gridApi, attributeId);
     if (cellElement !== null) {
         cellElement.classList.remove(className);
+    }
+}
+
+function setPinnedTopRowCellText(gridApi: GridApi, attributeId: string, text: string) {
+    const cellElement = getPinnedTopRowCellElement(gridApi, attributeId);
+
+    if (cellElement !== null) {
+        cellElement.innerText = text;
     }
 }
 
@@ -83,6 +96,8 @@ export default {
     setPinnedTopRowStyle,
     // pinned row cell element
     getPinnedTopRowCellElement,
+    getPinnedTopRowCellElementWrapper,
     addPinnedTopRowCellClass,
     removePinnedTopRowCellClass,
+    setPinnedTopRowCellText,
 };

--- a/src/components/core/pivotTable/stickyGroupHandler.ts
+++ b/src/components/core/pivotTable/stickyGroupHandler.ts
@@ -56,8 +56,6 @@ export const updateStickyHeaders = (
         return;
     }
     apiWrapper.addPinnedTopRowClass(gridApi, "gd-visible-sticky-row");
-    // set the sticky header text
-    gridApi.setPinnedTopRowData([firstVisibleNodeData]);
 
     const lastRowIndex = getGridIndex(lastScrollTop, rowHeight);
     const attributeKeys = Object.keys(firstVisibleNodeData).filter(colIdIsSimpleAttribute);
@@ -67,6 +65,8 @@ export const updateStickyHeaders = (
 
         // the following value is the same as the current one
         if (groupingProvider.isRepeatedValue(columnId, firstVisibleRowIndex + 1)) {
+            // set the sticky header text
+            apiWrapper.setPinnedTopRowCellText(gridApi, columnId, firstVisibleNodeData[columnId]);
             // show the sticky header
             apiWrapper.removePinnedTopRowCellClass(gridApi, columnId, "gd-hidden-sticky-column");
         } else {
@@ -74,7 +74,7 @@ export const updateStickyHeaders = (
             apiWrapper.addPinnedTopRowCellClass(gridApi, columnId, "gd-hidden-sticky-column");
             // if the column has some groups
             if (groupingProvider.isColumnWithGrouping(columnId)) {
-                // show the last cell of the froup temporarily so it scrolls out of the viewport nicely
+                // show the last cell of the group temporarily so it scrolls out of the viewport nicely
                 const currentRowIndex = getGridIndex(currentScrollTop, rowHeight);
                 apiWrapper.addCellClass(gridApi, columnId, currentRowIndex, "gd-cell-show-hidden");
             }

--- a/src/components/core/pivotTable/tests/agGridApiWrapper.spec.tsx
+++ b/src/components/core/pivotTable/tests/agGridApiWrapper.spec.tsx
@@ -4,7 +4,7 @@ import { mount } from "enzyme";
 import { AgGridReact } from "ag-grid-react";
 
 import ApiWrapper from "../agGridApiWrapper";
-import { GridApi, GridReadyEvent, IDatasource, IGetRowsParams } from "ag-grid";
+import { GridApi, GridReadyEvent, IDatasource, IGetRowsParams, ICellRendererParams } from "ag-grid";
 import { ICustomGridOptions } from "../../PivotTable";
 
 describe("agGridApiWrapper", () => {
@@ -30,8 +30,17 @@ describe("agGridApiWrapper", () => {
             columnDefs: [
                 {
                     children: [
-                        { headerName: "Attr #1", field: firstAttributeColumnId },
-                        { headerName: "Attr #2", field: secondAttributeColumnId },
+                        {
+                            headerName: "Attr #1",
+                            field: firstAttributeColumnId,
+                            cellRenderer: (params: ICellRendererParams) => {
+                                return params.value;
+                            },
+                        },
+                        {
+                            headerName: "Attr #2",
+                            field: secondAttributeColumnId,
+                        },
                     ],
                 },
             ],
@@ -71,7 +80,6 @@ describe("agGridApiWrapper", () => {
 
                 expect(cellElement instanceof HTMLElement).toBe(true);
                 expect(cellElement.classList.contains("ag-cell")).toBe(true);
-                expect(cellElement.innerHTML).toEqual(firstAttributeFirstRowValue);
             });
         });
 
@@ -151,15 +159,25 @@ describe("agGridApiWrapper", () => {
     });
 
     describe("pinned top row cell element", () => {
+        describe("getPinnedTopRowCellElementWrapper", () => {
+            it("should return the pinned top row cell element wrapper", async () => {
+                const api = await renderGridReady();
+
+                const cellElement = ApiWrapper.getPinnedTopRowCellElementWrapper(api, firstAttributeColumnId);
+
+                expect(cellElement instanceof HTMLElement).toBe(true);
+                expect(!!cellElement.querySelector("span")).toEqual(true);
+                expect(cellElement.classList.contains("ag-cell")).toBe(true);
+            });
+        });
+
         describe("getPinnedTopRowCellElement", () => {
             it("should return the pinned top row cell element", async () => {
                 const api = await renderGridReady();
 
                 const cellElement = ApiWrapper.getPinnedTopRowCellElement(api, firstAttributeColumnId);
 
-                expect(cellElement instanceof HTMLElement).toBe(true);
                 expect(cellElement.innerHTML).toEqual(firstAttributePinnedTopValue);
-                expect(cellElement.classList.contains("ag-cell")).toBe(true);
             });
         });
 
@@ -170,7 +188,7 @@ describe("agGridApiWrapper", () => {
 
                 ApiWrapper.addPinnedTopRowCellClass(api, firstAttributeColumnId, newPinnedRowCellClassName);
 
-                const pinnedTopRowElement = ApiWrapper.getPinnedTopRowCellElement(
+                const pinnedTopRowElement = ApiWrapper.getPinnedTopRowCellElementWrapper(
                     api,
                     firstAttributeColumnId,
                 );
@@ -190,11 +208,26 @@ describe("agGridApiWrapper", () => {
                     newPinnedRowCellClassName,
                 );
 
-                const pinnedTopRowElement = ApiWrapper.getPinnedTopRowCellElement(
+                const pinnedTopRowElement = ApiWrapper.getPinnedTopRowCellElementWrapper(
                     api,
                     firstAttributeColumnId,
                 );
                 expect(pinnedTopRowElement.classList.contains(newPinnedRowCellClassName)).toBe(false);
+            });
+        });
+
+        describe("setPinnedTopRowCellText", () => {
+            it("should set innerText of the pinned top row cell element", async () => {
+                const api = await renderGridReady();
+
+                ApiWrapper.setPinnedTopRowCellText(api, firstAttributeColumnId, "new_text");
+
+                const pinnedTopRowElement = ApiWrapper.getPinnedTopRowCellElement(
+                    api,
+                    firstAttributeColumnId,
+                );
+
+                expect(pinnedTopRowElement.innerText).toEqual("new_text");
             });
         });
     });

--- a/src/components/core/pivotTable/tests/stickyGroupHandler.spec.ts
+++ b/src/components/core/pivotTable/tests/stickyGroupHandler.spec.ts
@@ -5,10 +5,8 @@ import { GridApi } from "ag-grid";
 
 describe("updateStickyHeaders", () => {
     function getFakeGridApi(fakeGetDisplayedRowAtIndex: any = jest.fn()): GridApi {
-        const setPinnedTopRowData: any = jest.fn();
         const fakeGridApi = {
             getDisplayedRowAtIndex: fakeGetDisplayedRowAtIndex,
-            setPinnedTopRowData,
         };
         return fakeGridApi as GridApi;
     }
@@ -35,8 +33,10 @@ describe("updateStickyHeaders", () => {
             removePinnedTopRowClass: jest.fn(),
             setPinnedTopRowStyle: jest.fn(),
             getPinnedTopRowCellElement: jest.fn(),
+            getPinnedTopRowCellElementWrapper: jest.fn(),
             addPinnedTopRowCellClass: jest.fn(),
             removePinnedTopRowCellClass: jest.fn(),
+            setPinnedTopRowCellText: jest.fn(),
         };
     }
 
@@ -234,6 +234,10 @@ describe("updateStickyHeaders", () => {
             expect(fakeGridApiWrapper.removePinnedTopRowCellClass).not.toHaveBeenCalled();
         });
 
+        it("should not set pinned group header text", () => {
+            expect(fakeGridApiWrapper.setPinnedTopRowCellText).not.toHaveBeenCalled();
+        });
+
         it("should not temporarily show table cell behind", () => {
             expect(fakeGridApiWrapper.addCellClass).not.toHaveBeenCalled();
         });
@@ -277,6 +281,10 @@ describe("updateStickyHeaders", () => {
                 "gd-cell-show-hidden",
             );
         });
+
+        it("should not set pinned group header text", () => {
+            expect(fakeGridApiWrapper.setPinnedTopRowCellText).not.toHaveBeenCalled();
+        });
     });
 
     describe("column with repetitions and grouping when the current cell IS NOT the end of its group", () => {
@@ -310,7 +318,11 @@ describe("updateStickyHeaders", () => {
         });
 
         it("should set pinned group header text", () => {
-            expect(fakeGridApi.setPinnedTopRowData).toHaveBeenCalledWith([{ a_123: "123" }]);
+            expect(fakeGridApiWrapper.setPinnedTopRowCellText).toHaveBeenCalledWith(
+                fakeGridApi,
+                "a_123",
+                "123",
+            );
         });
 
         it("should not temporarily show table cell behind", () => {


### PR DESCRIPTION
We are no longer using official API method `setPinnedTopRowData` in order to set pivot table group sticky header content. We are managing the content manually now.

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`

# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-app-components:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2152
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/1848

# Related Jira tasks

- BB-1479: https://jira.intgdc.com/browse/BB-1479