### PR TITLE
 BUGFIX: BB-1519 Make drilling types backward compatible,  RELATED: BB-1519 Reexport color types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The REST API versions in the table are just for your information as the values a
 
 - We ask developers to consider using the Headline component instead of the KPI component. The KPI component may be eventually marked as deprecated in one of the next major versions.
 
+## 6.3.2
+
+ May 9, 2019
+
+ ### Changed
+
+ - Fixed drilling context types that were changed in version 6.3.0 resulting in major change. Types are now backward compatible with pre 6.3.0 versions.
+
 ## 6.3.1
 
 April 29, 2019

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -10,6 +10,19 @@ import { IMappingHeader } from './MappingHeader';
 
 export { DEFAULT_COLOR_PALETTE } from '../components/visualizations/utils/color';
 
+// reexport types to ensure backward compatibility (see BB-1519)
+export type IRGBColor = IColor;
+export {
+    GuidType,
+    RGBType,
+    IGuidColorItem,
+    IRGBColorItem,
+    IColorItem,
+    IColorMappingProperty,
+    IPropertiesControls,
+    IProperties
+} from '@gooddata/gooddata-js';
+
 export type IDataLabelsVisible = string | boolean;
 
 export interface IDataLabelsConfig {

--- a/src/interfaces/DrillEvents.ts
+++ b/src/interfaces/DrillEvents.ts
@@ -6,7 +6,9 @@ import {
     HeadlineElementType,
     HeadlineType,
     TableElementType,
-    TableType
+    TableType,
+    VisElementType,
+    VisType
 } from '../constants/visualizationTypes';
 
 export interface IDrillableItemUri {
@@ -87,14 +89,24 @@ export interface IDrillEventContextGroup {
 }
 
 // Drill context for all visualization types
-export type DrillEventContext =
-    IDrillEventContextTable |
-    IDrillEventContextHeadline |
-    IDrillEventContextPoint |
-    IDrillEventContextGroup;
+export interface IDrillEventContext {
+    type: VisType; // type of visualization
+    element: VisElementType; // type of visualization element drilled
+    x?: number; // chart x coordinate (if supported)
+    y?: number; // chart y coordinate (if supported)
+    z?: number; // chart z coordinate (if supported)
+    columnIndex?: number;
+    rowIndex?: number;
+    row?: any[]; // table row data of the drilled row
+    value?: string; // cell or element value drilled
+    // some drill headers that are relevant for current drill element
+    intersection: IDrillEventIntersectionElement[];
+    // A collection of chart series points (if available)
+    points?: IDrillPoint[];
+}
 
 // IDrillEvent is a parameter of the onFiredDrillEvent is callback
 export interface IDrillEvent {
     executionContext: AFM.IAfm;
-    drillContext: DrillEventContext;
+    drillContext: IDrillEventContext;
 }


### PR DESCRIPTION
This PR fixes TS types incompatibility introduced as minor breaking changes.

1. Drilling typing is more strict https://github.com/gooddata/gooddata-react-components/commit/4e1a23e7
Fixed by simplifying drilling types so they look like the previous version.

2. Moved export of IRGBColor and other to another repo  and https://github.com/gooddata/gooddata-react-components/commit/31b9339d
Fixed by reexporting original types.
