### PR TITLE
BUGFIX: SD-480 fix showing tooltip for treemap

### DIFF
--- a/src/components/afm/tests/Heatmap.spec.tsx
+++ b/src/components/afm/tests/Heatmap.spec.tsx
@@ -1,6 +1,6 @@
 // (C) 2007-2018 GoodData Corporation
 import * as React from "react";
-import { mount } from "enzyme";
+import { shallow } from "enzyme";
 import { testUtils } from "@gooddata/js-utils";
 
 import { Heatmap } from "../Heatmap";
@@ -17,8 +17,8 @@ describe("Heatmap", () => {
         ],
     };
 
-    it("should provide default resultSpec to core Heatmap with attributes", () => {
-        const wrapper = mount(
+    it("should provide default resultSpec to core Heatmap with attributes", async () => {
+        const wrapper = shallow(
             <Heatmap
                 projectId="prId"
                 afm={afmWithAttr}
@@ -27,7 +27,7 @@ describe("Heatmap", () => {
             />,
         );
 
-        return testUtils.delay().then(() => {
+        await testUtils.delay().then(() => {
             wrapper.update();
 
             const dimensions = wrapper.find(CoreHeatmap).props().resultSpec.dimensions;

--- a/src/components/visualizations/chart/chartOptionsBuilder.ts
+++ b/src/components/visualizations/chart/chartOptionsBuilder.ts
@@ -897,9 +897,8 @@ export function buildTooltipTreemapFactory(
     const { separators } = config;
 
     return (point: IPointData) => {
-        // root point don't have parent property
-        // no tooltip for root points
-        if (point.parent === undefined) {
+        // show tooltip for leaf node only
+        if (!point.node || point.node.isLeaf === false) {
             return null;
         }
         const formattedValue = formatValueForTooltip(point.value, point.format, separators);

--- a/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
+++ b/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
@@ -2652,9 +2652,11 @@ describe("chartOptionsBuilder", () => {
 
     describe("buildTooltipTreemapFactory", () => {
         const point: IPointData = {
-            parent: "1",
             category: {
                 name: "category",
+            },
+            node: {
+                isLeaf: true,
             },
             value: 300,
             name: "point name",


### PR DESCRIPTION
[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2255
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2001

# Related Jira tasks
- SD-480: https://jira.intgdc.com/browse/SD-480