### PR TITLE
RELATED: RAIL-1623 handle XSS in the data itself

### DIFF
--- a/examples/test/PivotTableXss_test.js
+++ b/examples/test/PivotTableXss_test.js
@@ -8,6 +8,12 @@ fixture
     .beforeEach(loginUsingLoginForm(`${config.url}/hidden/pivot-table-xss`));
 
 test("should render items HTML escaped", async t => {
-    await checkCellValue(t, ".s-pivot-table-xss", "1,406,548 <img />", ".s-cell-0-1");
-    await checkCellValue(t, ".s-pivot-table-xss", "4,334,353 <img />", ".s-cell-0-1", ".ag-floating-bottom");
+    await checkCellValue(t, ".s-pivot-table-xss", "1,406,548 &lt;img /&gt;", ".s-cell-0-1");
+    await checkCellValue(
+        t,
+        ".s-pivot-table-xss",
+        "4,334,353 &lt;img /&gt;",
+        ".s-cell-0-1",
+        ".ag-floating-bottom",
+    );
 });

--- a/src/components/core/pivotTable/agGridUtils.ts
+++ b/src/components/core/pivotTable/agGridUtils.ts
@@ -1,8 +1,9 @@
 // (C) 2007-2018 GoodData Corporation
+import { ICellRendererParams } from "ag-grid-community";
+import escape = require("lodash/escape");
 import { AFM, Execution } from "@gooddata/typings";
 import { getMappingHeaderUri } from "../../../helpers/mappingHeader";
 import { IMappingHeader, isMappingHeaderTotal } from "../../../interfaces/MappingHeader";
-import { ICellRendererParams } from "ag-grid-community";
 import {
     DOT_PLACEHOLDER,
     FIELD_SEPARATOR,
@@ -82,7 +83,7 @@ export const cellRenderer = (params: ICellRendererParams) => {
     const formattedValue =
         isRowTotalOrSubtotal && !isActiveRowTotal && !params.value
             ? "" // inactive row total cells should be really empty (no "-") when they have no value (RAIL-1525)
-            : params.formatValue(params.value);
+            : escape(params.formatValue(params.value)); // we still need to escape here in case the HTML is in the value itself (RAIL-1623)
     const className = params.node.rowPinned === "top" ? "gd-sticky-header-value" : "s-value";
     return `<span class="${className}">${formattedValue || ""}</span>`;
 };


### PR DESCRIPTION
[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2311
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2065
