### PR TITLE
BUGFIX: SD-400 - Show tooltip percent while value of measure display number

### DIFF
--- a/src/components/visualizations/chart/test/tooltip.spec.ts
+++ b/src/components/visualizations/chart/test/tooltip.spec.ts
@@ -33,10 +33,15 @@ describe("tooltip", () => {
     });
 
     describe("getFormattedValueForTooltip()", () => {
-        it.each([[false, 45.2490089197225], [true, null]])(
-            "should return formatted number if stackMeasuresToPercent is %s and percentageValue is %s",
-            (stackMeasuresToPercent: boolean, percentageValue: number) => {
+        it.each([
+            [false, false, 45.24], // stackMeasuresToPercent
+            [false, true, null], // percentageValue
+            [true, true, 45.24], // isDualAxis + isSecondAxis
+        ])(
+            "should return number if isDualChartWithRightAxis is %s, stackMeasuresToPercent is %s, percentageValue is %s",
+            (isDualChartWithRightAxis: boolean, stackMeasuresToPercent: boolean, percentageValue: number) => {
                 const formattedValue = getFormattedValueForTooltip(
+                    isDualChartWithRightAxis,
                     stackMeasuresToPercent,
                     testPointData,
                     testSeparators,
@@ -45,16 +50,26 @@ describe("tooltip", () => {
                 expect(formattedValue).toEqual(" 1");
             },
         );
-        it.each([["0%", 0], ["45.25%", 45.2490089197225], ["100%", 100]])(
-            "should return %s if stackMeasuresToPercent is true and percentageValue is %s",
-            (formattedValue: string, percentageValue: number) => {
-                const tooltip = getFormattedValueForTooltip(
-                    true,
+        it.each([
+            ["0%", false, true, 0],
+            ["45.25%", false, true, 45.2490089197225],
+            ["100%", false, true, 100],
+        ])(
+            "should return %s if isDualChartWithRightAxis is %s, stackMeasuresToPercent is %s, percentageValue is %s",
+            (
+                expectedValue: string,
+                isDualChartWithRightAxis: boolean,
+                stackMeasuresToPercent: boolean,
+                percentageValue: number,
+            ) => {
+                const formattedValue = getFormattedValueForTooltip(
+                    isDualChartWithRightAxis,
+                    stackMeasuresToPercent,
                     testPointData,
                     testSeparators,
                     percentageValue,
                 );
-                expect(tooltip).toEqual(formattedValue);
+                expect(formattedValue).toEqual(expectedValue);
             },
         );
     });

--- a/src/components/visualizations/chart/tooltip.ts
+++ b/src/components/visualizations/chart/tooltip.ts
@@ -14,12 +14,14 @@ export function formatValueForTooltip(
 }
 
 export function getFormattedValueForTooltip(
+    isDualChartWithRightAxis: boolean,
     stackMeasuresToPercent: boolean,
     point: IPoint,
     separators?: ISeparators,
     percentageValue?: number,
 ): string {
-    const isNotStackToPercent = stackMeasuresToPercent === false || isNil(percentageValue);
+    const isNotStackToPercent =
+        stackMeasuresToPercent === false || isNil(percentageValue) || isDualChartWithRightAxis;
     return isNotStackToPercent
         ? formatValueForTooltip(point.y, point.format, separators)
         : percentFormatter(percentageValue);


### PR DESCRIPTION
PR for [SD-400](https://jira.intgdc.com/browse/SD-400)
- Fix tooltip content for dual axes chart

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)
- [x] Squash commits

# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-app-components: https://github.com/gooddata/gdc-app-components/pull/545
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2186
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/1882

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
