### PR TITLE
BUGFIX: SD-494 disable saturate other element on hover for combo line line

### DIFF
--- a/src/components/visualizations/chart/highcharts/test/comboConfiguration.spec.ts
+++ b/src/components/visualizations/chart/highcharts/test/comboConfiguration.spec.ts
@@ -1,5 +1,7 @@
 // (C) 2019 GoodData Corporation
-import { getDefaultChartType } from "../comboConfiguration";
+import get = require("lodash/get");
+import { IChartConfig } from "../../../../../interfaces/Config";
+import { getDefaultChartType, getComboConfiguration } from "../comboConfiguration";
 import { VisualizationTypes } from "../../../../../constants/visualizationTypes";
 
 describe("Combo Configuration", () => {
@@ -7,7 +9,7 @@ describe("Combo Configuration", () => {
 
     describe("getDefaultChartType", () => {
         it.each([COLUMN, LINE, AREA])("should return '%s' when both y axes have same chart type", type => {
-            const config = {
+            const config: IChartConfig = {
                 primaryChartType: type,
                 secondaryChartType: type,
             };
@@ -18,7 +20,7 @@ describe("Combo Configuration", () => {
         it.each([[COLUMN, LINE], [COLUMN, AREA], [LINE, COLUMN], [AREA, COLUMN]])(
             "should return 'column' if primaryChartType=%s and secondaryChartType=%s",
             (primaryChartType, secondaryChartType) => {
-                const config = {
+                const config: IChartConfig = {
                     primaryChartType,
                     secondaryChartType,
                 };
@@ -28,12 +30,41 @@ describe("Combo Configuration", () => {
         );
 
         it("should return 'line' when there is no column chart type", () => {
-            const config = {
+            const config: IChartConfig = {
                 primaryChartType: LINE,
                 secondaryChartType: AREA,
             };
 
             expect(getDefaultChartType(config)).toEqual(LINE);
         });
+    });
+
+    it("should disable saturation on other line series in line_line combo chart?", () => {
+        const config: IChartConfig = {
+            primaryChartType: LINE,
+            secondaryChartType: LINE,
+        };
+        const {
+            plotOptions: { series: series },
+        } = getComboConfiguration(config);
+        expect(series.states.inactive.opacity).toBe(1);
+    });
+
+    it("should not disable saturation other series for another kind of combo", () => {
+        const config: IChartConfig = {
+            primaryChartType: LINE,
+            secondaryChartType: AREA,
+        };
+        const {
+            plotOptions: { series: series },
+        } = getComboConfiguration(config);
+        expect(get(series, "states.inactive.opacity")).not.toBe(1);
+    });
+
+    it("should not disable saturation other series for default combo", () => {
+        const {
+            plotOptions: { series: series },
+        } = getComboConfiguration({});
+        expect(get(series, "states.inactive.opacity")).not.toBe(1);
     });
 });


### PR DESCRIPTION
[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2290
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2024

# Related Jira tasks
- SD-494: https://jira.intgdc.com/browse/SD-494