### PR TITLE
BUGFIX: SD-526 fix treemap with null data point; SD-525 fix disable saturation others series in combo

### DIFF
--- a/src/components/visualizations/chart/highcharts/dataLabelsHelpers.ts
+++ b/src/components/visualizations/chart/highcharts/dataLabelsHelpers.ts
@@ -128,11 +128,12 @@ export function getDataLabelAttributes(point: any): IRectBySize {
 
 export function intersectsParentLabel(point: any, points: any) {
     const pointParent = parseInt(point.parent, 10);
-    if (isNaN(pointParent)) {
+    // Highchart 7 doesn't render dataLabel at points which have null value
+    const pointLabelShape = point.dataLabel;
+    if (isNaN(pointParent) || !pointLabelShape) {
         return false;
     }
 
-    const pointLabelShape = point.dataLabel;
     const parentPoint = points[pointParent];
     const parentLabelShape = parentPoint.dataLabel;
     return isIntersecting(pointLabelShape, parentLabelShape);

--- a/src/helpers/mdObjBucketHelper.ts
+++ b/src/helpers/mdObjBucketHelper.ts
@@ -1,8 +1,12 @@
 // (C) 2019 GoodData Corporation
 import get = require("lodash/get");
+import isEmpty = require("lodash/isEmpty");
 import { VisualizationObject } from "@gooddata/typings";
 
-export function findBucketByLocalIdentifier(buckets: VisualizationObject.IBucket[], bucketName: string) {
+export function findBucketByLocalIdentifier(
+    buckets: VisualizationObject.IBucket[],
+    bucketName: string,
+): VisualizationObject.IBucket {
     return (buckets || []).find(bucket => bucket.localIdentifier === bucketName);
 }
 
@@ -11,4 +15,8 @@ export function getBucketItems(
     localIdentifier: string,
 ): VisualizationObject.BucketItem[] {
     return get(findBucketByLocalIdentifier(buckets, localIdentifier), "items", []);
+}
+
+export function isBucketEmpty(buckets: VisualizationObject.IBucket[], bucketName: string): boolean {
+    return isEmpty(getBucketItems(buckets, bucketName));
 }


### PR DESCRIPTION
[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2320
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2077

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
- SD-525: https://jira.intgdc.com/browse/SD-525
- SD-526: https://jira.intgdc.com/browse/SD-526
