### PR TITLE
BUGFIX: SD-425 Different reports in case of loading NULL fact

### DIFF
--- a/src/components/visualizations/chart/chartOptions/extendedStackingChartOptions.ts
+++ b/src/components/visualizations/chart/chartOptions/extendedStackingChartOptions.ts
@@ -27,6 +27,7 @@ export function getCategoriesForTwoAttributes(
     name: string;
     categories: string[];
 }> {
+    const keys: string[] = [];
     const { items: children } = viewByAttribute;
     const { items: parent } = viewByParentAttribute;
 
@@ -36,21 +37,33 @@ export function getCategoriesForTwoAttributes(
             parentAttr: Execution.IResultAttributeHeaderItem,
             index: number,
         ) => {
-            const key: string = get(parentAttr, "attributeHeaderItem.name", "");
+            const uri: string = get(parentAttr, "attributeHeaderItem.uri", "");
+            const name: string = get(parentAttr, "attributeHeaderItem.name", "");
             const value: string = get(children[index], "attributeHeaderItem.name", "");
 
-            const childCategories: string[] = result[key] || [];
+            const childCategories: string[] = get(result, `${uri}.categories`, []);
+
+            if (!childCategories.length) {
+                keys.push(uri);
+            }
 
             return {
                 ...result,
-                [key]: [...childCategories, value], // append value
+                [uri]: {
+                    name,
+                    categories: [...childCategories, value], // append value
+                },
             };
         },
         {},
     );
 
-    return Object.keys(combinedResult).map((name: string) => ({
-        name,
-        categories: combinedResult[name],
-    }));
+    return keys.map((key: string) => {
+        const { name, categories } = combinedResult[key];
+
+        return {
+            name,
+            categories,
+        };
+    });
 }

--- a/src/components/visualizations/chart/chartOptions/test/extendedStackingChartOptions.spec.ts
+++ b/src/components/visualizations/chart/chartOptions/test/extendedStackingChartOptions.spec.ts
@@ -78,19 +78,19 @@ describe("getCategoriesForTwoAttributes", () => {
                 },
                 {
                     attributeHeaderItem: {
-                        uri: "/gdc/md/storybook/obj/4/elements?id=1",
+                        uri: "/gdc/md/storybook/obj/4/elements?id=2",
                         name: "Inside Sales",
                     },
                 },
                 {
                     attributeHeaderItem: {
-                        uri: "/gdc/md/storybook/obj/4/elements?id=1",
+                        uri: "/gdc/md/storybook/obj/4/elements?id=2",
                         name: "Inside Sales",
                     },
                 },
                 {
                     attributeHeaderItem: {
-                        uri: "/gdc/md/storybook/obj/4/elements?id=1",
+                        uri: "/gdc/md/storybook/obj/4/elements?id=3",
                         name: "Common Sales",
                     },
                 },
@@ -110,6 +110,71 @@ describe("getCategoriesForTwoAttributes", () => {
             {
                 name: "Common Sales",
                 categories: ["Lost"],
+            },
+        ]);
+    });
+
+    it("should return categories when attribute names have numerical values", () => {
+        const viewByAttribute: IUnwrappedAttributeHeadersWithItems = {
+            ...attributeHeader,
+            items: [
+                {
+                    attributeHeaderItem: {
+                        uri: "/gdc/md/storybook/obj/5/elements?id=1",
+                        name: "Jack",
+                    },
+                },
+                {
+                    attributeHeaderItem: {
+                        uri: "/gdc/md/storybook/obj/5/elements?id=2",
+                        name: "David",
+                    },
+                },
+                {
+                    attributeHeaderItem: {
+                        uri: "/gdc/md/storybook/obj/5/elements?id=3",
+                        name: "Ben",
+                    },
+                },
+            ],
+        };
+        const viewByParentAttribute: IUnwrappedAttributeHeadersWithItems = {
+            ...attributeHeader,
+            items: [
+                {
+                    attributeHeaderItem: {
+                        uri: "/gdc/md/storybook/obj/4/elements?id=3",
+                        name: "3",
+                    },
+                },
+                {
+                    attributeHeaderItem: {
+                        uri: "/gdc/md/storybook/obj/4/elements?id=2",
+                        name: "2",
+                    },
+                },
+                {
+                    attributeHeaderItem: {
+                        uri: "/gdc/md/storybook/obj/4/elements?id=1",
+                        name: "1",
+                    },
+                },
+            ],
+        };
+
+        const categories = getCategoriesForTwoAttributes(viewByAttribute, viewByParentAttribute);
+        expect(categories).toEqual([
+            {
+                name: "3",
+                categories: ["Jack"],
+            },
+            {
+                name: "2",
+                categories: ["David"],
+            },
+            {
+                name: "1",
+                categories: ["Ben"],
             },
         ]);
     });


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards)
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2209
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/1926

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
