### PR TITLE
BUGFIX: SD-441 fix tooltip is rendered off screen; SD-442 disable saturate others on hover for line chart

### DIFF
--- a/src/components/visualizations/chart/chartOptionsBuilder.ts
+++ b/src/components/visualizations/chart/chartOptionsBuilder.ts
@@ -935,8 +935,9 @@ export function buildTooltipTreemapFactory(
     const { separators } = config;
 
     return (point: IPoint) => {
-        if (point.id !== undefined) {
-            // no tooltip for root points
+        // root point don't have parent property
+        // no tooltip for root points
+        if (point.parent === undefined) {
             return null;
         }
         const formattedValue = formatValueForTooltip(point.value, point.format, separators);

--- a/src/components/visualizations/chart/highcharts/commonConfiguration.ts
+++ b/src/components/visualizations/chart/highcharts/commonConfiguration.ts
@@ -1,9 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import cloneDeep = require("lodash/cloneDeep");
 import invoke = require("lodash/invoke");
 import get = require("lodash/get");
 import set = require("lodash/set");
 import isEmpty = require("lodash/isEmpty");
+import { css } from "highcharts";
 import { chartClick } from "../../utils/drilldownEventing";
 import { styleVariables } from "../../styles/variables";
 import { isOneOfTypes } from "../../utils/common";
@@ -19,6 +20,10 @@ export const MAX_POINT_WIDTH = 100;
 export const HOVER_BRIGHTNESS = 0.1;
 export const MINIMUM_HC_SAFE_BRIGHTNESS = Number.MIN_VALUE;
 
+function handleTooltipOffScreen(renderTo: Highcharts.HTMLDOMElement) {
+    // allow tooltip over the container wrapper
+    css(renderTo, { overflow: "visible" });
+}
 let previousChart: any = null;
 
 const BASE_TEMPLATE: any = {
@@ -97,6 +102,11 @@ const BASE_TEMPLATE: any = {
         animation: false,
         style: {
             fontFamily: 'Avenir, "Helvetica Neue", Arial, sans-serif',
+        },
+        events: {
+            afterGetContainer() {
+                handleTooltipOffScreen(this.renderTo);
+            },
         },
     },
 };

--- a/src/components/visualizations/chart/highcharts/lineConfiguration.ts
+++ b/src/components/visualizations/chart/highcharts/lineConfiguration.ts
@@ -19,6 +19,9 @@ const LINE_TEMPLATE: any = {
                 hover: {
                     lineWidth: LINE_WIDTH + 1,
                 },
+                inactive: {
+                    opacity: 1,
+                },
             },
         },
         column: {

--- a/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
+++ b/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
@@ -2612,6 +2612,7 @@ describe("chartOptionsBuilder", () => {
 
     describe("buildTooltipTreemapFactory", () => {
         const point: IPoint = {
+            parent: "1",
             category: {
                 name: "category",
             },


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist
- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)

# Demo

AD: https://client-demo.na.intgdc.com:50019/analyze/

# Related Jira tasks
- SD-441: https://jira.intgdc.com/browse/SD-441
- SD-442: https://jira.intgdc.com/browse/SD-442
