### PR TITLE
BUGFIX: SD-461 only check width when shapeArgs existed for hiding data label

### DIFF
--- a/src/components/visualizations/chart/highcharts/plugins/autohideLabels/autohideColumnLabels.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/autohideLabels/autohideColumnLabels.ts
@@ -26,6 +26,7 @@ import {
     getShapeVisiblePart,
     hasShape,
 } from "../../dataLabelsHelpers";
+import { IDataPoint } from "../../../../../../interfaces/Config";
 
 const toggleNonStackedChartLabels = (
     visiblePoints: any,
@@ -83,21 +84,24 @@ const toggleStackedChartLabels = (visiblePoints: any, axisRangeForAxes: IAxisRan
         return null;
     };
 
-    const isOverlappingWidth = visiblePoints.filter(hasDataLabel).some((point: any) => {
-        const { dataLabel } = point;
-        if (dataLabel) {
-            const labelWidth = dataLabel.width + 2 * dataLabel.padding;
-            return labelWidth > point.shapeArgs.width;
-        }
-        return false;
-    });
-
-    if (isOverlappingWidth) {
+    if (isOverlappingWidth(visiblePoints)) {
         hideDataLabels(visiblePoints);
     } else {
         visiblePoints.forEach(toggleLabel);
     }
 };
+
+export function isOverlappingWidth(visiblePoints: IDataPoint[]) {
+    return visiblePoints.filter(hasDataLabel).some((point: IDataPoint) => {
+        const { dataLabel, shapeArgs } = point;
+
+        if (dataLabel && shapeArgs) {
+            const labelWidth = dataLabel.width + 2 * dataLabel.padding;
+            return labelWidth > shapeArgs.width;
+        }
+        return false;
+    });
+}
 
 function areNeighborsOverlapping(neighbors: any[]) {
     return neighbors.some(labelsPair => {

--- a/src/components/visualizations/chart/highcharts/plugins/autohideLabels/test/autohideColumnLabels.spec.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/autohideLabels/test/autohideColumnLabels.spec.ts
@@ -1,5 +1,6 @@
-// (C) 2007-2018 GoodData Corporation
-import { getStackLabelPointsForDualAxis } from "../autohideColumnLabels";
+// (C) 2007-2019 GoodData Corporation
+import { getStackLabelPointsForDualAxis, isOverlappingWidth } from "../autohideColumnLabels";
+import { IDataPoint } from "../../../../../../../interfaces/Config";
 
 describe("getStackLabelPointsForDualAxis", () => {
     it("should return points for column0 and column", () => {
@@ -30,5 +31,44 @@ describe("getStackLabelPointsForDualAxis", () => {
             stacks[0].column0[1],
             stacks[1].column1[1],
         ]);
+    });
+});
+
+describe("isOverlappingWidth", () => {
+    const visiblePointsWithoutShape: IDataPoint[] = [
+        {
+            dataLabel: {
+                width: 98,
+                padding: 2,
+            },
+        },
+    ];
+
+    it("should return true when point has datalabel width greater than shape width", () => {
+        const visiblePointsWithShape: IDataPoint[] = [
+            {
+                ...visiblePointsWithoutShape[0],
+                shapeArgs: {
+                    width: 100,
+                },
+            },
+        ];
+        expect(isOverlappingWidth(visiblePointsWithShape)).toEqual(true);
+    });
+
+    it("should return false when point has datalabel width less than shape width", () => {
+        const visiblePointsWithShape: IDataPoint[] = [
+            {
+                ...visiblePointsWithoutShape[0],
+                shapeArgs: {
+                    width: 105,
+                },
+            },
+        ];
+        expect(isOverlappingWidth(visiblePointsWithShape)).toEqual(false);
+    });
+
+    it("should return false when shapeArgs is undefined", () => {
+        expect(isOverlappingWidth(visiblePointsWithoutShape)).toEqual(false);
     });
 });

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -14,6 +14,8 @@ export type IDataLabelsVisible = string | boolean;
 
 export interface IDataLabelsConfig {
     visible?: IDataLabelsVisible;
+    width?: number;
+    padding?: number;
 }
 
 export interface IColorMapping {
@@ -140,4 +142,16 @@ export interface ISeriesItem {
     labelKey?: string;
     stack?: number;
     stacking?: string;
+}
+
+export interface IShapeArgsConfig {
+    width?: number;
+    heigth?: number;
+    x?: number;
+    y?: number;
+}
+
+export interface IDataPoint {
+    dataLabel?: IDataLabelsConfig;
+    shapeArgs?: IShapeArgsConfig;
 }


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-app-components: https://github.com/gooddata/gdc-app-components/pull/575
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2247
- gdc-dashboard: https://github.com/gooddata/gdc-dashboards/pull/1983

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
