### PR TITLE
RELATED: RAIL-1539 distinguish active row totals

### DIFF
--- a/src/helpers/tests/agGrid.spec.ts
+++ b/src/helpers/tests/agGrid.spec.ts
@@ -116,6 +116,8 @@ describe("getRowTotals", () => {
                 fixture.executionResult.totals,
                 [...rowFields, ...columnFields],
                 fixture.executionResponse.dimensions[0].headers,
+                fixture.executionRequest.resultSpec,
+                fixture.executionRequest.afm.measures.map((measure: AFM.IMeasure) => measure.localIdentifier),
                 intl,
             ),
         ).toEqual([
@@ -149,6 +151,7 @@ describe("getRowTotals", () => {
                     count: 3,
                     headerKey: "a_2211",
                 },
+                rowTotalActiveMeasures: ["m_0", "m_1"],
                 type: {
                     rowTotal: true,
                 },
@@ -183,6 +186,7 @@ describe("getRowTotals", () => {
                     count: 3,
                     headerKey: "a_2211",
                 },
+                rowTotalActiveMeasures: ["m_0"],
                 type: {
                     rowTotal: true,
                 },
@@ -202,6 +206,8 @@ describe("getRowTotals", () => {
                 fixture.executionResult.totals,
                 [...rowFields, ...columnFields],
                 fixture.executionResponse.dimensions[0].headers,
+                fixture.executionRequest.resultSpec,
+                fixture.executionRequest.afm.measures.map((measure: AFM.IMeasure) => measure.localIdentifier),
                 intl,
             ),
         ).toBe(null);

--- a/src/interfaces/AGGrid.ts
+++ b/src/interfaces/AGGrid.ts
@@ -18,6 +18,7 @@ export interface IGridTotalsRow {
         count: number;
         headerKey: string;
     };
+    rowTotalActiveMeasures?: string[];
     [key: string]: any;
 }
 


### PR DESCRIPTION
[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-app-components: https://github.com/gooddata/gdc-app-components/pull/561
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2215
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/1940
