### PR TITLE
BUGFIX: RAIL-1562 Pivot table which isn't applied filter can't render by Visualization component

### DIFF
--- a/src/components/uri/Visualization.tsx
+++ b/src/components/uri/Visualization.tsx
@@ -350,7 +350,15 @@ export class VisualizationWrapped extends React.Component<
             case VisualizationTypes.TABLE:
                 return <TableComponent {...commonProps} {...sourceProps} totals={totals} />;
             case VisualizationTypes.PIVOT_TABLE: {
-                const pivotBucketProps = mdObjectToPivotBucketProps(mdObject, filtersFromProps);
+                const processedVisualizationObject = {
+                    ...mdObject,
+                    content: fillMissingTitles(mdObject.content, locale),
+                };
+                this.exportTitle = get(processedVisualizationObject, "meta.title", "");
+                const pivotBucketProps = mdObjectToPivotBucketProps(
+                    processedVisualizationObject,
+                    filtersFromProps,
+                );
                 // we do not need to pass totals={totals} because BucketPivotTable deals with changes in totals itself
                 return <PivotTableComponent {...commonProps} {...pivotBucketProps} />;
             }

--- a/src/helpers/MdObjectHelper.ts
+++ b/src/helpers/MdObjectHelper.ts
@@ -12,9 +12,7 @@ import { mergeFiltersToAfm } from "./afmHelper";
 function getTotals(
     mdObject: VisualizationObject.IVisualizationObject,
 ): VisualizationObject.IVisualizationTotal[] {
-    const attributes: VisualizationObject.IBucket = mdObject.content.buckets.find(
-        bucket => bucket.localIdentifier === ATTRIBUTE,
-    );
+    const attributes = mdObject.content.buckets.find(bucket => bucket.localIdentifier === ATTRIBUTE);
     return get(attributes, "totals", []);
 }
 
@@ -70,13 +68,20 @@ export const mdObjectToPivotBucketProps = (
         (rowBucket && (rowBucket.items as VisualizationObject.IVisualizationAttribute[])) || [];
     const columns: IPivotTableBucketProps["columns"] =
         (columnBucket && (columnBucket.items as VisualizationObject.IVisualizationAttribute[])) || [];
-    const sortBy: IPivotTableBucketProps["sortBy"] = JSON.parse(mdObject.content.properties).sortItems || [];
-    const totals: IPivotTableBucketProps["totals"] = rowBucket.totals || [];
+    const sortBy: IPivotTableBucketProps["sortBy"] =
+        (mdObject &&
+            mdObject.content &&
+            mdObject.content.properties &&
+            JSON.parse(mdObject.content.properties).sortItems) ||
+        [];
+    const totals: IPivotTableBucketProps["totals"] = (rowBucket && rowBucket.totals) || [];
 
     const afmWithoutMergedFilters = DataLayer.toAfmResultSpec(mdObject.content).afm;
+    afmWithoutMergedFilters.filters = afmWithoutMergedFilters.filters || [];
+
     const afm = mergeFiltersToAfm(afmWithoutMergedFilters, filtersFromProps);
 
-    const filters: VisualizationInput.IFilter[] = afm.filters.filter(afmFilter => {
+    const filters: VisualizationInput.IFilter[] = (afm.filters || []).filter(afmFilter => {
         // Filter out expression filters which are not supported in bucket interface
         return AFM.isDateFilter(afmFilter) || AFM.isAttributeFilter(afmFilter);
     }) as AFM.FilterItem[];


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-app-components:
- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
