### PR TITLE
BUGFIX: SD-518 Revert - Disable Headline exporting in SDK

### DIFF
--- a/examples/src/components/HeadlineExportExample.jsx
+++ b/examples/src/components/HeadlineExportExample.jsx
@@ -1,0 +1,53 @@
+// (C) 2007-2019 GoodData Corporation
+import React, { Component } from "react";
+import { Headline, Model } from "@gooddata/react-components";
+
+import "@gooddata/react-components/styles/css/main.css";
+
+import ExampleWithExport from "./utils/ExampleWithExport";
+import {
+    dateDataSetUri,
+    franchiseFeesIdentifier,
+    franchiseFeesAdRoyaltyIdentifier,
+    projectId,
+} from "../utils/fixtures";
+
+export class HeadlineExportExample extends Component {
+    onLoadingChanged(...params) {
+        // eslint-disable-next-line no-console
+        console.info("HeadlineExportExample onLoadingChanged", ...params);
+    }
+
+    onError(...params) {
+        // eslint-disable-next-line no-console
+        console.info("HeadlineExportExample onError", ...params);
+    }
+
+    render() {
+        const primaryMeasure = Model.measure(franchiseFeesIdentifier).format("#,##0");
+
+        const secondaryMeasure = Model.measure(franchiseFeesAdRoyaltyIdentifier).format("#,##0");
+
+        const filters = [Model.absoluteDateFilter(dateDataSetUri, "2017-01-01", "2017-12-31")];
+
+        return (
+            <ExampleWithExport>
+                {onExportReady => (
+                    <div className="s-headline" style={{ display: "flex" }}>
+                        <Headline
+                            projectId={projectId}
+                            primaryMeasure={primaryMeasure}
+                            secondaryMeasure={secondaryMeasure}
+                            filters={filters}
+                            onExportReady={onExportReady}
+                            onLoadingChanged={this.onLoadingChanged}
+                            onError={this.onError}
+                        />
+                    </div>
+                )}
+            </ExampleWithExport>
+        );
+    }
+}
+
+export default HeadlineExportExample;

--- a/examples/src/routes/Export.jsx
+++ b/examples/src/routes/Export.jsx
@@ -6,11 +6,13 @@ import BarChartExportExample from "../components/BarChartExportExample";
 import TableExportExample from "../components/TableExportExample";
 import PivotTableExportExample from "../components/PivotTableExportExample";
 import VisualizationColumnChartExportExample from "../components/VisualizationColumnChartExportExample";
+import HeadlineExportExample from "../components/HeadlineExportExample";
 
 import BarChartExportExampleSRC from "!raw-loader!../components/BarChartExportExample"; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
 import TableExportExampleSRC from "!raw-loader!../components/TableExportExample"; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
 import PivotTableExportExampleSRC from "!raw-loader!../components/PivotTableExportExample"; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
 import VisualizationColumnChartExportExampleSRC from "!raw-loader!../components/VisualizationColumnChartExportExample"; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
+import HeadlineExportExampleSRC from "!raw-loader!../components/HeadlineExportExample"; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
 
 export const Export = () => (
     <div>
@@ -42,6 +44,11 @@ export const Export = () => (
             for={VisualizationColumnChartExportExample}
             source={VisualizationColumnChartExportExampleSRC}
         />
+
+        <hr className="separator" />
+
+        <h2>Export Headline Data</h2>
+        <ExampleWithSource for={HeadlineExportExample} source={HeadlineExportExampleSRC} />
     </div>
 );
 

--- a/src/components/afm/DataSourceProvider.tsx
+++ b/src/components/afm/DataSourceProvider.tsx
@@ -74,6 +74,7 @@ export function dataSourceProvider<T>(
     InnerComponent: React.ComponentType<T & IDataSourceProviderInjectedProps>,
     generateDefaultDimensions: IGenerateDefaultDimensionsFunction,
     componentName: string,
+    exportTitle?: string,
 ): React.ComponentClass<IDataSourceProviderProps> {
     return class WrappedComponent extends React.Component<
         IDataSourceProviderProps,
@@ -179,7 +180,7 @@ export function dataSourceProvider<T>(
             return (
                 <InnerComponent
                     {...props}
-                    exportTitle={componentName}
+                    exportTitle={exportTitle || componentName}
                     dataSource={dataSource}
                     updateTotals={this.updateTotals}
                     resultSpec={resultSpec}

--- a/src/components/afm/Headline.ts
+++ b/src/components/afm/Headline.ts
@@ -21,4 +21,5 @@ export const Headline: React.ComponentClass<IDataSourceProviderProps> = dataSour
     CoreHeadline,
     generateDefaultDimensions,
     "CoreHeadline",
+    "Headline",
 );

--- a/src/components/afm/tests/DataSourceProvider.spec.tsx
+++ b/src/components/afm/tests/DataSourceProvider.spec.tsx
@@ -28,8 +28,14 @@ describe("DataSourceProvider", () => {
     function createComponent(
         component: React.ComponentType<IDataSourceProviderInjectedProps>,
         props: IDataSourceProviderProps = defaultProps,
+        exportTitle?: string,
     ): ReactWrapper {
-        const WrappedComponent = dataSourceProvider(component, generateDefaultDimensions, COMPONENT_NAME);
+        const WrappedComponent = dataSourceProvider(
+            component,
+            generateDefaultDimensions,
+            COMPONENT_NAME,
+            exportTitle,
+        );
 
         return mount(<WrappedComponent {...props} />);
     }
@@ -57,6 +63,17 @@ describe("DataSourceProvider", () => {
             expect(TableElement.props.exportTitle).toEqual(COMPONENT_NAME);
             expect(TableElement.props.projectId).toEqual(PROJECT_ID);
         });
+    });
+
+    it("should pass correct exportTitle to InnerComponent", async () => {
+        const customTitle = "CustomTitle";
+        const wrapper = createComponent(Table, undefined, customTitle);
+
+        await testUtils.delay();
+        wrapper.update();
+        expect(wrapper.find(Table).length).toBe(1);
+        const TableElement = wrapper.find(Table).get(0);
+        expect(TableElement.props.exportTitle).toEqual(customTitle);
     });
 
     it("should recreate dataSource when projects differ", () => {

--- a/stories/internal/Export.tsx
+++ b/stories/internal/Export.tsx
@@ -6,12 +6,12 @@ import { AFM } from "@gooddata/typings";
 import { action } from "@storybook/addon-actions";
 import { storiesOf } from "@storybook/react";
 
-import { BarChart, PivotTable, Table } from "../../src";
+import { BarChart, Headline, PivotTable, Table } from "../../src";
 import { Visualization } from "../../src/components/uri/Visualization";
 import { IExportFunction, OnExportReady } from "../../src/interfaces/Events";
 
 import { onErrorHandler } from "../mocks";
-import { ATTRIBUTE_1, MEASURE_1, MEASURE_2 } from "../data/componentProps";
+import { ATTRIBUTE_1, MEASURE_1, MEASURE_1_WITH_ALIAS, MEASURE_2 } from "../data/componentProps";
 
 const WRAPPER_STYLE = { width: 800, height: 400 };
 const INNER_STYLE = { width: 800, height: 370 };
@@ -224,6 +224,23 @@ storiesOf("Internal/Export", module)
                         onExportReady={onExportReady}
                         onError={onErrorHandler}
                         locale="en-US"
+                        LoadingComponent={null}
+                        ErrorComponent={null}
+                    />
+                )}
+            </WrapperComponent>
+        </div>
+    ))
+    .add("export headline data", () => (
+        <div style={WRAPPER_STYLE}>
+            <WrapperComponent>
+                {(onExportReady: OnExportReady) => (
+                    <Headline
+                        projectId="storybook"
+                        primaryMeasure={MEASURE_1_WITH_ALIAS}
+                        secondaryMeasure={MEASURE_2}
+                        filters={defaultFilters}
+                        onExportReady={onExportReady}
                         LoadingComponent={null}
                         ErrorComponent={null}
                     />


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)
- [x] Squash commits

# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2305
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2064

# Related Jira tasks
- SD-518: https://jira.intgdc.com/browse/SD-518
