### PR TITLE
BUGFIX: BB-1519 Make drilling types backward compatible, reexport color types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The REST API versions in the table are just for your information as the values a
 
 - We ask developers to consider using the Headline component instead of the KPI component. The KPI component may be eventually marked as deprecated in one of the next major versions.
 
+## 6.3.2
+
+May 9, 2019
+
+### Changed
+
+- Fixed drilling context types that were changed in version 6.3.0 resulting in major change. Types are now backward compatible with pre 6.3.0 versions.
+
 ## 6.3.1
 
 April 29, 2019

--- a/src/components/visualizations/utils/drilldownEventing.ts
+++ b/src/components/visualizations/utils/drilldownEventing.ts
@@ -13,10 +13,8 @@ import {
 } from '../../../constants/visualizationTypes';
 import {
     IDrillEvent,
-    DrillEventContext,
-    IDrillEventContextGroup,
+    IDrillEventContext,
     IDrillEventIntersectionElement,
-    IDrillEventContextPoint,
     IDrillEventContextTable,
     IDrillPoint
 } from '../../../interfaces/DrillEvents';
@@ -90,7 +88,7 @@ function fireEvent(onFiredDrillEvent: OnFiredDrillEvent, data: IDrillEvent, targ
 function composeDrillContextGroup(
     { points }: IHighchartsChartDrilldownEvent,
     chartType: ChartType
-): IDrillEventContextGroup {
+): IDrillEventContext {
     const contextPoints: IDrillPoint[] = points.map((point: IHighchartsPointObject) => {
         return {
             x: point.x,
@@ -108,8 +106,8 @@ function composeDrillContextGroup(
 function composeDrillContextPoint(
     { point }: IHighchartsChartDrilldownEvent,
     chartType: ChartType
-): IDrillEventContextPoint {
-    const context: IDrillEventContextPoint = {
+): IDrillEventContext {
+    const context: IDrillEventContext = {
         type: chartType,
         element: getClickableElementNameByChartType(chartType),
         intersection: point.drillIntersection
@@ -140,7 +138,7 @@ const chartClickDebounced = debounce((drillConfig: IDrillConfig, event: IHighcha
         usedChartType = get(event, ['point', 'series', 'options', 'type'], chartType);
     }
 
-    const drillContext: DrillEventContext = isGroupHighchartsDrillEvent(event)
+    const drillContext: IDrillEventContext = isGroupHighchartsDrillEvent(event)
         ? composeDrillContextGroup(event, usedChartType)
         : composeDrillContextPoint(event, usedChartType);
 

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -10,6 +10,19 @@ import { IMappingHeader } from './MappingHeader';
 
 export { DEFAULT_COLOR_PALETTE } from '../components/visualizations/utils/color';
 
+// reexport types to ensure backward compatibility (see BB-1519)
+export type IRGBColor = IColor;
+export {
+    GuidType,
+    RGBType,
+    IGuidColorItem,
+    IRGBColorItem,
+    IColorItem,
+    IColorMappingProperty,
+    IPropertiesControls,
+    IProperties
+} from '@gooddata/gooddata-js';
+
 export type IDataLabelsVisible = string | boolean;
 
 export interface IDataLabelsConfig {

--- a/src/interfaces/DrillEvents.ts
+++ b/src/interfaces/DrillEvents.ts
@@ -1,12 +1,12 @@
 // (C) 2007-2018 GoodData Corporation
 import { AFM } from '@gooddata/typings';
 import {
-    ChartElementType,
-    ChartType,
     HeadlineElementType,
     HeadlineType,
     TableElementType,
-    TableType
+    TableType,
+    VisElementType,
+    VisType
 } from '../constants/visualizationTypes';
 
 export interface IDrillableItemUri {
@@ -60,17 +60,6 @@ export interface IDrillEventContextHeadline {
     intersection: IDrillEventIntersectionElement[];
 }
 
-// Drill context for chart
-export interface IDrillEventContextPoint {
-    type: ChartType;
-    element: ChartElementType;
-    x?: number;
-    y?: number;
-    z?: number;
-    value?: string;
-    intersection: IDrillEventIntersectionElement[];
-}
-
 // Chart series point with intersection element
 export interface IDrillPoint {
     x: number;
@@ -78,23 +67,23 @@ export interface IDrillPoint {
     intersection: IDrillEventIntersectionElement[];
 }
 
-// Drill context for chart element group (multiple series + click on axis value)
-// where every point has own intersection
-export interface IDrillEventContextGroup {
-    type: ChartType;
-    element: ChartElementType;
-    points: IDrillPoint[];
+// Shared drill context for all visualizations used in onFiredDrillEvent
+export interface IDrillEventContext {
+    type: VisType;
+    element: VisElementType;
+    x?: number;
+    y?: number;
+    z?: number;
+    columnIndex?: number;
+    rowIndex?: number;
+    row?: any[];
+    value?: string;
+    intersection?: IDrillEventIntersectionElement[];
+    points?: IDrillPoint[];
 }
-
-// Drill context for all visualization types
-export type DrillEventContext =
-    IDrillEventContextTable |
-    IDrillEventContextHeadline |
-    IDrillEventContextPoint |
-    IDrillEventContextGroup;
 
 // IDrillEvent is a parameter of the onFiredDrillEvent is callback
 export interface IDrillEvent {
     executionContext: AFM.IAfm;
-    drillContext: DrillEventContext;
+    drillContext: IDrillEventContext;
 }


### PR DESCRIPTION
This PR fixes TS types incompatibility introduced as minor breaking changes.

1. Drilling typing is more strict https://github.com/gooddata/gooddata-react-components/commit/4e1a23e7
Fixed by simplifying drilling type so they look like the previous version.

2. Moved export of IRGBColor and other to another repo  and https://github.com/gooddata/gooddata-react-components/commit/31b9339d
Fixed by reexporting original types.

This change is targeted only to 6.3 branch and will not be merged to 7.0 branch. 
Also, changes are done only in types, not in runtime code = no tests needed.
