### PR TITLE
RELATED: ONE-3831 Use updated goodstrap and wrap pivot table

### DIFF
--- a/examples/src/components/AttributeElementsExample.jsx
+++ b/examples/src/components/AttributeElementsExample.jsx
@@ -56,7 +56,7 @@ export class AttributeElementsExample extends Component {
                         return (
                             <div>
                                 <button
-                                    className="button button-secondary s-show-more-filters-button"
+                                    className="gd-button gd-button-secondary s-show-more-filters-button"
                                     onClick={loadMore}
                                     disabled={isLoading || offset + count === total}
                                 >

--- a/examples/src/components/CustomVisualizationExample.jsx
+++ b/examples/src/components/CustomVisualizationExample.jsx
@@ -87,7 +87,7 @@ export class CustomVisualization extends Component {
                 </ResponsiveContainer>
                 <div>
                     <p>
-                        <button className="button button-secondary" onClick={this.toggleDisplayRawData}>
+                        <button className="gd-button gd-button-secondary" onClick={this.toggleDisplayRawData}>
                             Toggle Raw Data
                         </button>
                     </p>

--- a/examples/src/components/DrillWithExternalDataExample.jsx
+++ b/examples/src/components/DrillWithExternalDataExample.jsx
@@ -317,7 +317,7 @@ export class DrillWithExternalDataExample extends React.Component {
                                 {state.name}&nbsp;
                                 <button
                                     onClick={this.onStateClear}
-                                    className="button button-primary button-small button-icon-only icon-cross s-employee-heading-clear-state"
+                                    className="gd-button gd-button-primary gd-button-small gd-button-icon-only icon-cross s-employee-heading-clear-state"
                                 />
                             </span>
                         )}
@@ -326,7 +326,7 @@ export class DrillWithExternalDataExample extends React.Component {
                                 {location.name}&nbsp;
                                 <button
                                     onClick={this.onLocationClear}
-                                    className="button button-primary button-small button-icon-only icon-cross s-employee-heading-clear-location"
+                                    className="gd-button gd-button-primary gd-button-small gd-button-icon-only icon-cross s-employee-heading-clear-location"
                                 />
                             </span>
                         )}
@@ -341,7 +341,7 @@ export class DrillWithExternalDataExample extends React.Component {
                                 {state.name}&nbsp;
                                 <button
                                     onClick={this.onStateClear}
-                                    className="button button-primary button-small button-icon-only icon-cross s-sales-heading-clear-state"
+                                    className="gd-button gd-button-primary gd-button-small gd-button-icon-only icon-cross s-sales-heading-clear-state"
                                 />
                             </span>
                         )}
@@ -350,7 +350,7 @@ export class DrillWithExternalDataExample extends React.Component {
                                 {location.name}&nbsp;
                                 <button
                                     onClick={this.onLocationClear}
-                                    className="button button-primary button-small button-icon-only icon-cross s-sales-heading-clear-location"
+                                    className="gd-button gd-button-primary gd-button-small gd-button-icon-only icon-cross s-sales-heading-clear-location"
                                 />
                             </span>
                         )}

--- a/examples/src/components/DynamicSortingExample.jsx
+++ b/examples/src/components/DynamicSortingExample.jsx
@@ -168,9 +168,9 @@ export class DynamicSortingExample extends Component {
                         return (
                             <button
                                 key={sortOptionItem.key}
-                                className={`sorting-option button button-secondary s-${sortOptionItem.key} ${
-                                    sortOption.key === sortOptionItem.key ? " is-active" : ""
-                                }`}
+                                className={`sorting-option gd-button gd-button-secondary s-${
+                                    sortOptionItem.key
+                                } ${sortOption.key === sortOptionItem.key ? " is-active" : ""}`}
                                 onClick={this.onSortOptionChange(sortOptionItem)}
                             >
                                 {sortOptionItem.label}
@@ -181,7 +181,7 @@ export class DynamicSortingExample extends Component {
                 <div className="sorting-options">
                     <span className="sorting-label">Direction</span>
                     <button
-                        className={`sorting-option button button-secondary s-ascending${
+                        className={`sorting-option gd-button gd-button-secondary s-ascending${
                             isAsc ? " is-active" : ""
                         }`}
                         onClick={this.onDirectionChange("asc")}
@@ -189,7 +189,7 @@ export class DynamicSortingExample extends Component {
                         Ascending
                     </button>
                     <button
-                        className={`sorting-option button button-secondary s-descending${
+                        className={`sorting-option gd-button gd-button-secondary s-descending${
                             isDesc ? " is-active" : ""
                         }`}
                         onClick={this.onDirectionChange("desc")}

--- a/examples/src/components/ExecuteExample.jsx
+++ b/examples/src/components/ExecuteExample.jsx
@@ -43,7 +43,7 @@ export class ExecuteExample extends Component {
     executeChildrenFunction = retry => ({ result, isLoading, error }) => {
         const retryButton = (
             <p>
-                <button onClick={retry} className="button button-action s-retry-button">
+                <button onClick={retry} className="gd-button gd-button-action s-retry-button">
                     Retry
                 </button>
                 &ensp;(fails every second attempt)

--- a/examples/src/components/MultipleDomainsExample.jsx
+++ b/examples/src/components/MultipleDomainsExample.jsx
@@ -105,7 +105,7 @@ export class MultipleDomainsExample extends Component {
                     </table>
 
                     <div style={{ position: "relative" }}>
-                        <input type="submit" className="button-action" value="Login to second SDK" />
+                        <input type="submit" className="gd-button-action" value="Login to second SDK" />
                         {sdk2LoginError ? (
                             <div className="gd-message error" style={{ top: "1em", left: "1em" }}>
                                 <div className="gd-message-text">{sdk2LoginError}</div>

--- a/examples/src/components/PivotTableDynamicExample.jsx
+++ b/examples/src/components/PivotTableDynamicExample.jsx
@@ -531,7 +531,7 @@ export class PivotTableDrillingExample extends Component {
                         return (
                             <ElementWithParam
                                 key={key}
-                                className={`preset-option button button-secondary s-bucket-preset-${key} ${
+                                className={`preset-option gd-button gd-button-secondary s-bucket-preset-${key} ${
                                     bucketPresetKey === key ? " is-active" : ""
                                 }`}
                                 onClick={this.onBucketPresetChange}
@@ -549,7 +549,7 @@ export class PivotTableDrillingExample extends Component {
                         return (
                             <ElementWithParam
                                 key={key}
-                                className={`preset-option button button-secondary s-drilling-preset-${key} ${
+                                className={`preset-option gd-button gd-button-secondary s-drilling-preset-${key} ${
                                     filterPresetKeys[key] ? " is-active" : ""
                                 }`}
                                 onClick={this.onFilterPresetChange}
@@ -567,7 +567,7 @@ export class PivotTableDrillingExample extends Component {
                         return (
                             <ElementWithParam
                                 key={key}
-                                className={`preset-option button button-secondary s-drilling-preset-${key} ${
+                                className={`preset-option gd-button gd-button-secondary s-drilling-preset-${key} ${
                                     drillingPresetKeys[key] ? " is-active" : ""
                                 }`}
                                 onClick={this.onDrillingPresetChange}
@@ -585,7 +585,7 @@ export class PivotTableDrillingExample extends Component {
                         return (
                             <ElementWithParam
                                 key={key}
-                                className={`preset-option button button-secondary s-sorting-preset-${key} ${
+                                className={`preset-option gd-button gd-button-secondary s-sorting-preset-${key} ${
                                     sortingPresetKey === key ? " is-active" : ""
                                 }`}
                                 onClick={this.onSortingPresetChange}
@@ -603,7 +603,7 @@ export class PivotTableDrillingExample extends Component {
                         return (
                             <ElementWithParam
                                 key={key}
-                                className={`preset-option button button-secondary s-total-preset-${key} ${
+                                className={`preset-option gd-button gd-button-secondary s-total-preset-${key} ${
                                     totalPresetKeys[key] ? " is-active" : ""
                                 }`}
                                 onClick={this.onTotalPresetChange}
@@ -621,7 +621,7 @@ export class PivotTableDrillingExample extends Component {
                         return (
                             <ElementWithParam
                                 key={key}
-                                className={`preset-option button button-secondary s-total-preset-${key} ${
+                                className={`preset-option gd-button gd-button-secondary s-total-preset-${key} ${
                                     menuPresetKey === key ? " is-active" : ""
                                 }`}
                                 onClick={this.onMenuPresetChange}
@@ -639,7 +639,7 @@ export class PivotTableDrillingExample extends Component {
                         return (
                             <ElementWithParam
                                 key={key}
-                                className={`preset-option button button-secondary s-total-preset-${key} ${
+                                className={`preset-option gd-button gd-button-secondary s-total-preset-${key} ${
                                     pivotTableSizeKey === key ? " is-active" : ""
                                 }`}
                                 onClick={this.onPivotTableSizeChange}
@@ -657,7 +657,7 @@ export class PivotTableDrillingExample extends Component {
                         return (
                             <ElementWithParam
                                 key={key}
-                                className={`preset-option button button-secondary s-max-height-preset-${key} ${
+                                className={`preset-option gd-button gd-button-secondary s-max-height-preset-${key} ${
                                     maxHeightPresetKey === key ? " is-active" : ""
                                 }`}
                                 onClick={this.onMaxHeightPresetChange}
@@ -675,7 +675,7 @@ export class PivotTableDrillingExample extends Component {
                         return (
                             <ElementWithParam
                                 key={key}
-                                className={`preset-option button button-secondary s-group-rows-preset-${key} ${
+                                className={`preset-option gd-button gd-button-secondary s-group-rows-preset-${key} ${
                                     groupRowsKey === key ? " is-active" : ""
                                 }`}
                                 onClick={this.onGroupRowsPresetChange}

--- a/examples/src/components/ResponsiveExample.jsx
+++ b/examples/src/components/ResponsiveExample.jsx
@@ -47,13 +47,13 @@ export class ResponsiveExample extends Component {
             <div>
                 <button
                     onClick={() => this.setState({ size: [500, 400] })}
-                    className="button button-secondary"
+                    className="gd-button gd-button-secondary"
                 >
                     500x400
                 </button>
                 <button
                     onClick={() => this.setState({ size: [800, 200] })}
-                    className="button button-secondary s-resize-800x200"
+                    className="gd-button gd-button-secondary s-resize-800x200"
                 >
                     800x200
                 </button>

--- a/examples/src/components/utils/ExampleWithExport.jsx
+++ b/examples/src/components/utils/ExampleWithExport.jsx
@@ -114,16 +114,16 @@ export class ExampleWithExport extends React.Component {
             <div style={{ height: 367 }}>
                 {this.props.children(this.onExportReady)}
                 <div style={{ marginTop: 15 }}>
-                    <button className="button button-secondary" onClick={this.exportToCSV}>
+                    <button className="gd-button gd-button-secondary" onClick={this.exportToCSV}>
                         Export CSV
                     </button>
-                    <button className="button button-secondary" onClick={this.exportToXLSX}>
+                    <button className="gd-button gd-button-secondary" onClick={this.exportToXLSX}>
                         Export XLSX
                     </button>
-                    <button className="button button-secondary" onClick={this.exportWithCustomName}>
+                    <button className="gd-button gd-button-secondary" onClick={this.exportWithCustomName}>
                         Export with custom name CustomName
                     </button>
-                    <button className="button button-secondary" onClick={this.exportWithDialog}>
+                    <button className="gd-button gd-button-secondary" onClick={this.exportWithDialog}>
                         Export using Export Dialog
                     </button>
                 </div>

--- a/examples/src/components/utils/ExampleWithSource.jsx
+++ b/examples/src/components/utils/ExampleWithSource.jsx
@@ -58,7 +58,7 @@ export class ExampleWithSource extends React.Component {
                 </div>
                 <div className="source">
                     <button
-                        className={`button button-secondary button-dropdown icon-right ${iconClassName}`}
+                        className={`gd-button gd-button-secondary button-dropdown icon-right ${iconClassName}`}
                         onClick={this.toggle}
                     >
                         source code

--- a/examples/src/components/utils/Login.jsx
+++ b/examples/src/components/utils/Login.jsx
@@ -114,7 +114,7 @@ export const LoginFormUncontrolled = props => {
                 <div className="gd-input buttons">
                     <button
                         type="submit"
-                        className={`button button-primary button-important submit-button s-login-submit${
+                        className={`gd-button gd-button-primary gd-button-important submit-button s-login-submit${
                             isSubmitting || isLoading ? " disabled" : ""
                         }`}
                         disabled={isSubmitting || isLoading}
@@ -123,7 +123,7 @@ export const LoginFormUncontrolled = props => {
                         Sign in
                     </button>
                     <Link
-                        className="button button-link"
+                        className="gd-button gd-button-link"
                         to={{
                             pathname: "/registration",
                         }}

--- a/examples/src/components/utils/LoginOverlay.jsx
+++ b/examples/src/components/utils/LoginOverlay.jsx
@@ -139,7 +139,7 @@ class LoginOverlay extends React.Component {
                         <div className="gd-input" style={{ margin: "5px 0", textAlign: "center" }}>
                             <button
                                 type="submit"
-                                className="button button-primary button-important submit-button s-login-submit"
+                                className="gd-button gd-button-primary gd-button-important submit-button s-login-submit"
                             >
                                 Sign in
                             </button>

--- a/examples/src/components/utils/Registration.jsx
+++ b/examples/src/components/utils/Registration.jsx
@@ -223,7 +223,9 @@ export const RegistrationForm = props => {
             <div className="form-actions">
                 <button
                     disabled={isSubmitting}
-                    className={`button button-primary button-important${isSubmitting ? " disabled" : ""}`}
+                    className={`gd-button gd-button-primary gd-button-important${
+                        isSubmitting ? " disabled" : ""
+                    }`}
                     tabIndex="-1"
                     type="submit"
                 >

--- a/examples/test/AttributeFilter_test.js
+++ b/examples/test/AttributeFilter_test.js
@@ -14,7 +14,7 @@ fixture("Attribute filter components")
     .beforeEach(loginUsingLoginForm(`${config.url}/attribute-filter-components`));
 
 test("Dropdown filter opens, clears, selects all and applies", async t => {
-    const dropdownButton = Selector(".button.s-employee_name");
+    const dropdownButton = Selector(".gd-button.s-employee_name");
 
     await t
         .click(dropdownButton)
@@ -38,7 +38,7 @@ test("Dropdown filter opens, clears, selects all and applies", async t => {
 });
 
 test("Positive, negative and error attribute filters", async t => {
-    const dropdownButton = Selector(".s-location_resort.button");
+    const dropdownButton = Selector(".s-location_resort.gd-button");
     const lineChart = Selector(".s-line-chart");
     const markers = Selector(".highcharts-markers path");
     const error = Selector(".s-error .info-label");

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@gooddata/gooddata-js": "^11.14.2",
-    "@gooddata/goodstrap": "^61.2.0",
+    "@gooddata/goodstrap": "^62.0.0",
     "@gooddata/js-utils": "^3.4.0",
     "@gooddata/numberjs": "^3.1.2",
     "@gooddata/typings": "^2.13.2",

--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -253,23 +253,27 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
             </div>
         ) : null;
 
+        const style: React.CSSProperties = {
+            height: desiredHeight || "100%",
+            position: "relative",
+            overflow: "hidden",
+        };
+
         return (
-            <div
-                className="gd-table ag-theme-balham s-pivot-table"
-                style={{
-                    height: desiredHeight || "100%",
-                    position: "relative",
-                    overflow: "hidden",
-                }}
-                ref={this.setContainerRef}
-            >
-                {tableLoadingOverlay}
-                <AgGridReact
-                    {...gridOptions}
-                    // To force Ag grid rerender because AFAIK there is no way
-                    // to tell Ag grid header cell to rerender
-                    key={this.state.agGridRerenderNumber}
-                />
+            <div className="gd-table-component" style={style}>
+                <div
+                    className="gd-table ag-theme-balham s-pivot-table"
+                    style={style}
+                    ref={this.setContainerRef}
+                >
+                    {tableLoadingOverlay}
+                    <AgGridReact
+                        {...gridOptions}
+                        // To force Ag grid rerender because AFAIK there is no way
+                        // to tell Ag grid header cell to rerender
+                        key={this.state.agGridRerenderNumber}
+                    />
+                </div>
             </div>
         );
     }

--- a/src/components/filters/AttributeFilter/AttributeDropdown.tsx
+++ b/src/components/filters/AttributeFilter/AttributeDropdown.tsx
@@ -364,14 +364,14 @@ export class AttributeDropdownWrapped extends React.PureComponent<
         return (
             <div className="gd-attribute-filter-actions">
                 <Button
-                    className="button-secondary button-small cancel-button"
+                    className="gd-button-secondary gd-button-small cancel-button"
                     onClick={this.onClose}
                     value={cancelText}
                     title={cancelText}
                 />
                 <Button
                     disabled={applyDisabled}
-                    className="button-action button-small s-apply"
+                    className="gd-button-action gd-button-small s-apply"
                     onClick={this.onApply}
                     value={applyText}
                     title={applyText}

--- a/src/components/filters/AttributeFilter/AttributeElements.tsx
+++ b/src/components/filters/AttributeFilter/AttributeElements.tsx
@@ -63,7 +63,7 @@ const defaultChildren = ({ validElements, loadMore, isLoading, error }: IAttribu
                 to your React components.
             </p>
             <button
-                className="button button-secondary"
+                className="gd-button gd-button-secondary"
                 onClick={loadMore as any}
                 disabled={isLoading || offset + count === total}
             >

--- a/src/components/filters/AttributeFilter/AttributeFilter.tsx
+++ b/src/components/filters/AttributeFilter/AttributeFilter.tsx
@@ -29,7 +29,7 @@ export interface IAttributeFilterProps {
 
 const DefaultFilterLoading = injectIntl(({ intl }) => {
     return (
-        <button className="button button-secondary button-small icon-right icon disabled s-button-loading">
+        <button className="gd-button gd-button-secondary gd-button-small icon-right icon disabled s-button-loading">
             {intl.formatMessage({ id: "gs.filter.loading" })}
         </button>
     );

--- a/src/components/filters/AttributeFilter/tests/AttributeDropdown.spec.tsx
+++ b/src/components/filters/AttributeFilter/tests/AttributeDropdown.spec.tsx
@@ -54,7 +54,7 @@ describe("AttributeDropdown", () => {
     it("should render attribute title", () => {
         const attributeDisplayForm = createADF();
         const wrapper = renderComponent({ attributeDisplayForm });
-        expect(wrapper.find(".gd-attribute-filter .button-text").text()).toBe(
+        expect(wrapper.find(".gd-attribute-filter .gd-button-text").text()).toBe(
             attributeDisplayForm.meta.title,
         );
     });

--- a/src/components/visualizations/chart/legend/FluidLegend.tsx
+++ b/src/components/visualizations/chart/legend/FluidLegend.tsx
@@ -45,7 +45,7 @@ export default class FluidLegend extends React.PureComponent<any, any> {
     }
 
     public renderPaging() {
-        const classes = cx("button-link", "button-icon-only", "paging-button", {
+        const classes = cx("gd-button-link", "gd-button-icon-only", "paging-button", {
             "icon-chevron-up": this.state.showAll,
             "icon-chevron-down": !this.state.showAll,
         });

--- a/src/components/visualizations/chart/legend/StaticLegend.tsx
+++ b/src/components/visualizations/chart/legend/StaticLegend.tsx
@@ -27,7 +27,7 @@ export default class StaticLegend extends React.PureComponent<any, any> {
     }
 
     public renderPagingButton(type: any, handler: any, disabled: any) {
-        const classes = cx("button-link", "button-icon-only", `icon-chevron-${type}`, "paging-button");
+        const classes = cx("gd-button-link", "gd-button-icon-only", `icon-chevron-${type}`, "paging-button");
         return <button className={classes} onClick={handler} disabled={disabled} />;
     }
 

--- a/src/components/visualizations/styles/table.scss
+++ b/src/components/visualizations/styles/table.scss
@@ -639,7 +639,7 @@ $gdc-goodstrap-basepath: "~@gooddata/goodstrap/lib/";
     }
 
     .content {
-        .close-button.button-link {
+        .close-button.gd-button-link {
             position: absolute;
             top: 12px;
             right: 12px;
@@ -663,7 +663,7 @@ $gdc-goodstrap-basepath: "~@gooddata/goodstrap/lib/";
             flex-wrap: wrap;
             margin-left: -20px;
 
-            .button {
+            .gd-button {
                 flex: 1 1 auto;
                 margin-left: 20px;
                 margin-top: 10px;
@@ -680,7 +680,7 @@ $gdc-goodstrap-basepath: "~@gooddata/goodstrap/lib/";
             }
         }
 
-        .button.button-primary {
+        .gd-button.gd-button-primary {
             &.button-sort-asc {
                 // refactor
                 // stylelint-disable-next-line max-nesting-depth

--- a/src/components/visualizations/table/TableControls.tsx
+++ b/src/components/visualizations/table/TableControls.tsx
@@ -41,7 +41,7 @@ export class TableControlsClass extends React.Component<ITableControlsProps & In
 
         return (
             <Button
-                className="button-secondary button-small"
+                className="gd-button-secondary gd-button-small"
                 onClick={this.props.onMore}
                 value={label}
                 title={label}
@@ -58,7 +58,7 @@ export class TableControlsClass extends React.Component<ITableControlsProps & In
 
         return (
             <Button
-                className="button-small button-link-dimmed"
+                className="gd-button-small gd-button-link-dimmed"
                 onClick={this.props.onLess}
                 value={label}
                 title={label}

--- a/src/components/visualizations/table/TableSortBubbleContent.tsx
+++ b/src/components/visualizations/table/TableSortBubbleContent.tsx
@@ -38,7 +38,10 @@ export class TableSortBubbleContentClass extends React.Component<
 
         return (
             <div>
-                <button className="close-button button-link button-icon-only icon-cross" onClick={onClose} />
+                <button
+                    className="close-button gd-button-link gd-button-icon-only icon-cross"
+                    onClick={onClose}
+                />
                 <div className="gd-dialog-header gd-heading-3">{title}</div>
                 <FormattedMessage id="visualizations.sorting" />
                 <div className="buttons-wrap">
@@ -55,9 +58,9 @@ export class TableSortBubbleContentClass extends React.Component<
         const { activeSortDir } = this.props;
         const isDisabled = dir === activeSortDir;
         const buttonClasses = classNames(
-            "button",
-            "button-primary",
-            "button-small",
+            "gd-button",
+            "gd-button-primary",
+            "gd-button-small",
             "icon-dropdown",
             "icon-right",
             {

--- a/src/components/visualizations/table/totals/TotalCell.tsx
+++ b/src/components/visualizations/table/totals/TotalCell.tsx
@@ -200,8 +200,8 @@ export class TotalCellPure extends React.Component<ITotalCellProps & InjectedInt
                     <span>
                         <span
                             className={classNames(
-                                "button-link",
-                                "button-icon-only",
+                                "gd-button-link",
+                                "gd-button-icon-only",
                                 "icon-circle-cross",
                                 "indigo-totals-disable-column-button",
                                 "s-disable-total-column",
@@ -217,8 +217,8 @@ export class TotalCellPure extends React.Component<ITotalCellProps & InjectedInt
             return (
                 <span
                     className={classNames(
-                        "button-link",
-                        "button-icon-only",
+                        "gd-button-link",
+                        "gd-button-icon-only",
                         "icon-circle-plus",
                         "indigo-totals-enable-column-button",
                         "s-enable-total-column",

--- a/src/internal/components/configurationControls/colors/ColorsSection.tsx
+++ b/src/internal/components/configurationControls/colors/ColorsSection.tsx
@@ -77,7 +77,7 @@ class ColorsSection extends React.Component<IColorsSectionProps & InjectedIntlPr
             <div className={classes}>
                 <Button
                     value={getTranslation("properties.colors.reset-colors", this.props.intl)}
-                    className="button-link s-reset-colors-button"
+                    className="gd-button-link s-reset-colors-button"
                     onClick={this.onResetColors}
                     disabled={isDisabled}
                 />

--- a/src/internal/components/configurationControls/colors/colorDropdown/CustomColorButton.tsx
+++ b/src/internal/components/configurationControls/colors/colorDropdown/CustomColorButton.tsx
@@ -14,7 +14,7 @@ class CustomColorButton extends React.PureComponent<ICustomColorButtonProps & In
             <div className="gd-color-drop-down-custom-section">
                 <Button
                     value={getTranslation("gs.color-dropdown.custom-color", this.props.intl)}
-                    className="button-link gd-color-drop-down-custom-section-button s-custom-section-button"
+                    className="gd-button-link gd-color-drop-down-custom-section-button s-custom-section-button"
                     onClick={this.onClick}
                 />
             </div>

--- a/src/internal/components/configurationControls/legend/tests/LegendSection.spec.tsx
+++ b/src/internal/components/configurationControls/legend/tests/LegendSection.spec.tsx
@@ -43,7 +43,7 @@ describe("LegendSection render", () => {
         const node = wrapper.find(LegendPositionControl);
 
         expect(node.length).toBe(1);
-        expect(node.find(".button.disabled").length).toBe(1);
+        expect(node.find(".gd-button.disabled").length).toBe(1);
     });
 
     it(
@@ -62,7 +62,7 @@ describe("LegendSection render", () => {
             const node = wrapper.find(LegendPositionControl);
 
             expect(node.length).toBe(1);
-            expect(node.find(".button.disabled").length).toBe(1);
+            expect(node.find(".gd-button.disabled").length).toBe(1);
         },
     );
 
@@ -81,7 +81,7 @@ describe("LegendSection render", () => {
 
             const node = wrapper.find(LegendPositionControl);
             expect(node.length).toBe(1);
-            expect(node.find(".button").hasClass("disabled")).toBe(false);
+            expect(node.find(".gd-button").hasClass("disabled")).toBe(false);
         },
     );
 
@@ -100,6 +100,6 @@ describe("LegendSection render", () => {
 
         const node = wrapper.find(LegendPositionControl);
         expect(node.length).toBe(1);
-        expect(node.find(".button").hasClass("disabled")).toBe(true);
+        expect(node.find(".gd-button").hasClass("disabled")).toBe(true);
     });
 });

--- a/src/internal/components/configurationControls/tests/DataLabelsControl.spec.tsx
+++ b/src/internal/components/configurationControls/tests/DataLabelsControl.spec.tsx
@@ -25,7 +25,7 @@ describe("DataLabelsControl", () => {
         const VISIBLE_LABEL = "show";
         const AUTO_LABEL = "auto (default)";
         const dataLabelsButtonSelector = ".s-data-labels-config .dropdown-button";
-        const dataLabelsButtonTextSelector = ".s-data-labels-config .dropdown-button .button-text";
+        const dataLabelsButtonTextSelector = ".s-data-labels-config .dropdown-button .gd-button-text";
 
         it("should render data labels control", () => {
             const wrapper = createComponent();

--- a/styles/internal/scss/config_panel.scss
+++ b/styles/internal/scss/config_panel.scss
@@ -89,7 +89,7 @@ $color-picker-spacing: 5px;
         border-top: 1px solid $border-color;
     }
 
-    .button-link {
+    .gd-button-link {
         width: 100%;
         justify-content: center;
         margin: 0;
@@ -110,7 +110,7 @@ $color-picker-spacing: 5px;
         padding-top: 0;
     }
 
-    .button-link {
+    .gd-button-link {
         font-size: 12px;
     }
 }

--- a/styles/scss/_settings.scss
+++ b/styles/scss/_settings.scss
@@ -1,6 +1,9 @@
 // (C) 2007-2018 GoodData Corporation
 // Here we define the breakpoints which will become the upper border for each media size.
 // The function em-calc() calculates the em-value from a px-value.
+
+@import "~@gooddata/goodstrap/lib/core/styles/foundations";
+
 $small-breakpoint: em-calc(640) !default;
 $medium-breakpoint: em-calc(1024) !default;
 $large-breakpoint: em-calc(1440) !default;

--- a/styles/scss/pivotTable.scss
+++ b/styles/scss/pivotTable.scss
@@ -20,215 +20,217 @@ $cell-border: 1px dashed transparent;
 $cell-border-color: transparentize($gd-color-disabled, 0.5);
 $header-cell-resize-width: 20px;
 
-@import "~ag-grid-community/src/styles/ag-grid";
-@import "~ag-grid-community/src/styles/ag-theme-balham/sass/ag-theme-balham";
+.gd-table-component {
+    @import "~ag-grid-community/src/styles/ag-grid";
+    @import "~ag-grid-community/src/styles/ag-theme-balham/sass/ag-theme-balham";
 
-.gd-table {
-    .ag-root-wrapper {
-        text-align: left;
-    }
-
-    .ag-root {
-        border: none;
-    }
-
-    .ag-font-style {
-        user-select: auto;
-    }
-
-    .ag-header-cell,
-    .ag-header-group-cell {
-        &::after {
-            display: none;
+    .gd-table {
+        .ag-root-wrapper {
+            text-align: left;
         }
-    }
 
-    .ag-header {
-        border-bottom: none;
-    }
+        .ag-root {
+            border: none;
+        }
 
-    .ag-cell {
-        outline: none;
+        .ag-font-style {
+            user-select: auto;
+        }
 
-        &,
-        &.ag-cell-focus {
-            border-top: $cell-border;
-            border-top-color: $cell-border-color;
-            border-right: none;
+        .ag-header-cell,
+        .ag-header-group-cell {
+            &::after {
+                display: none;
+            }
+        }
+
+        .ag-header {
+            border-bottom: none;
+        }
+
+        .ag-cell {
+            outline: none;
+
+            &,
+            &.ag-cell-focus {
+                border-top: $cell-border;
+                border-top-color: $cell-border-color;
+                border-right: none;
+                border-left: none;
+            }
+
+            &,
+            .ag-react-container {
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+
+        [row-index="0"] {
+            .ag-cell {
+                border-top-color: transparent;
+            }
+        }
+
+        .ag-header-cell,
+        .gd-column-group-header {
+            border-bottom: $cell-border;
+            border-bottom-color: $cell-border-color;
+        }
+
+        .gd-column-group-header-0,
+        .gd-column-measure-0,
+        .ag-header-group-cell-with-group {
+            &,
+            &.ag-cell-focus {
+                border-left: $cell-border;
+                border-left-color: $cell-border-color;
+            }
+        }
+
+        .gd-column-index-0,
+        .gd-column-group-header--first {
             border-left: none;
         }
 
-        &,
-        .ag-react-container {
-            overflow: hidden;
-            text-overflow: ellipsis;
+        .gd-column-group-header--empty {
+            border-bottom-color: transparent;
+
+            .ag-header-cell-resize {
+                display: none;
+            }
         }
-    }
 
-    [row-index="0"] {
-        .ag-cell {
-            border-top-color: transparent;
+        .ag-header-row {
+            &:last-child {
+                border-bottom: none;
+
+                .ag-header-cell,
+                .ag-header-group-cell-with-group {
+                    border-bottom-style: solid;
+                }
+
+                .gd-pivot-table-header {
+                    min-height: 30px;
+                }
+            }
         }
-    }
 
-    .ag-header-cell,
-    .gd-column-group-header {
-        border-bottom: $cell-border;
-        border-bottom-color: $cell-border-color;
-    }
-
-    .gd-column-group-header-0,
-    .gd-column-measure-0,
-    .ag-header-group-cell-with-group {
-        &,
-        &.ag-cell-focus {
-            border-left: $cell-border;
-            border-left-color: $cell-border-color;
+        .ag-header-group-cell {
+            overflow: visible;
         }
-    }
-
-    .gd-column-index-0,
-    .gd-column-group-header--first {
-        border-left: none;
-    }
-
-    .gd-column-group-header--empty {
-        border-bottom-color: transparent;
 
         .ag-header-cell-resize {
+            right: -$header-cell-resize-width / 2;
+            width: $header-cell-resize-width;
+            opacity: 0;
+
+            &::after {
+                width: $header-cell-resize-width / 2;
+                margin-right: $header-cell-resize-width / 2;
+                border-right: 1px solid $gd-color-highlight;
+                text-indent: $header-cell-resize-width / 2;
+                height: 16px;
+                content: "";
+                display: block;
+                box-sizing: content-box;
+            }
+        }
+
+        .gd-column-group-header:hover {
+            .gd-pivot-table-header-label--clickable,
+            .gd-pivot-table-header-menu ~ .gd-pivot-table-header-label {
+                background-color: $gd-color-highlight-dimmed;
+            }
+
+            .ag-header-cell-resize {
+                opacity: 1;
+            }
+        }
+
+        .gd-table-row {
+            border: none;
+        }
+
+        .gd-row-total {
+            border-bottom-color: transparent;
+            color: $gd-color-dark;
+            font-weight: bold;
+            background-color: #e7ebef;
+
+            &,
+            &.ag-cell-focus {
+                border-top: 1px solid transparentize($gd-color-disabled, 0.5);
+            }
+        }
+
+        .gd-table-row-subtotal {
+            font-weight: bold;
+            border-top: 1px solid transparentize($gd-color-disabled, 0.5);
+            &-even {
+                background-color: #eff2f4;
+            }
+            &-odd {
+                background-color: #f7f8f9;
+            }
+        }
+
+        .gd-column-merged {
             display: none;
         }
-    }
 
-    .ag-header-row {
-        &:last-child {
-            border-bottom: none;
-
-            .ag-header-cell,
-            .ag-header-group-cell-with-group {
-                border-bottom-style: solid;
-            }
-
-            .gd-pivot-table-header {
-                min-height: 30px;
-            }
-        }
-    }
-
-    .ag-header-group-cell {
-        overflow: visible;
-    }
-
-    .ag-header-cell-resize {
-        right: -$header-cell-resize-width / 2;
-        width: $header-cell-resize-width;
-        opacity: 0;
-
-        &::after {
-            width: $header-cell-resize-width / 2;
-            margin-right: $header-cell-resize-width / 2;
-            border-right: 1px solid $gd-color-highlight;
-            text-indent: $header-cell-resize-width / 2;
-            height: 16px;
-            content: "";
-            display: block;
-            box-sizing: content-box;
-        }
-    }
-
-    .gd-column-group-header:hover {
-        .gd-pivot-table-header-label--clickable,
-        .gd-pivot-table-header-menu ~ .gd-pivot-table-header-label {
-            background-color: $gd-color-highlight-dimmed;
+        .gd-cell-hide {
+            color: transparent;
+            border-top: 1px solid transparent;
+            background-color: white;
         }
 
-        .ag-header-cell-resize {
-            opacity: 1;
+        .gd-cell-show-hidden {
+            color: inherit;
+            font-weight: normal;
         }
-    }
 
-    .gd-table-row {
-        border: none;
-    }
-
-    .gd-row-total {
-        border-bottom-color: transparent;
-        color: $gd-color-dark;
-        font-weight: bold;
-        background-color: #e7ebef;
-
-        &,
-        &.ag-cell-focus {
+        .gd-table-row-separator {
             border-top: 1px solid transparentize($gd-color-disabled, 0.5);
         }
-    }
 
-    .gd-table-row-subtotal {
-        font-weight: bold;
-        border-top: 1px solid transparentize($gd-color-disabled, 0.5);
-        &-even {
-            background-color: #eff2f4;
-        }
-        &-odd {
-            background-color: #f7f8f9;
-        }
-    }
+        .ag-floating-top {
+            position: absolute;
+            z-index: 1;
+            pointer-events: none;
+            display: none;
+            overflow: hidden !important;
+            border-bottom: none;
 
-    .gd-column-merged {
-        display: none;
-    }
+            &.gd-visible-sticky-row {
+                display: inherit;
+            }
 
-    .gd-cell-hide {
-        color: transparent;
-        border-top: 1px solid transparent;
-        background-color: white;
-    }
+            .ag-row {
+                background-color: transparent;
 
-    .gd-cell-show-hidden {
-        color: inherit;
-        font-weight: normal;
-    }
+                .ag-cell {
+                    background-color: #fff;
+                    border-top-color: white;
 
-    .gd-table-row-separator {
-        border-top: 1px solid transparentize($gd-color-disabled, 0.5);
-    }
+                    &.gd-hidden-sticky-column {
+                        border-top-color: transparent;
+                        background-color: transparent;
+                        color: transparent;
+                    }
 
-    .ag-floating-top {
-        position: absolute;
-        z-index: 1;
-        pointer-events: none;
-        display: none;
-        overflow: hidden !important;
-        border-bottom: none;
-
-        &.gd-visible-sticky-row {
-            display: inherit;
-        }
-
-        .ag-row {
-            background-color: transparent;
-
-            .ag-cell {
-                background-color: #fff;
-                border-top-color: white;
-
-                &.gd-hidden-sticky-column {
-                    border-top-color: transparent;
-                    background-color: transparent;
-                    color: transparent;
-                }
-
-                &.gd-measure-column,
-                &.gd-column-attribute-column {
-                    display: none;
+                    &.gd-measure-column,
+                    &.gd-column-attribute-column {
+                        display: none;
+                    }
                 }
             }
         }
-    }
 
-    .ag-floating-bottom {
-        overflow: auto !important;
-        border-top: none;
+        .ag-floating-bottom {
+            overflow: auto !important;
+            border-top: none;
+        }
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,10 +1145,10 @@
     rxjs "^5.5.6"
     uuid "^3.2.1"
 
-"@gooddata/goodstrap@^61.2.0":
-  version "61.2.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/goodstrap/-/goodstrap-61.2.0.tgz#d99ecd731d23a44c18afaafdfa6065e9cb579dfd"
-  integrity sha512-89nFQ75DvTAfnO/gHDPpo0DayOiI61o66kIbDMo0L5bpf3ZQTqoaTxIFv2CKSja1S1RdTUYzU0PC+z+Nj4LNjg==
+"@gooddata/goodstrap@^62.0.0":
+  version "62.0.0"
+  resolved "https://registry.yarnpkg.com/@gooddata/goodstrap/-/goodstrap-62.0.0.tgz#920818122eb75b884ac7b179f796c82dd916588d"
+  integrity sha512-/G2BrUE7Jn20DdotMQi/ig/65XKXTqUeHHcoGI85mzKajHq+6GvVyTk1sbngEyDcZ6PE+QwUInNykWzIxhlqeQ==
   dependencies:
     "@gooddata/js-utils" "^3.4.0"
     classnames "^2.2.6"


### PR DESCRIPTION
* Use updated goodstrap with button styles wrapped (button -> gd-button)
* Wrap pivot table so that we can wrap ag-grid selectors

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
* https://github.com/gooddata/gdc-goodstrap/pull/958
* https://github.com/gooddata/gdc-analytical-designer/pull/2296
* https://github.com/gooddata/gdc-dashboards/pull/2044
* https://github.com/gooddata/graphene-tests/pull/3231

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->