### PR TITLE
RELATED: ONE-3851 Fix internal intl provider

### DIFF
--- a/src/internal/components/DisabledBubbleMessage.tsx
+++ b/src/internal/components/DisabledBubbleMessage.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
+import { InjectedIntlProps, injectIntl } from "react-intl";
 import * as classNames from "classnames";
 import Bubble from "@gooddata/goodstrap/lib/Bubble/Bubble";
 import BubbleHoverTrigger from "@gooddata/goodstrap/lib/Bubble/BubbleHoverTrigger";
@@ -9,10 +9,9 @@ import { getTranslation } from "../utils/translations";
 export interface IBubbleMessageProps {
     showDisabledMessage: boolean;
     className?: string;
-    intl?: InjectedIntl;
 }
 
-export default class DisabledBubbleMessage extends React.PureComponent<IBubbleMessageProps> {
+export class DisabledBubbleMessage extends React.PureComponent<IBubbleMessageProps & InjectedIntlProps> {
     public render() {
         const { className, children, intl } = this.props;
         return (
@@ -31,3 +30,5 @@ export default class DisabledBubbleMessage extends React.PureComponent<IBubbleMe
         });
     }
 }
+
+export default injectIntl(DisabledBubbleMessage);

--- a/src/internal/components/configurationControls/CheckboxControl.tsx
+++ b/src/internal/components/configurationControls/CheckboxControl.tsx
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
-import noop = require("lodash/noop");
+import { injectIntl, InjectedIntlProps } from "react-intl";
 import set = require("lodash/set");
 import DisabledBubbleMessage from "../DisabledBubbleMessage";
 import { IVisualizationProperties } from "../../interfaces/Visualization";
@@ -11,22 +10,20 @@ export interface ICheckboxControlProps {
     valuePath: string;
     properties: IVisualizationProperties;
     labelText?: string;
-    intl?: InjectedIntl;
     checked?: boolean;
     disabled?: boolean;
     showDisabledMessage?: boolean;
     pushData(data: any): void;
 }
 
-export default class CheckboxControl extends React.Component<ICheckboxControlProps> {
+class CheckboxControl extends React.Component<ICheckboxControlProps & InjectedIntlProps> {
     public static defaultProps = {
         checked: false,
         disabled: false,
         showDisabledMessage: false,
-        intl: noop,
     };
 
-    constructor(props: ICheckboxControlProps) {
+    constructor(props: ICheckboxControlProps & InjectedIntlProps) {
         super(props);
 
         this.onValueChanged = this.onValueChanged.bind(this);
@@ -35,7 +32,7 @@ export default class CheckboxControl extends React.Component<ICheckboxControlPro
     public render() {
         const { checked, disabled, labelText, showDisabledMessage, intl } = this.props;
         return (
-            <DisabledBubbleMessage showDisabledMessage={showDisabledMessage} intl={intl}>
+            <DisabledBubbleMessage showDisabledMessage={showDisabledMessage}>
                 <label className="input-checkbox-label">
                     <input
                         checked={checked}
@@ -57,3 +54,5 @@ export default class CheckboxControl extends React.Component<ICheckboxControlPro
         pushData({ properties: newProperties });
     }
 }
+
+export default injectIntl(CheckboxControl);

--- a/src/internal/components/configurationControls/ConfigSection.tsx
+++ b/src/internal/components/configurationControls/ConfigSection.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
+import { injectIntl, InjectedIntlProps } from "react-intl";
 import * as classNames from "classnames";
 import noop = require("lodash/noop");
 import get = require("lodash/get");
@@ -16,7 +16,6 @@ export interface IConfigSectionProps {
     canBeToggled?: boolean;
     toggleDisabled?: boolean;
     toggledOn?: boolean;
-    intl?: InjectedIntl;
     propertiesMeta: any;
     properties?: any;
     title: string;
@@ -30,13 +29,15 @@ export interface IConfigSectionState {
     collapsed: boolean;
 }
 
-export default class ConfigSection extends React.Component<IConfigSectionProps, IConfigSectionState> {
+export class ConfigSection extends React.Component<
+    IConfigSectionProps & InjectedIntlProps,
+    IConfigSectionState
+> {
     public static defaultProps = {
         collapsed: true,
         canBeToggled: false,
         toggleDisabled: false,
         toggledOn: true,
-        intl: noop,
         disabled: false,
         pushData: noop,
         showDisabledMessage: false,
@@ -44,7 +45,7 @@ export default class ConfigSection extends React.Component<IConfigSectionProps, 
         properties: {},
     };
 
-    constructor(props: IConfigSectionProps) {
+    constructor(props: IConfigSectionProps & InjectedIntlProps) {
         super(props);
 
         this.toggleCollapsed = this.toggleCollapsed.bind(this);
@@ -57,7 +58,7 @@ export default class ConfigSection extends React.Component<IConfigSectionProps, 
         };
     }
 
-    public componentWillReceiveProps(nextProps: IConfigSectionProps) {
+    public componentWillReceiveProps(nextProps: IConfigSectionProps & InjectedIntlProps) {
         const collapsed = get(nextProps, `propertiesMeta.${this.props.id}.collapsed`, true);
         this.setState({ collapsed });
     }
@@ -82,13 +83,12 @@ export default class ConfigSection extends React.Component<IConfigSectionProps, 
 
     private renderToggleSwitch() {
         if (this.props.canBeToggled) {
-            const { toggledOn, toggleDisabled, showDisabledMessage, intl } = this.props;
+            const { toggledOn, toggleDisabled, showDisabledMessage } = this.props;
 
             return (
                 <DisabledBubbleMessage
                     className="adi-bucket-item-toggle"
                     showDisabledMessage={showDisabledMessage}
-                    intl={intl}
                 >
                     <label className={this.getToggleLabelClassNames()}>
                         <input
@@ -153,3 +153,5 @@ export default class ConfigSection extends React.Component<IConfigSectionProps, 
         }
     }
 }
+
+export default injectIntl(ConfigSection);

--- a/src/internal/components/configurationControls/ConfigSubsection.tsx
+++ b/src/internal/components/configurationControls/ConfigSubsection.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
+import { InjectedIntlProps, injectIntl } from "react-intl";
 import noop = require("lodash/noop");
 import set = require("lodash/set");
 import DisabledBubbleMessage from "../DisabledBubbleMessage";
@@ -10,7 +10,6 @@ import { getTranslation } from "../../utils/translations";
 export interface IConfigSubsectionProps {
     valuePath?: string;
     title: string;
-    intl?: InjectedIntl;
     canBeToggled?: boolean;
     toggleDisabled?: boolean;
     toggledOn?: boolean;
@@ -23,8 +22,8 @@ export interface IConfigSubsectionState {
     disabled: boolean;
 }
 
-export default class ConfigSubsection extends React.Component<
-    IConfigSubsectionProps,
+class ConfigSubsection extends React.Component<
+    IConfigSubsectionProps & InjectedIntlProps,
     IConfigSubsectionState
 > {
     public static defaultProps = {
@@ -33,11 +32,10 @@ export default class ConfigSubsection extends React.Component<
         toggleDisabled: false,
         toggledOn: true,
         pushData: noop,
-        intl: noop,
         showDisabledMessage: false,
     };
 
-    constructor(props: IConfigSubsectionProps) {
+    constructor(props: IConfigSubsectionProps & InjectedIntlProps) {
         super(props);
         this.toggleValue = this.toggleValue.bind(this);
     }
@@ -60,13 +58,12 @@ export default class ConfigSubsection extends React.Component<
 
     private renderToggleSwitch() {
         if (this.props.canBeToggled) {
-            const { toggledOn, toggleDisabled, showDisabledMessage, intl } = this.props;
+            const { toggledOn, toggleDisabled, showDisabledMessage } = this.props;
 
             return (
                 <DisabledBubbleMessage
                     className="input-checkbox-toggle"
                     showDisabledMessage={showDisabledMessage}
-                    intl={intl}
                 >
                     <label className="s-checkbox-toggle-label">
                         <input
@@ -95,3 +92,5 @@ export default class ConfigSubsection extends React.Component<
         }
     }
 }
+
+export default injectIntl(ConfigSubsection);

--- a/src/internal/components/configurationControls/DataLabelsControl.tsx
+++ b/src/internal/components/configurationControls/DataLabelsControl.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
+import { InjectedIntlProps, injectIntl } from "react-intl";
 import get = require("lodash/get");
 import DropdownControl from "./DropdownControl";
 
@@ -11,13 +11,12 @@ import { IVisualizationProperties } from "../../interfaces/Visualization";
 export interface IDataLabelsControlProps {
     pushData: (data: any) => any;
     properties: IVisualizationProperties;
-    intl: InjectedIntl;
     isDisabled: boolean;
     showDisabledMessage?: boolean;
     defaultValue?: string | boolean;
 }
 
-export default class DataLabelsControl extends React.Component<IDataLabelsControlProps> {
+class DataLabelsControl extends React.Component<IDataLabelsControlProps & InjectedIntlProps> {
     public static defaultProps = {
         defaultValue: "auto",
         showDisabledMessage: false,
@@ -32,7 +31,6 @@ export default class DataLabelsControl extends React.Component<IDataLabelsContro
                     value={dataLabels}
                     valuePath="dataLabels.visible"
                     labelText="properties.canvas.dataLabels"
-                    intl={intl}
                     disabled={isDisabled}
                     properties={properties}
                     pushData={pushData}
@@ -43,3 +41,5 @@ export default class DataLabelsControl extends React.Component<IDataLabelsContro
         );
     }
 }
+
+export default injectIntl(DataLabelsControl);

--- a/src/internal/components/configurationControls/DropdownControl.tsx
+++ b/src/internal/components/configurationControls/DropdownControl.tsx
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
-import noop = require("lodash/noop");
+import { injectIntl, InjectedIntlProps } from "react-intl";
 import set = require("lodash/set");
 import Dropdown, { DropdownButton, DropdownBody } from "@gooddata/goodstrap/lib/Dropdown/Dropdown";
 import DisabledBubbleMessage from "../DisabledBubbleMessage";
@@ -20,7 +19,6 @@ export interface IDropdownControlProps {
     valuePath: string;
     properties: IVisualizationProperties;
     labelText?: string;
-    intl?: InjectedIntl;
     value?: string;
     items?: IDropdownItem[];
     disabled?: boolean;
@@ -33,17 +31,16 @@ const alignPoints = ["bl tl", "tl bl", "br tr", "tr br"];
 
 export const DROPDOWN_ALIGMENTS = alignPoints.map(align => ({ align, offset: { x: 1, y: 0 } }));
 
-export default class DropdownControl extends React.PureComponent<IDropdownControlProps> {
+class DropdownControl extends React.PureComponent<IDropdownControlProps & InjectedIntlProps> {
     public static defaultProps = {
         value: "",
-        items: [] as IDropdownItem,
+        items: [] as IDropdownItem[],
         disabled: false,
         width: 117,
-        intl: noop,
         showDisabledMessage: false,
     };
 
-    constructor(props: IDropdownControlProps) {
+    constructor(props: IDropdownControlProps & InjectedIntlProps) {
         super(props);
         this.onSelect = this.onSelect.bind(this);
     }
@@ -53,7 +50,7 @@ export default class DropdownControl extends React.PureComponent<IDropdownContro
         const selectedItem = this.getSelectedItem(value) || {};
 
         return (
-            <DisabledBubbleMessage showDisabledMessage={showDisabledMessage} intl={intl}>
+            <DisabledBubbleMessage showDisabledMessage={showDisabledMessage}>
                 <div className="adi-properties-dropdown-container">
                     <span className="input-label-text">{getTranslation(labelText, intl)}</span>
                     <label className="adi-bucket-inputfield gd-input gd-input-small">
@@ -100,3 +97,5 @@ export default class DropdownControl extends React.PureComponent<IDropdownContro
         return undefined;
     }
 }
+
+export default injectIntl(DropdownControl);

--- a/src/internal/components/configurationControls/InputControl.tsx
+++ b/src/internal/components/configurationControls/InputControl.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
+import { InjectedIntlProps, injectIntl } from "react-intl";
 import noop = require("lodash/noop");
 import set = require("lodash/set");
 import cloneDeep = require("lodash/cloneDeep");
@@ -15,7 +15,6 @@ export interface IInputControlProps {
     labelText?: string;
     value?: string;
     placeholder?: string;
-    intl?: InjectedIntl;
     type?: string;
     max?: number;
     min?: number;
@@ -34,7 +33,10 @@ export interface IInputControlState {
 
 const MAX_NUMBER_LENGTH = 15;
 
-export default class InputControl extends React.Component<IInputControlProps, IInputControlState> {
+export class InputControl extends React.Component<
+    IInputControlProps & InjectedIntlProps,
+    IInputControlState
+> {
     public static defaultProps = {
         value: "",
         type: "text",
@@ -50,7 +52,7 @@ export default class InputControl extends React.Component<IInputControlProps, II
 
     private inputRef: HTMLElement;
 
-    constructor(props: IInputControlProps) {
+    constructor(props: IInputControlProps & InjectedIntlProps) {
         super(props);
 
         this.state = {
@@ -64,7 +66,7 @@ export default class InputControl extends React.Component<IInputControlProps, II
         this.triggerBlur = this.triggerBlur.bind(this);
     }
 
-    public componentWillReceiveProps(newProps: IInputControlProps) {
+    public componentWillReceiveProps(newProps: IInputControlProps & InjectedIntlProps) {
         if (newProps.value !== this.state.value) {
             this.setState({
                 value: newProps.value,
@@ -177,3 +179,5 @@ export default class InputControl extends React.Component<IInputControlProps, II
         }
     }
 }
+
+export default injectIntl(InputControl);

--- a/src/internal/components/configurationControls/MinMaxControl.tsx
+++ b/src/internal/components/configurationControls/MinMaxControl.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 import get = require("lodash/get");
 import Message from "@gooddata/goodstrap/lib/Messages/Message";
+import { InjectedIntlProps, injectIntl } from "react-intl";
 
 import ConfigSubsection from "../configurationControls/ConfigSubsection";
 import InputControl from "../configurationControls/InputControl";
@@ -22,8 +23,8 @@ const defaultMinMaxControlState = {
     },
 };
 
-export default class MinMaxControl extends React.Component<IMinMaxControlProps, IMinMaxControlState> {
-    public static getDerivedStateFromProps(props: IMinMaxControlProps) {
+class MinMaxControl extends React.Component<IMinMaxControlProps & InjectedIntlProps, IMinMaxControlState> {
+    public static getDerivedStateFromProps(props: IMinMaxControlProps & InjectedIntlProps) {
         if (get(props, ["propertiesMeta", "undoApplied"], false)) {
             return defaultMinMaxControlState;
         }
@@ -31,7 +32,7 @@ export default class MinMaxControl extends React.Component<IMinMaxControlProps, 
         return null;
     }
 
-    constructor(props: IMinMaxControlProps) {
+    constructor(props: IMinMaxControlProps & InjectedIntlProps) {
         super(props);
         this.state = defaultMinMaxControlState;
     }
@@ -41,18 +42,17 @@ export default class MinMaxControl extends React.Component<IMinMaxControlProps, 
     }
 
     private renderMinMaxSection() {
-        const { properties, intl, basePath, isDisabled } = this.props;
+        const { properties, basePath, isDisabled } = this.props;
         const axisScaleMin = get(this.props, `properties.controls.${basePath}.min`, "");
         const axisScaleMax = get(this.props, `properties.controls.${basePath}.max`, "");
         const axisVisible = get(this.props, `properties.controls.${basePath}.visible`, true);
 
         return (
-            <ConfigSubsection title="properties.axis.scale" intl={intl}>
+            <ConfigSubsection title="properties.axis.scale">
                 <InputControl
                     valuePath={`${basePath}.min`}
                     labelText="properties.axis.min"
                     placeholder="properties.auto_placeholder"
-                    intl={intl}
                     type="number"
                     hasWarning={this.minScaleHasWarning()}
                     value={
@@ -70,7 +70,6 @@ export default class MinMaxControl extends React.Component<IMinMaxControlProps, 
                     valuePath={`${basePath}.max`}
                     labelText="properties.axis.max"
                     placeholder="properties.auto_placeholder"
-                    intl={intl}
                     type="number"
                     hasWarning={this.maxScaleHasWarning()}
                     value={
@@ -149,3 +148,5 @@ export default class MinMaxControl extends React.Component<IMinMaxControlProps, 
         );
     }
 }
+
+export default injectIntl(MinMaxControl);

--- a/src/internal/components/configurationControls/UnsupportedProperties.tsx
+++ b/src/internal/components/configurationControls/UnsupportedProperties.tsx
@@ -1,22 +1,13 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import * as classNames from "classnames";
-import { getTranslation } from "../../utils/translations";
 
-export interface IUnsupportedPropertiesProps {
-    intl: InjectedIntl;
-}
-
-export default class UnsupportedProperties extends React.Component<IUnsupportedPropertiesProps, null> {
-    constructor(props: IUnsupportedPropertiesProps) {
-        super(props);
-    }
-
+export default class UnsupportedProperties extends React.Component {
     public render() {
         return (
             <div className={this.getClassNames()}>
-                {getTranslation("properties.unsupported", this.props.intl)}
+                <FormattedMessage id="properties.unsupported" />
             </div>
         );
     }

--- a/src/internal/components/configurationControls/axis/LabelRotationControl.tsx
+++ b/src/internal/components/configurationControls/axis/LabelRotationControl.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
+import { InjectedIntlProps, injectIntl } from "react-intl";
 import get = require("lodash/get");
 
 import DropdownControl from "../DropdownControl";
@@ -13,12 +13,11 @@ export interface ILabelRotationControl {
     disabled: boolean;
     configPanelDisabled: boolean;
     axis: AxisType;
-    intl: InjectedIntl;
     properties: IVisualizationProperties;
     pushData: (data: any) => any;
 }
 
-export default class LabelRotationControl extends React.PureComponent<ILabelRotationControl, {}> {
+class LabelRotationControl extends React.PureComponent<ILabelRotationControl & InjectedIntlProps, {}> {
     public render() {
         const { axisVisible, axisLabelsEnabled, axisRotation } = this.getControlProperties();
 
@@ -28,7 +27,6 @@ export default class LabelRotationControl extends React.PureComponent<ILabelRota
                 value={axisRotation}
                 valuePath={`${this.props.axis}.rotation`}
                 labelText="properties.axis.rotation"
-                intl={this.props.intl}
                 disabled={isDisabled}
                 showDisabledMessage={!this.props.configPanelDisabled && isDisabled}
                 properties={this.props.properties}
@@ -54,3 +52,5 @@ export default class LabelRotationControl extends React.PureComponent<ILabelRota
         };
     }
 }
+
+export default injectIntl(LabelRotationControl);

--- a/src/internal/components/configurationControls/axis/LabelSubsection.tsx
+++ b/src/internal/components/configurationControls/axis/LabelSubsection.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
+import { InjectedIntlProps, injectIntl } from "react-intl";
 import ConfigSubsection from "../../configurationControls/ConfigSubsection";
 import get = require("lodash/get");
 import { AxisType } from "../../../interfaces/AxisType";
@@ -11,12 +11,11 @@ export interface ILabelSubsection {
     disabled: boolean;
     configPanelDisabled: boolean;
     axis: AxisType;
-    intl: InjectedIntl;
     properties: IVisualizationProperties;
     pushData: (data: any) => any;
 }
 
-export default class LabelSubsection extends React.PureComponent<ILabelSubsection, {}> {
+class LabelSubsection extends React.PureComponent<ILabelSubsection & InjectedIntlProps, {}> {
     public render() {
         const { axisVisible, axisLabelsEnabled } = this.getControlProperties();
 
@@ -24,7 +23,6 @@ export default class LabelSubsection extends React.PureComponent<ILabelSubsectio
             <ConfigSubsection
                 title="properties.axis.labels"
                 valuePath={`${this.props.axis}.labelsEnabled`}
-                intl={this.props.intl}
                 properties={this.props.properties}
                 pushData={this.props.pushData}
                 canBeToggled={true}
@@ -36,7 +34,6 @@ export default class LabelSubsection extends React.PureComponent<ILabelSubsectio
                     disabled={this.props.disabled}
                     configPanelDisabled={this.props.configPanelDisabled}
                     axis={this.props.axis}
-                    intl={this.props.intl}
                     properties={this.props.properties}
                     pushData={this.props.pushData}
                 />
@@ -58,3 +55,5 @@ export default class LabelSubsection extends React.PureComponent<ILabelSubsectio
         };
     }
 }
+
+export default injectIntl(LabelSubsection);

--- a/src/internal/components/configurationControls/axis/tests/LabelRotationControl.spec.tsx
+++ b/src/internal/components/configurationControls/axis/tests/LabelRotationControl.spec.tsx
@@ -1,12 +1,11 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
 import { mount } from "enzyme";
-import { createInternalIntl } from "../../../../utils/internalIntlProvider";
 import noop = require("lodash/noop");
 import cloneDeep = require("lodash/cloneDeep");
 import set = require("lodash/set");
-import { IntlProvider } from "react-intl";
 
+import { InternalIntlWrapper } from "../../../../utils/internalIntlProvider";
 import LabelRotationControl, { ILabelRotationControl } from "../LabelRotationControl";
 import DropdownControl from "../../DropdownControl";
 
@@ -15,16 +14,15 @@ const defaultProps: ILabelRotationControl = {
     configPanelDisabled: false,
     properties: {},
     axis: "xaxis",
-    intl: createInternalIntl(),
     pushData: noop,
 };
 
 function createComponent(customProps: Partial<ILabelRotationControl> = {}) {
     const props: ILabelRotationControl = { ...cloneDeep(defaultProps), ...customProps };
     return mount<ILabelRotationControl, null>(
-        <IntlProvider locale="en">
+        <InternalIntlWrapper>
             <LabelRotationControl {...props} />
-        </IntlProvider>,
+        </InternalIntlWrapper>,
     );
 }
 

--- a/src/internal/components/configurationControls/axis/tests/LabelSubsection.spec.tsx
+++ b/src/internal/components/configurationControls/axis/tests/LabelSubsection.spec.tsx
@@ -1,30 +1,28 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
 import { mount } from "enzyme";
-import { createInternalIntl } from "../../../../utils/internalIntlProvider";
 import noop = require("lodash/noop");
 import cloneDeep = require("lodash/cloneDeep");
 import set = require("lodash/set");
-import { IntlProvider } from "react-intl";
 import LabelSubsection, { ILabelSubsection } from "../LabelSubsection";
 import LabelRotationControl from "../LabelRotationControl";
 import ConfigSubsection from "../../../configurationControls/ConfigSubsection";
+import { InternalIntlWrapper } from "../../../../utils/internalIntlProvider";
 
 const defaultProps: ILabelSubsection = {
     disabled: true,
     configPanelDisabled: false,
     properties: {},
     axis: "xaxis",
-    intl: createInternalIntl(),
     pushData: noop,
 };
 
 function createComponent(customProps: Partial<ILabelSubsection> = {}) {
     const props: ILabelSubsection = { ...cloneDeep(defaultProps), ...customProps };
     return mount<ILabelSubsection, null>(
-        <IntlProvider locale="en">
+        <InternalIntlWrapper>
             <LabelSubsection {...props} />
-        </IntlProvider>,
+        </InternalIntlWrapper>,
     );
 }
 

--- a/src/internal/components/configurationControls/colors/ColorsSection.tsx
+++ b/src/internal/components/configurationControls/colors/ColorsSection.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import set = require("lodash/set");
 import get = require("lodash/get");
 import cloneDeep = require("lodash/cloneDeep");
-import { InjectedIntl } from "react-intl";
+import { injectIntl, InjectedIntlProps } from "react-intl";
 import { IColorItem } from "@gooddata/gooddata-js";
 import Button from "@gooddata/goodstrap/lib/Button/Button";
 import * as classNames from "classnames";
@@ -18,7 +18,6 @@ import { getColoredInputItems, getProperties } from "../../../utils/colors";
 export interface IColorsSectionProps {
     controlsDisabled: boolean;
     showCustomPicker: boolean;
-    intl: InjectedIntl;
     properties: IVisualizationProperties;
     propertiesMeta: any;
     references: IReferences;
@@ -30,14 +29,13 @@ export interface IColorsSectionProps {
 
 export const COLOR_MAPPING_CHANGED = "COLOR_MAPPING_CHANGED";
 
-export default class ColorsSection extends React.Component<IColorsSectionProps> {
+class ColorsSection extends React.Component<IColorsSectionProps & InjectedIntlProps> {
     public render() {
-        const { intl, pushData, propertiesMeta } = this.props;
+        const { pushData, propertiesMeta } = this.props;
 
         return (
             <ConfigSection
                 title="properties.colors"
-                intl={intl}
                 pushData={pushData}
                 propertiesMeta={propertiesMeta}
                 id="colors_section"
@@ -140,3 +138,5 @@ export default class ColorsSection extends React.Component<IColorsSectionProps> 
         return this.isColoredListVisible() ? this.renderColoredList() : this.renderUnsupportedColoredList();
     }
 }
+
+export default injectIntl(ColorsSection);

--- a/src/internal/components/configurationControls/colors/colorDropdown/ColorDropdown.tsx
+++ b/src/internal/components/configurationControls/colors/colorDropdown/ColorDropdown.tsx
@@ -1,7 +1,7 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
 import ColorPicker from "@gooddata/goodstrap/lib/ColorPicker/ColorPicker";
+import { InjectedIntlProps, injectIntl } from "react-intl";
 import { TypeGuards, IColor, IColorItem } from "@gooddata/gooddata-js";
 import * as uuid from "uuid";
 import ColorOverlay, { DropdownVersionType } from "./ColorOverlay";
@@ -24,7 +24,6 @@ export interface IColorDropdownProps {
     colorPalette: ChartConfiguration.IColorPalette;
     showCustomPicker: boolean;
     onColorSelected: (color: IColorItem) => void;
-    intl?: InjectedIntl;
 }
 
 export interface IColorDropdownState {
@@ -38,10 +37,13 @@ const COLOR_FOR_UNKNOWN_ITEM: IColor = {
     b: 0,
 };
 
-export default class ColorDropdown extends React.PureComponent<IColorDropdownProps, IColorDropdownState> {
+class ColorDropdown extends React.PureComponent<
+    IColorDropdownProps & InjectedIntlProps,
+    IColorDropdownState
+> {
     private id: string;
 
-    constructor(props: IColorDropdownProps) {
+    constructor(props: IColorDropdownProps & InjectedIntlProps) {
         super(props);
         this.id = uuid.v4();
         this.state = {
@@ -100,9 +102,7 @@ export default class ColorDropdown extends React.PureComponent<IColorDropdownPro
                     colorPalette={this.props.colorPalette}
                     onColorSelected={this.onColorSelected}
                 />
-                {this.props.showCustomPicker && (
-                    <CustomColorButton onClick={this.onCustomColorButtonClick} intl={this.props.intl} />
-                )}
+                {this.props.showCustomPicker && <CustomColorButton onClick={this.onCustomColorButtonClick} />}
             </div>
         );
     }
@@ -191,3 +191,5 @@ export default class ColorDropdown extends React.PureComponent<IColorDropdownPro
         });
     }
 }
+
+export default injectIntl(ColorDropdown);

--- a/src/internal/components/configurationControls/colors/colorDropdown/CustomColorButton.tsx
+++ b/src/internal/components/configurationControls/colors/colorDropdown/CustomColorButton.tsx
@@ -1,15 +1,14 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
 import Button from "@gooddata/goodstrap/lib/Button/Button";
-import { InjectedIntl } from "react-intl";
+import { InjectedIntlProps, injectIntl } from "react-intl";
 import { getTranslation } from "../../../../utils/translations";
 
 export interface ICustomColorButtonProps {
     onClick: () => void;
-    intl: InjectedIntl;
 }
 
-export default class CustomColorButton extends React.PureComponent<ICustomColorButtonProps> {
+class CustomColorButton extends React.PureComponent<ICustomColorButtonProps & InjectedIntlProps> {
     public render() {
         return (
             <div className="gd-color-drop-down-custom-section">
@@ -26,3 +25,5 @@ export default class CustomColorButton extends React.PureComponent<ICustomColorB
         this.props.onClick();
     };
 }
+
+export default injectIntl(CustomColorButton);

--- a/src/internal/components/configurationControls/colors/colorDropdown/tests/ColorDropdown.spec.tsx
+++ b/src/internal/components/configurationControls/colors/colorDropdown/tests/ColorDropdown.spec.tsx
@@ -17,7 +17,6 @@ const defaultProps: IColorDropdownProps = {
         type: "guid",
         value: "04",
     },
-    intl: null,
     colorPalette,
     showCustomPicker: false,
     onColorSelected: noop,

--- a/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItem.tsx
+++ b/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItem.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
+import { InjectedIntlProps, injectIntl } from "react-intl";
 import { IColorItem } from "@gooddata/gooddata-js";
 import ColoredItemContent from "./ColoredItemContent";
 import ColorDropdown from "../colorDropdown/ColorDropdown";
@@ -16,10 +16,9 @@ export interface IColoredItemProps {
     showCustomPicker?: boolean;
     isSelected?: boolean;
     disabled?: boolean;
-    intl: InjectedIntl;
 }
 
-export class ColoredItem extends React.PureComponent<IColoredItemProps> {
+class ColoredItem extends React.PureComponent<IColoredItemProps & InjectedIntlProps> {
     public static defaultProps = {
         showCustomPicker: false,
         disabled: false,
@@ -41,7 +40,6 @@ export class ColoredItem extends React.PureComponent<IColoredItemProps> {
                 colorPalette={this.props.colorPalette}
                 onColorSelected={this.onColorSelected}
                 showCustomPicker={this.props.showCustomPicker}
-                intl={this.props.intl}
             >
                 <ColoredItemContent text={text} color={coloredItem.color} />
             </ColorDropdown>
@@ -71,3 +69,5 @@ export class ColoredItem extends React.PureComponent<IColoredItemProps> {
         return text;
     }
 }
+
+export default injectIntl(ColoredItem);

--- a/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItemsList.tsx
+++ b/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItemsList.tsx
@@ -6,10 +6,9 @@ import { DropdownBody } from "@gooddata/goodstrap/lib/Dropdown/Dropdown";
 import * as ChartConfiguration from "../../../../../interfaces/Config";
 import { IColorItem } from "@gooddata/gooddata-js";
 
-import { ColoredItem } from "./ColoredItem";
+import ColoredItem from "./ColoredItem";
 import { getSearchedItems } from "../../../../utils/colors";
 import { IColoredItem } from "../../../../interfaces/Colors";
-import { InternalIntlWrapper } from "../../../../utils/internalIntlProvider";
 
 const VISIBLE_ITEMS_COUNT = 5;
 const SEARCHFIELD_VISIBILITY_THRESHOLD = 7;
@@ -54,29 +53,26 @@ class ColoredItemsList extends React.PureComponent<IColoredItemsListProps, IColo
 
         return (
             <div ref={this.listRef}>
-                <InternalIntlWrapper locale={this.props.intl.locale}>
-                    <DropdownBody
-                        width={DROPDOWN_BODY_WIDTH}
-                        isSearchFieldVisible={this.isSearchFieldVisible()}
-                        searchString={searchString}
-                        onSearch={this.onSearch}
-                        onScrollStart={this.onScroll}
-                        items={items}
-                        rowItem={
-                            <ColoredItem
-                                colorPalette={this.props.colorPalette}
-                                onSelect={this.onSelect}
-                                showCustomPicker={this.props.showCustomPicker}
-                                disabled={this.props.disabled}
-                                intl={this.props.intl}
-                            />
-                        }
-                        className="gd-colored-items-list"
-                        maxVisibleItemsCount={VISIBLE_ITEMS_COUNT}
-                        disabled={this.props.disabled}
-                        isLoading={this.props.isLoading}
-                    />
-                </InternalIntlWrapper>
+                <DropdownBody
+                    width={DROPDOWN_BODY_WIDTH}
+                    isSearchFieldVisible={this.isSearchFieldVisible()}
+                    searchString={searchString}
+                    onSearch={this.onSearch}
+                    onScrollStart={this.onScroll}
+                    items={items}
+                    rowItem={
+                        <ColoredItem
+                            colorPalette={this.props.colorPalette}
+                            onSelect={this.onSelect}
+                            showCustomPicker={this.props.showCustomPicker}
+                            disabled={this.props.disabled}
+                        />
+                    }
+                    className="gd-colored-items-list"
+                    maxVisibleItemsCount={VISIBLE_ITEMS_COUNT}
+                    disabled={this.props.disabled}
+                    isLoading={this.props.isLoading}
+                />
             </div>
         );
     }

--- a/src/internal/components/configurationControls/colors/tests/ColorsSection.spec.tsx
+++ b/src/internal/components/configurationControls/colors/tests/ColorsSection.spec.tsx
@@ -2,14 +2,13 @@
 import * as React from "react";
 import { mount } from "enzyme";
 import { noop, cloneDeep } from "lodash";
-import { IntlProvider } from "react-intl";
 import * as ChartConfiguration from "../../../../../interfaces/Config";
 import { IColorItem } from "@gooddata/gooddata-js";
 
-import { createInternalIntl } from "../../../../utils/internalIntlProvider";
 import ColoredItemsList from "../coloredItemsList/ColoredItemsList";
 import ColorsSection, { IColorsSectionProps, COLOR_MAPPING_CHANGED } from "../ColorsSection";
 import { IColorConfiguration } from "../../../../interfaces/Colors";
+import { InternalIntlWrapper } from "../../../../utils/internalIntlProvider";
 
 const colors: IColorConfiguration = {
     colorPalette: ChartConfiguration.DEFAULT_COLOR_PALETTE,
@@ -45,15 +44,14 @@ const defaultProps: IColorsSectionProps = {
     hasMeasures: true,
     colors,
     isLoading: false,
-    intl: createInternalIntl(),
 };
 
 function createComponent(customProps: Partial<IColorsSectionProps> = {}) {
     const props: IColorsSectionProps = { ...cloneDeep(defaultProps), ...customProps };
     return mount<IColorsSectionProps>(
-        <IntlProvider locale="en-US">
+        <InternalIntlWrapper>
             <ColorsSection {...props} />
-        </IntlProvider>,
+        </InternalIntlWrapper>,
     );
 }
 

--- a/src/internal/components/configurationControls/legend/LegendPositionControl.tsx
+++ b/src/internal/components/configurationControls/legend/LegendPositionControl.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
+import { injectIntl, InjectedIntlProps } from "react-intl";
 
 import DropdownControl from "../DropdownControl";
 import { legendPositionDropdownItems } from "../../../constants/dropdowns";
@@ -11,19 +11,17 @@ export interface ILegendPositionControl {
     disabled: boolean;
     value: string;
     showDisabledMessage: boolean;
-    intl: InjectedIntl;
     properties: IVisualizationProperties;
     pushData: (data: any) => any;
 }
 
-export default class LegendPositionControl extends React.PureComponent<ILegendPositionControl, {}> {
+class LegendPositionControl extends React.PureComponent<ILegendPositionControl & InjectedIntlProps, {}> {
     public render() {
         return (
             <DropdownControl
                 value={this.props.value}
                 valuePath="legend.position"
                 labelText="properties.legend.position"
-                intl={this.props.intl}
                 disabled={this.props.disabled}
                 properties={this.props.properties}
                 pushData={this.props.pushData}
@@ -37,3 +35,5 @@ export default class LegendPositionControl extends React.PureComponent<ILegendPo
         return getTranslatedDropdownItems(legendPositionDropdownItems, this.props.intl);
     }
 }
+
+export default injectIntl(LegendPositionControl);

--- a/src/internal/components/configurationControls/legend/LegendSection.tsx
+++ b/src/internal/components/configurationControls/legend/LegendSection.tsx
@@ -1,6 +1,5 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
 import ConfigSection from "../ConfigSection";
 import LegendPositionControl from "./LegendPositionControl";
 import { IVisualizationProperties } from "../../../interfaces/Visualization";
@@ -10,13 +9,12 @@ export interface ILegendSection {
     controlsDisabled: boolean;
     properties: IVisualizationProperties;
     propertiesMeta: any;
-    intl: InjectedIntl;
     pushData: (data: any) => any;
 }
 
-export default class LegendSection extends React.PureComponent<ILegendSection, {}> {
+export class LegendSection extends React.PureComponent<ILegendSection, {}> {
     public render() {
-        const { controlsDisabled, properties, intl, pushData } = this.props;
+        const { controlsDisabled, properties, pushData } = this.props;
 
         const legendEnabled = get(this.props, "properties.controls.legend.enabled", true);
         const legendPosition = get(this.props, "properties.controls.legend.position", "auto");
@@ -31,7 +29,6 @@ export default class LegendSection extends React.PureComponent<ILegendSection, {
                 id="legend_section"
                 valuePath="legend.enabled"
                 title="properties.legend.title"
-                intl={intl}
                 propertiesMeta={this.props.propertiesMeta}
                 properties={properties}
                 canBeToggled={true}
@@ -44,7 +41,6 @@ export default class LegendSection extends React.PureComponent<ILegendSection, {
                     disabled={legendPositionControlDisabled}
                     value={legendPosition}
                     showDisabledMessage={showDisabledMessage}
-                    intl={intl}
                     properties={properties}
                     pushData={pushData}
                 />
@@ -52,3 +48,5 @@ export default class LegendSection extends React.PureComponent<ILegendSection, {
         );
     }
 }
+
+export default LegendSection;

--- a/src/internal/components/configurationControls/legend/tests/LegendSection.spec.tsx
+++ b/src/internal/components/configurationControls/legend/tests/LegendSection.spec.tsx
@@ -3,26 +3,24 @@ import * as React from "react";
 import { mount } from "enzyme";
 import LegendSection, { ILegendSection } from "../LegendSection";
 import LegendPositionControl from "../LegendPositionControl";
-import { createInternalIntl } from "../../../../utils/internalIntlProvider";
+import { InternalIntlWrapper } from "../../../../utils/internalIntlProvider";
 import noop = require("lodash/noop");
 import cloneDeep = require("lodash/cloneDeep");
 import set = require("lodash/set");
-import { IntlProvider } from "react-intl";
 
 const defaultProps: ILegendSection = {
     controlsDisabled: true,
     properties: {},
     propertiesMeta: {},
-    intl: createInternalIntl(),
     pushData: noop,
 };
 
 function createComponent(customProps: Partial<ILegendSection> = {}) {
     const props: ILegendSection = { ...cloneDeep(defaultProps), ...customProps };
-    return mount<ILegendSection, null>(
-        <IntlProvider locale="en">
+    return mount(
+        <InternalIntlWrapper>
             <LegendSection {...props} />
-        </IntlProvider>,
+        </InternalIntlWrapper>,
     );
 }
 

--- a/src/internal/components/configurationControls/tests/CheckboxControl.spec.tsx
+++ b/src/internal/components/configurationControls/tests/CheckboxControl.spec.tsx
@@ -1,11 +1,10 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import noop = require("lodash/noop");
-import { createInternalIntl } from "../../../utils/internalIntlProvider";
+import { InternalIntlWrapper } from "../../../utils/internalIntlProvider";
 
 import CheckboxControl, { ICheckboxControlProps } from "../CheckboxControl";
-import { DEFAULT_LOCALE } from "../../../../constants/localization";
 
 describe("CheckboxControl", () => {
     const defaultProps = {
@@ -13,15 +12,16 @@ describe("CheckboxControl", () => {
         labelText: "properties.canvas.gridline",
         properties: {},
         propertiesMeta: {},
-        intl: createInternalIntl(DEFAULT_LOCALE),
         pushData: noop,
     };
 
     function createComponent(customProps: Partial<ICheckboxControlProps> = {}) {
         const props = { ...defaultProps, ...customProps };
-        return shallow<ICheckboxControlProps, null>(<CheckboxControl {...props} />, {
-            lifecycleExperimental: true,
-        });
+        return mount(
+            <InternalIntlWrapper>
+                <CheckboxControl {...props} />
+            </InternalIntlWrapper>,
+        );
     }
 
     it("should render checkbox control", () => {

--- a/src/internal/components/configurationControls/tests/ConfigSection.spec.tsx
+++ b/src/internal/components/configurationControls/tests/ConfigSection.spec.tsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 import noop = require("lodash/noop");
-import ConfigSection, { IConfigSectionProps } from "../ConfigSection";
+import { ConfigSection, IConfigSectionProps } from "../ConfigSection";
 import { createInternalIntl } from "../../../utils/internalIntlProvider";
 import { DEFAULT_LOCALE } from "../../../../constants/localization";
 

--- a/src/internal/components/configurationControls/tests/ConfigSubsection.spec.tsx
+++ b/src/internal/components/configurationControls/tests/ConfigSubsection.spec.tsx
@@ -1,9 +1,9 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import ConfigSubsection, { IConfigSubsectionProps } from "../ConfigSubsection";
-import { createInternalIntl } from "../../../utils/internalIntlProvider";
-import { DEFAULT_LOCALE } from "../../../../constants/localization";
+import DisabledBubbleMessage from "../../DisabledBubbleMessage";
+import { InternalIntlWrapper } from "../../../utils/internalIntlProvider";
 
 describe("ConfigSubsection", () => {
     const defaultProps = {
@@ -11,16 +11,16 @@ describe("ConfigSubsection", () => {
         properties: {},
         propertiesMeta: {},
         title: "properties.legend.title",
-        intl: createInternalIntl(DEFAULT_LOCALE),
     };
 
     function createComponent(customProps: Partial<IConfigSubsectionProps> = {}) {
         const props = { ...defaultProps, ...customProps };
-        return shallow<IConfigSubsectionProps, null>(
-            <ConfigSubsection {...props}>
-                <div className="child" />
-            </ConfigSubsection>,
-            { lifecycleExperimental: true },
+        return mount(
+            <InternalIntlWrapper>
+                <ConfigSubsection {...props}>
+                    <div className="child" />
+                </ConfigSubsection>
+            </InternalIntlWrapper>,
         );
     }
 
@@ -42,7 +42,7 @@ describe("ConfigSubsection", () => {
         it('should render toggle switch when property "canBeToggled" is set on true', () => {
             const wrapper = createComponent({ canBeToggled: true });
 
-            expect(wrapper.find(".input-checkbox-toggle").length).toBe(1);
+            expect(wrapper.find(DisabledBubbleMessage).hasClass("input-checkbox-toggle")).toBe(true);
             expect(wrapper.find(".s-checkbox-toggle").props().disabled).toBeFalsy();
         });
 

--- a/src/internal/components/configurationControls/tests/DataLabelsControl.spec.tsx
+++ b/src/internal/components/configurationControls/tests/DataLabelsControl.spec.tsx
@@ -3,20 +3,22 @@ import * as React from "react";
 import { mount } from "enzyme";
 import noop = require("lodash/noop");
 import DataLabelsControl, { IDataLabelsControlProps } from "../DataLabelsControl";
-import { createInternalIntl } from "../../../utils/internalIntlProvider";
-import { DEFAULT_LOCALE } from "../../../../constants/localization";
+import { InternalIntlWrapper } from "../../../utils/internalIntlProvider";
 
 describe("DataLabelsControl", () => {
     const defaultProps = {
         properties: {},
-        intl: createInternalIntl(DEFAULT_LOCALE),
         pushData: noop,
         isDisabled: false,
     };
 
     function createComponent(customProps: Partial<IDataLabelsControlProps> = {}) {
         const props = { ...defaultProps, ...customProps };
-        return mount<IDataLabelsControlProps, null>(<DataLabelsControl {...props} />);
+        return mount(
+            <InternalIntlWrapper>
+                <DataLabelsControl {...props} />
+            </InternalIntlWrapper>,
+        );
     }
 
     describe("Rendering", () => {

--- a/src/internal/components/configurationControls/tests/DropdownControl.spec.tsx
+++ b/src/internal/components/configurationControls/tests/DropdownControl.spec.tsx
@@ -4,21 +4,23 @@ import { mount } from "enzyme";
 import noop = require("lodash/noop");
 import Dropdown from "@gooddata/goodstrap/lib/Dropdown/Dropdown";
 import DropdownControl, { IDropdownControlProps } from "../DropdownControl";
-import { createInternalIntl } from "../../../utils/internalIntlProvider";
-import { DEFAULT_LOCALE } from "../../../../constants/localization";
+import { InternalIntlWrapper } from "../../../utils/internalIntlProvider";
 
 describe("DropdownControl", () => {
     const defaultProps = {
         valuePath: "valuePath",
         labelText: "properties.legend.title",
-        intl: createInternalIntl(DEFAULT_LOCALE),
         properties: {},
         pushData: noop,
     };
 
     function createComponent(customProps: Partial<IDropdownControlProps> = {}) {
         const props = { ...defaultProps, ...customProps };
-        return mount(<DropdownControl {...props} />);
+        return mount(
+            <InternalIntlWrapper>
+                <DropdownControl {...props} />
+            </InternalIntlWrapper>,
+        );
     }
 
     it("should render dropdown control", () => {

--- a/src/internal/components/configurationControls/tests/InputControl.spec.tsx
+++ b/src/internal/components/configurationControls/tests/InputControl.spec.tsx
@@ -2,14 +2,18 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 import noop = require("lodash/noop");
-import InputControl, { IInputControlProps } from "../InputControl";
+import { InputControl, IInputControlProps } from "../InputControl";
+import { createInternalIntl } from "../../../utils/internalIntlProvider";
 
 describe("InputControl", () => {
     const defaultProps = {
         valuePath: "valuePath",
         properties: {},
+        intl: createInternalIntl(),
         propertiesMeta: {},
         pushData: noop,
+        placeholder: "properties.auto_placeholder",
+        labelText: "properties.canvas.gridline", // pick something what exists in the dictionary
     };
 
     function createComponent(customProps: Partial<IInputControlProps> = {}) {
@@ -36,8 +40,9 @@ describe("InputControl", () => {
     });
 
     it("should render label provided by props", () => {
-        const wrapper = createComponent({ labelText: "foo" });
-        expect(wrapper.find(".input-label-text").text()).toEqual("foo");
+        // pick something in the dictionary
+        const wrapper = createComponent({ labelText: "properties.canvas.title" });
+        expect(wrapper.find(".input-label-text").text()).toEqual("Canvas");
     });
 
     it("should render input control with given value", () => {

--- a/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
@@ -1,5 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
+import { FormattedMessage } from "react-intl";
 import get = require("lodash/get");
 import includes = require("lodash/includes");
 import * as BucketNames from "../../../constants/bucketNames";
@@ -12,7 +13,6 @@ import ConfigurationPanelContent from "./ConfigurationPanelContent";
 import ConfigSection from "../configurationControls/ConfigSection";
 import CheckboxControl from "../configurationControls/CheckboxControl";
 import DataLabelsControl from "../configurationControls/DataLabelsControl";
-import { getTranslation } from "../../utils/translations";
 import {
     SHOW_DELAY_DEFAULT,
     HIDE_DELAY_DEFAULT,
@@ -28,13 +28,12 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
     protected renderCanvasSection() {
         const { gridEnabled } = this.getControlProperties();
 
-        const { properties, propertiesMeta, intl, pushData } = this.props;
+        const { properties, propertiesMeta, pushData } = this.props;
         const controlsDisabled = this.isControlDisabled();
         return (
             <ConfigSection
                 id="canvas_section"
                 title="properties.canvas.title"
-                intl={intl}
                 propertiesMeta={propertiesMeta}
                 properties={properties}
                 pushData={pushData}
@@ -42,13 +41,11 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
                 <DataLabelsControl
                     pushData={pushData}
                     properties={properties}
-                    intl={intl}
                     isDisabled={controlsDisabled}
                 />
                 <CheckboxControl
                     valuePath="grid.enabled"
                     labelText="properties.canvas.gridline"
-                    intl={intl}
                     properties={properties}
                     checked={gridEnabled}
                     disabled={controlsDisabled}
@@ -61,7 +58,7 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
     protected renderConfigurationPanel() {
         const { axes } = this.getControlProperties();
 
-        const { properties, propertiesMeta, intl } = this.props;
+        const { properties, propertiesMeta } = this.props;
 
         return (
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
@@ -76,7 +73,7 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
                     arrowOffsets={{ "tc bc": [BUBBLE_ARROW_OFFSET_X, BUBBLE_ARROW_OFFSET_Y] }}
                     alignPoints={[{ align: "tc bc" }]}
                 >
-                    {getTranslation("properties.config.not_applicable", intl)}
+                    <FormattedMessage id="properties.config.not_applicable" />
                 </Bubble>
             </BubbleHoverTrigger>
         );
@@ -132,7 +129,6 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
     ) {
         const controlsDisabled = this.isControlDisabled();
         const isViewedBy = this.isViewedBy();
-        const { intl } = this.props;
 
         return axes.map(axis => (
             <ConfigSection
@@ -140,7 +136,6 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
                 id={`${axis.name}_section`}
                 title={axis.title}
                 subtitle={axis.subtitle}
-                intl={intl}
                 valuePath={`${axis.name}.visible`}
                 canBeToggled={true}
                 toggledOn={axis.visible}
@@ -153,7 +148,6 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
                     disabled={controlsDisabled || (!axis.primary && !isViewedBy)}
                     configPanelDisabled={controlsDisabled}
                     axis={axis.name}
-                    intl={intl}
                     properties={properties}
                     pushData={this.props.pushData}
                 />
@@ -163,13 +157,12 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
     }
 
     protected renderMinMax(basePath: string) {
-        const { pushData, properties, intl, propertiesMeta } = this.props;
+        const { pushData, properties, propertiesMeta } = this.props;
         return (
             <MinMaxControl
                 isDisabled={this.isControlDisabled()}
                 basePath={basePath}
                 pushData={pushData}
-                intl={intl}
                 properties={properties}
                 propertiesMeta={propertiesMeta}
             />

--- a/src/internal/components/configurationPanels/BubbleChartConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/BubbleChartConfigurationPanel.tsx
@@ -1,6 +1,7 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
 import get = require("lodash/get");
+import { FormattedMessage } from "react-intl";
 import Bubble from "@gooddata/goodstrap/lib/Bubble/Bubble";
 import BubbleHoverTrigger from "@gooddata/goodstrap/lib/Bubble/BubbleHoverTrigger";
 import * as classNames from "classnames";
@@ -10,7 +11,6 @@ import LabelSubsection from "../configurationControls/axis/LabelSubsection";
 import ConfigSection from "../configurationControls/ConfigSection";
 import DataLabelsControl from "../configurationControls/DataLabelsControl";
 import CheckboxControl from "../configurationControls/CheckboxControl";
-import { getTranslation } from "../../utils/translations";
 import MinMaxControl from "../configurationControls//MinMaxControl";
 import { hasTertiaryMeasures } from "../../utils/mdObjectHelper";
 import {
@@ -24,7 +24,7 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
     protected renderConfigurationPanel() {
         const { xAxisVisible, yAxisVisible, gridEnabled } = this.getControlProperties();
 
-        const { propertiesMeta, properties, intl, pushData } = this.props;
+        const { propertiesMeta, properties, pushData } = this.props;
         const controlsDisabled = this.isControlDisabled();
 
         return (
@@ -35,7 +35,6 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                         id="xaxis_section"
                         title="properties.xaxis.title"
                         valuePath="xaxis.visible"
-                        intl={intl}
                         canBeToggled={true}
                         toggledOn={xAxisVisible}
                         toggleDisabled={controlsDisabled}
@@ -47,7 +46,6 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                             disabled={controlsDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={"xaxis"}
-                            intl={intl}
                             properties={properties}
                             pushData={pushData}
                         />
@@ -57,7 +55,6 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                         id="yaxis_section"
                         title="properties.yaxis.title"
                         valuePath="yaxis.visible"
-                        intl={intl}
                         canBeToggled={true}
                         toggledOn={yAxisVisible}
                         toggleDisabled={controlsDisabled}
@@ -69,7 +66,6 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                             disabled={controlsDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={"yaxis"}
-                            intl={intl}
                             properties={properties}
                             pushData={pushData}
                         />
@@ -79,7 +75,6 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                     <ConfigSection
                         id="canvas_section"
                         title="properties.canvas.title"
-                        intl={intl}
                         propertiesMeta={propertiesMeta}
                         properties={properties}
                         pushData={pushData}
@@ -87,7 +82,6 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                         <DataLabelsControl
                             pushData={pushData}
                             properties={properties}
-                            intl={intl}
                             isDisabled={this.areDataLabelsDisabled()}
                             defaultValue={false}
                             showDisabledMessage={this.isDataLabelsWarningShown()}
@@ -95,7 +89,6 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                         <CheckboxControl
                             valuePath="grid.enabled"
                             labelText="properties.canvas.gridline"
-                            intl={intl}
                             properties={properties}
                             checked={gridEnabled}
                             disabled={controlsDisabled}
@@ -108,20 +101,19 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                     arrowOffsets={{ "tc bc": [BUBBLE_ARROW_OFFSET_X, BUBBLE_ARROW_OFFSET_Y] }}
                     alignPoints={[{ align: "tc bc" }]}
                 >
-                    {getTranslation("properties.config.not_applicable", intl)}
+                    <FormattedMessage id="properties.config.not_applicable" />
                 </Bubble>
             </BubbleHoverTrigger>
         );
     }
 
     private renderMinMax(basePath: string) {
-        const { pushData, properties, intl, propertiesMeta } = this.props;
+        const { pushData, properties, propertiesMeta } = this.props;
         return (
             <MinMaxControl
                 isDisabled={this.isControlDisabled()}
                 basePath={basePath}
                 pushData={pushData}
-                intl={intl}
                 properties={properties}
                 propertiesMeta={propertiesMeta}
             />

--- a/src/internal/components/configurationPanels/ConfigurationPanelContent.tsx
+++ b/src/internal/components/configurationPanels/ConfigurationPanelContent.tsx
@@ -1,6 +1,5 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { InjectedIntl } from "react-intl";
 import noop = require("lodash/noop");
 import { ChartType } from "../../../constants/visualizationTypes";
 import { VisualizationObject } from "@gooddata/typings";
@@ -11,13 +10,14 @@ import { IColorConfiguration } from "../../interfaces/Colors";
 import ColorsSection from "../configurationControls/colors/ColorsSection";
 import LegendSection from "../configurationControls/legend/LegendSection";
 import { InternalIntlWrapper } from "../../utils/internalIntlProvider";
+import { DEFAULT_LOCALE } from "../../../constants/localization";
 
 export interface IConfigurationPanelContentProps {
     properties?: IVisualizationProperties;
     references?: IReferences;
     propertiesMeta?: any;
     colors?: IColorConfiguration;
-    intl?: InjectedIntl;
+    locale: string;
     type?: ChartType;
     isError?: boolean;
     isLoading?: boolean;
@@ -35,7 +35,7 @@ export default abstract class ConfigurationPanelContent extends React.PureCompon
         references: null,
         propertiesMeta: null,
         colors: null,
-        intl: null,
+        locale: DEFAULT_LOCALE,
         isError: false,
         isLoading: false,
         mdObject: null,
@@ -49,7 +49,9 @@ export default abstract class ConfigurationPanelContent extends React.PureCompon
     public render() {
         return (
             <div key={`config-${this.props.type}`}>
-                <InternalIntlWrapper>{this.renderConfigurationPanel()}</InternalIntlWrapper>
+                <InternalIntlWrapper locale={this.props.locale}>
+                    {this.renderConfigurationPanel()}
+                </InternalIntlWrapper>
             </div>
         );
     }
@@ -65,7 +67,6 @@ export default abstract class ConfigurationPanelContent extends React.PureCompon
         const {
             properties,
             propertiesMeta,
-            intl,
             pushData,
             colors,
             featureFlags,
@@ -83,7 +84,6 @@ export default abstract class ConfigurationPanelContent extends React.PureCompon
                 references={references}
                 colors={colors}
                 controlsDisabled={controlsDisabled}
-                intl={intl}
                 pushData={pushData}
                 hasMeasures={hasMeasures(mdObject)}
                 showCustomPicker={featureFlags.enableCustomColorPicker as boolean}
@@ -93,7 +93,7 @@ export default abstract class ConfigurationPanelContent extends React.PureCompon
     }
 
     protected renderLegendSection() {
-        const { properties, propertiesMeta, intl, pushData } = this.props;
+        const { properties, propertiesMeta, pushData } = this.props;
         const controlsDisabled = this.isControlDisabled();
 
         return (
@@ -101,7 +101,6 @@ export default abstract class ConfigurationPanelContent extends React.PureCompon
                 properties={properties}
                 propertiesMeta={propertiesMeta}
                 controlsDisabled={controlsDisabled}
-                intl={intl}
                 pushData={pushData}
             />
         );

--- a/src/internal/components/configurationPanels/HeatMapConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/HeatMapConfigurationPanel.tsx
@@ -1,5 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
+import { FormattedMessage } from "react-intl";
 import Bubble from "@gooddata/goodstrap/lib/Bubble/Bubble";
 import BubbleHoverTrigger from "@gooddata/goodstrap/lib/Bubble/BubbleHoverTrigger";
 import { VisualizationObject } from "@gooddata/typings";
@@ -9,7 +10,6 @@ import * as classNames from "classnames";
 import ConfigurationPanelContent from "./ConfigurationPanelContent";
 import ConfigSection from "../configurationControls/ConfigSection";
 import DataLabelsControl from "../configurationControls/DataLabelsControl";
-import { getTranslation } from "../../utils/translations";
 import {
     SHOW_DELAY_DEFAULT,
     HIDE_DELAY_DEFAULT,
@@ -22,7 +22,7 @@ import { noRowsAndHasOneMeasure, noColumnsAndHasOneMeasure } from "../../utils/b
 
 export default class HeatMapConfigurationPanel extends ConfigurationPanelContent {
     protected renderConfigurationPanel() {
-        const { propertiesMeta, properties, intl, pushData } = this.props;
+        const { propertiesMeta, properties, pushData } = this.props;
         const { xAxisVisible, yAxisVisible } = this.getControlProperties();
 
         const controlsDisabled = this.isControlDisabled();
@@ -37,7 +37,6 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
                         id="xaxis_section"
                         title="properties.xaxis.title"
                         valuePath="xaxis.visible"
-                        intl={intl}
                         canBeToggled={true}
                         toggledOn={xAxisVisible}
                         toggleDisabled={xAxisDisabled}
@@ -50,7 +49,6 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
                             disabled={xAxisDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={"xaxis"}
-                            intl={intl}
                             properties={properties}
                             pushData={pushData}
                         />
@@ -59,7 +57,6 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
                         id="yaxis_section"
                         title="properties.yaxis.title"
                         valuePath="yaxis.visible"
-                        intl={intl}
                         canBeToggled={true}
                         toggledOn={yAxisVisible}
                         toggleDisabled={yAxisDisabled}
@@ -72,7 +69,6 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
                             disabled={yAxisDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={"yaxis"}
-                            intl={intl}
                             properties={properties}
                             pushData={pushData}
                         />
@@ -81,7 +77,6 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
                     <ConfigSection
                         id="canvas_section"
                         title="properties.canvas.title"
-                        intl={intl}
                         propertiesMeta={propertiesMeta}
                         properties={properties}
                         pushData={pushData}
@@ -89,7 +84,6 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
                         <DataLabelsControl
                             pushData={pushData}
                             properties={properties}
-                            intl={intl}
                             isDisabled={controlsDisabled}
                             defaultValue="auto"
                         />
@@ -100,7 +94,7 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
                     arrowOffsets={{ "tc bc": [BUBBLE_ARROW_OFFSET_X, BUBBLE_ARROW_OFFSET_Y] }}
                     alignPoints={[{ align: "tc bc" }]}
                 >
-                    {getTranslation("properties.config.not_applicable", intl)}
+                    <FormattedMessage id="properties.config.not_applicable" />
                 </Bubble>
             </BubbleHoverTrigger>
         );

--- a/src/internal/components/configurationPanels/LineChartBasedConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/LineChartBasedConfigurationPanel.tsx
@@ -1,11 +1,11 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
+import { FormattedMessage } from "react-intl";
 import Bubble from "@gooddata/goodstrap/lib/Bubble/Bubble";
 import BubbleHoverTrigger from "@gooddata/goodstrap/lib/Bubble/BubbleHoverTrigger";
 import ConfigSection from "../configurationControls/ConfigSection";
 import CheckboxControl from "../configurationControls/CheckboxControl";
 import DataLabelsControl from "../configurationControls/DataLabelsControl";
-import { getTranslation } from "../../utils/translations";
 import {
     SHOW_DELAY_DEFAULT,
     HIDE_DELAY_DEFAULT,
@@ -18,7 +18,7 @@ export default class LineChartBasedConfigurationPanel extends BaseChartConfigura
     protected renderConfigurationPanel() {
         const { gridEnabled, axes } = this.getControlProperties();
 
-        const { properties, propertiesMeta, intl, pushData } = this.props;
+        const { properties, propertiesMeta, pushData } = this.props;
         const controlsDisabled = this.isControlDisabled();
 
         return (
@@ -30,7 +30,6 @@ export default class LineChartBasedConfigurationPanel extends BaseChartConfigura
                     <ConfigSection
                         id="canvas_section"
                         title="properties.canvas.title"
-                        intl={intl}
                         propertiesMeta={propertiesMeta}
                         properties={properties}
                         pushData={pushData}
@@ -38,14 +37,12 @@ export default class LineChartBasedConfigurationPanel extends BaseChartConfigura
                         <DataLabelsControl
                             pushData={pushData}
                             properties={properties}
-                            intl={intl}
                             isDisabled={controlsDisabled}
                             defaultValue={false}
                         />
                         <CheckboxControl
                             valuePath="grid.enabled"
                             labelText="properties.canvas.gridline"
-                            intl={intl}
                             properties={properties}
                             checked={gridEnabled}
                             disabled={controlsDisabled}
@@ -58,7 +55,7 @@ export default class LineChartBasedConfigurationPanel extends BaseChartConfigura
                     arrowOffsets={{ "tc bc": [BUBBLE_ARROW_OFFSET_X, BUBBLE_ARROW_OFFSET_Y] }}
                     alignPoints={[{ align: "tc bc" }]}
                 >
-                    {getTranslation("properties.config.not_applicable", intl)}
+                    <FormattedMessage id="properties.config.not_applicable" />
                 </Bubble>
             </BubbleHoverTrigger>
         );

--- a/src/internal/components/configurationPanels/PieChartConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/PieChartConfigurationPanel.tsx
@@ -1,13 +1,13 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
 import * as classNames from "classnames";
+import { FormattedMessage } from "react-intl";
 import Bubble from "@gooddata/goodstrap/lib/Bubble/Bubble";
 import BubbleHoverTrigger from "@gooddata/goodstrap/lib/Bubble/BubbleHoverTrigger";
 
 import ConfigurationPanelContent from "./ConfigurationPanelContent";
 import ConfigSection from "../configurationControls/ConfigSection";
 import DataLabelsControl from "../configurationControls/DataLabelsControl";
-import { getTranslation } from "../../utils/translations";
 import {
     SHOW_DELAY_DEFAULT,
     HIDE_DELAY_DEFAULT,
@@ -17,7 +17,7 @@ import {
 
 export default class PieChartConfigurationPanel extends ConfigurationPanelContent {
     protected renderConfigurationPanel() {
-        const { propertiesMeta, properties, intl, pushData } = this.props;
+        const { propertiesMeta, properties, pushData } = this.props;
         const controlsDisabled = this.isControlDisabled();
 
         return (
@@ -28,7 +28,6 @@ export default class PieChartConfigurationPanel extends ConfigurationPanelConten
                     <ConfigSection
                         id="canvas_section"
                         title="properties.canvas.title"
-                        intl={intl}
                         propertiesMeta={propertiesMeta}
                         properties={properties}
                         pushData={pushData}
@@ -36,7 +35,6 @@ export default class PieChartConfigurationPanel extends ConfigurationPanelConten
                         <DataLabelsControl
                             pushData={pushData}
                             properties={properties}
-                            intl={intl}
                             isDisabled={controlsDisabled}
                             defaultValue={false}
                         />
@@ -47,7 +45,7 @@ export default class PieChartConfigurationPanel extends ConfigurationPanelConten
                     arrowOffsets={{ "tc bc": [BUBBLE_ARROW_OFFSET_X, BUBBLE_ARROW_OFFSET_Y] }}
                     alignPoints={[{ align: "tc bc" }]}
                 >
-                    {getTranslation("properties.config.not_applicable", intl)}
+                    <FormattedMessage id="properties.config.not_applicable" />
                 </Bubble>
             </BubbleHoverTrigger>
         );

--- a/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
@@ -1,5 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
+import { FormattedMessage } from "react-intl";
 import get = require("lodash/get");
 import Bubble from "@gooddata/goodstrap/lib/Bubble/Bubble";
 import BubbleHoverTrigger from "@gooddata/goodstrap/lib/Bubble/BubbleHoverTrigger";
@@ -12,7 +13,6 @@ import ConfigSection from "../configurationControls/ConfigSection";
 import DataLabelsControl from "../configurationControls/DataLabelsControl";
 import CheckboxControl from "../configurationControls/CheckboxControl";
 import { getMeasuresFromMdObject } from "../../utils/bucketHelper";
-import { getTranslation } from "../../utils/translations";
 import { hasAttribute } from "../../utils/mdObjectHelper";
 import {
     SHOW_DELAY_DEFAULT,
@@ -31,7 +31,7 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
     protected renderConfigurationPanel() {
         const { xAxisVisible, gridEnabled, yAxisVisible } = this.getControlProperties();
 
-        const { propertiesMeta, properties, intl, pushData } = this.props;
+        const { propertiesMeta, properties, pushData } = this.props;
         const controlsDisabled = this.isControlDisabled();
 
         return (
@@ -42,7 +42,6 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                         id="xaxis_section"
                         title="properties.xaxis.title"
                         valuePath="xaxis.visible"
-                        intl={intl}
                         canBeToggled={true}
                         toggledOn={xAxisVisible}
                         toggleDisabled={controlsDisabled}
@@ -54,7 +53,6 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                             disabled={controlsDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={"xaxis"}
-                            intl={intl}
                             properties={properties}
                             pushData={pushData}
                         />
@@ -64,7 +62,6 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                         id="yaxis_section"
                         title="properties.yaxis.title"
                         valuePath="yaxis.visible"
-                        intl={intl}
                         canBeToggled={true}
                         toggledOn={yAxisVisible}
                         toggleDisabled={controlsDisabled}
@@ -76,7 +73,6 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                             disabled={controlsDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={"yaxis"}
-                            intl={intl}
                             properties={properties}
                             pushData={pushData}
                         />
@@ -85,7 +81,6 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                     <ConfigSection
                         id="canvas_section"
                         title="properties.canvas.title"
-                        intl={intl}
                         propertiesMeta={propertiesMeta}
                         properties={properties}
                         pushData={pushData}
@@ -93,7 +88,6 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                         <DataLabelsControl
                             pushData={pushData}
                             properties={properties}
-                            intl={intl}
                             isDisabled={this.areDataLabelsDisabled()}
                             defaultValue={false}
                             showDisabledMessage={this.isDataLabelsWarningShown()}
@@ -101,7 +95,6 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                         <CheckboxControl
                             valuePath="grid.enabled"
                             labelText="properties.canvas.gridline"
-                            intl={intl}
                             properties={properties}
                             checked={gridEnabled}
                             disabled={controlsDisabled}
@@ -114,20 +107,19 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                     arrowOffsets={{ "tc bc": [BUBBLE_ARROW_OFFSET_X, BUBBLE_ARROW_OFFSET_Y] }}
                     alignPoints={[{ align: "tc bc" }]}
                 >
-                    {getTranslation("properties.config.not_applicable", intl)}
+                    <FormattedMessage id="properties.config.not_applicable" />
                 </Bubble>
             </BubbleHoverTrigger>
         );
     }
 
     private renderMinMax(basePath: string) {
-        const { pushData, properties, intl, propertiesMeta } = this.props;
+        const { pushData, properties, propertiesMeta } = this.props;
         return (
             <MinMaxControl
                 isDisabled={this.isControlDisabled()}
                 basePath={basePath}
                 pushData={pushData}
-                intl={intl}
                 properties={properties}
                 propertiesMeta={propertiesMeta}
             />

--- a/src/internal/components/configurationPanels/TreeMapConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/TreeMapConfigurationPanel.tsx
@@ -1,5 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
+import { FormattedMessage } from "react-intl";
 import Bubble from "@gooddata/goodstrap/lib/Bubble/Bubble";
 import BubbleHoverTrigger from "@gooddata/goodstrap/lib/Bubble/BubbleHoverTrigger";
 import * as classNames from "classnames";
@@ -7,7 +8,6 @@ import * as classNames from "classnames";
 import ConfigurationPanelContent from "./ConfigurationPanelContent";
 import ConfigSection from "../configurationControls/ConfigSection";
 import DataLabelsControl from "../configurationControls/DataLabelsControl";
-import { getTranslation } from "../../utils/translations";
 import {
     SHOW_DELAY_DEFAULT,
     HIDE_DELAY_DEFAULT,
@@ -17,7 +17,7 @@ import {
 
 export default class TreeMapConfigurationPanel extends ConfigurationPanelContent {
     protected renderConfigurationPanel() {
-        const { propertiesMeta, properties, intl, pushData } = this.props;
+        const { propertiesMeta, properties, pushData } = this.props;
         const controlsDisabled = this.isControlDisabled();
 
         return (
@@ -28,7 +28,6 @@ export default class TreeMapConfigurationPanel extends ConfigurationPanelContent
                     <ConfigSection
                         id="canvas_section"
                         title="properties.canvas.title"
-                        intl={intl}
                         propertiesMeta={propertiesMeta}
                         properties={properties}
                         pushData={pushData}
@@ -36,7 +35,6 @@ export default class TreeMapConfigurationPanel extends ConfigurationPanelContent
                         <DataLabelsControl
                             pushData={pushData}
                             properties={properties}
-                            intl={intl}
                             isDisabled={controlsDisabled}
                             defaultValue="auto"
                         />
@@ -47,7 +45,7 @@ export default class TreeMapConfigurationPanel extends ConfigurationPanelContent
                     arrowOffsets={{ "tc bc": [BUBBLE_ARROW_OFFSET_X, BUBBLE_ARROW_OFFSET_Y] }}
                     alignPoints={[{ align: "tc bc" }]}
                 >
-                    {getTranslation("properties.config.not_applicable", intl)}
+                    <FormattedMessage id="properties.config.not_applicable" />
                 </Bubble>
             </BubbleHoverTrigger>
         );

--- a/src/internal/components/configurationPanels/UnsupportedConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/UnsupportedConfigurationPanel.tsx
@@ -18,6 +18,6 @@ export default class UnsupportedConfigurationPanel extends ConfigurationPanelCon
     }
 
     protected renderConfigurationPanel() {
-        return <UnsupportedProperties intl={this.props.intl} />;
+        return <UnsupportedProperties />;
     }
 }

--- a/src/internal/components/configurationPanels/tests/BubbleChartConfigurationPanel.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/BubbleChartConfigurationPanel.spec.tsx
@@ -4,9 +4,10 @@ import { shallow } from "enzyme";
 import BubbleChartConfigurationPanel from "../BubbleChartConfigurationPanel";
 import { IConfigurationPanelContentProps } from "../ConfigurationPanelContent";
 import ConfigSection from "../../configurationControls/ConfigSection";
+import { DEFAULT_LOCALE } from "../../../../constants/localization";
 
 describe("BubbleChartconfigurationPanel", () => {
-    function createComponent(props: IConfigurationPanelContentProps = {}) {
+    function createComponent(props: IConfigurationPanelContentProps) {
         return shallow<IConfigurationPanelContentProps, null>(<BubbleChartConfigurationPanel {...props} />, {
             lifecycleExperimental: true,
         });
@@ -33,6 +34,7 @@ describe("BubbleChartconfigurationPanel", () => {
             mdObject,
             isError: false,
             isLoading: false,
+            locale: DEFAULT_LOCALE,
         };
 
         const wrapper = createComponent(props);
@@ -61,6 +63,7 @@ describe("BubbleChartconfigurationPanel", () => {
             mdObject,
             isError: false,
             isLoading: false,
+            locale: DEFAULT_LOCALE,
         };
 
         const wrapper = createComponent(props);
@@ -89,6 +92,7 @@ describe("BubbleChartconfigurationPanel", () => {
             mdObject,
             isError: true,
             isLoading: false,
+            locale: DEFAULT_LOCALE,
         };
 
         const wrapper = createComponent(props);
@@ -117,6 +121,7 @@ describe("BubbleChartconfigurationPanel", () => {
             mdObject,
             isError: false,
             isLoading: true,
+            locale: DEFAULT_LOCALE,
         };
 
         const wrapper = createComponent(props);

--- a/src/internal/components/configurationPanels/tests/ConfigurationPanelContent.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/ConfigurationPanelContent.spec.tsx
@@ -4,6 +4,7 @@ import { shallow } from "enzyme";
 import ConfigurationPanelContent, {
     IConfigurationPanelContentProps,
 } from "../../configurationPanels/ConfigurationPanelContent";
+import { DEFAULT_LOCALE } from "../../../../constants/localization";
 
 class DummyConfigurationPanel extends ConfigurationPanelContent {
     constructor(props: IConfigurationPanelContentProps) {
@@ -21,7 +22,11 @@ class DummyConfigurationPanel extends ConfigurationPanelContent {
 }
 
 describe("ConfigurationPanelContent", () => {
-    function createComponent(props: IConfigurationPanelContentProps = {}) {
+    function createComponent(
+        props: IConfigurationPanelContentProps = {
+            locale: DEFAULT_LOCALE,
+        },
+    ) {
         return shallow<IConfigurationPanelContentProps, null>(<DummyConfigurationPanel {...props} />, {
             lifecycleExperimental: true,
         });

--- a/src/internal/components/configurationPanels/tests/ScatterPlotConfigurationPanel.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/ScatterPlotConfigurationPanel.spec.tsx
@@ -4,16 +4,21 @@ import { shallow } from "enzyme";
 import ScatterPlotConfigurationPanel from "../ScatterPlotConfigurationPanel";
 import { IConfigurationPanelContentProps } from "../ConfigurationPanelContent";
 import ConfigSection from "../../configurationControls/ConfigSection";
+import { DEFAULT_LOCALE } from "../../../../constants/localization";
 
 describe("ScatterPlotConfigurationPanel", () => {
-    function createComponent(props: IConfigurationPanelContentProps = {}) {
+    function createComponent(
+        props: IConfigurationPanelContentProps = {
+            locale: DEFAULT_LOCALE,
+        },
+    ) {
         return shallow<IConfigurationPanelContentProps, null>(<ScatterPlotConfigurationPanel {...props} />, {
             lifecycleExperimental: true,
         });
     }
 
     it("should render three sections in configuration panel for bubble chart", () => {
-        const wrapper = createComponent({});
+        const wrapper = createComponent();
 
         expect(wrapper.find(ConfigSection).length).toBe(3);
     });

--- a/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -129,12 +129,12 @@ export class PluggableAreaChart extends PluggableBaseChart {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <LineChartBasedConfigurationPanel
+                    locale={this.locale}
                     colors={this.colors}
                     properties={this.visualizationProperties}
                     propertiesMeta={this.propertiesMeta}
                     mdObject={this.mdObject}
                     references={this.references}
-                    intl={this.intl}
                     pushData={this.handlePushData}
                     type={this.type}
                     isError={this.isError}

--- a/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -33,12 +33,12 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <BarChartConfigurationPanel
+                    locale={this.locale}
                     colors={this.colors}
                     references={this.references}
                     properties={this.visualizationProperties}
                     propertiesMeta={this.propertiesMeta}
                     mdObject={this.mdObject}
-                    intl={this.intl}
                     pushData={this.handlePushData}
                     type={this.type}
                     isError={this.isError}

--- a/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -94,8 +94,8 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
     protected ignoreUndoRedo: boolean;
     protected axis: string;
     protected secondaryAxis: AxisType;
+    protected locale: ILocale;
     private environment: string;
-    private locale: ILocale;
     private element: string;
 
     constructor(props: IVisConstruct) {
@@ -318,11 +318,11 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <BaseChartConfigurationPanel
+                    locale={this.locale}
                     references={this.references}
                     properties={this.visualizationProperties}
                     propertiesMeta={this.propertiesMeta}
                     mdObject={this.mdObject}
-                    intl={this.intl}
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}

--- a/src/internal/components/pluggableVisualizations/baseChart/tests/PluggableBaseChart.spec.tsx
+++ b/src/internal/components/pluggableVisualizations/baseChart/tests/PluggableBaseChart.spec.tsx
@@ -12,6 +12,7 @@ import BaseChartConfigurationPanel from "../../../configurationPanels/BaseChartC
 import { VisualizationEnvironment } from "../../../../../components/uri/Visualization";
 import { ChartType, VisualizationTypes } from "../../../../../constants/visualizationTypes";
 import { BaseChart } from "../../../../../components/core/base/BaseChart";
+import { DEFAULT_LOCALE } from "../../../../../constants/localization";
 
 jest.mock("react-dom", () => {
     const renderObject = {
@@ -96,6 +97,7 @@ describe("PluggableBaseChart", () => {
 
         return (
             <BaseChartConfigurationPanel
+                locale={DEFAULT_LOCALE}
                 properties={properties}
                 propertiesMeta={propertiesMeta}
                 mdObject={mdObject}
@@ -291,7 +293,6 @@ describe("PluggableBaseChart", () => {
         // compare without intl and pushData
         expect({
             ...renderArguments.props,
-            intl: null,
             pushData: noop,
         }).toEqual(expectedConfigPanelElement.props);
     });

--- a/src/internal/components/pluggableVisualizations/bubbleChart/PluggableBubbleChart.tsx
+++ b/src/internal/components/pluggableVisualizations/bubbleChart/PluggableBubbleChart.tsx
@@ -125,11 +125,11 @@ export class PluggableBubbleChart extends PluggableBaseChart {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <BubbleChartConfigurationPanel
+                    locale={this.locale}
                     references={this.references}
                     properties={this.visualizationProperties}
                     propertiesMeta={this.propertiesMeta}
                     mdObject={this.mdObject}
-                    intl={this.intl}
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}

--- a/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChartDeprecated.tsx
+++ b/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChartDeprecated.tsx
@@ -112,7 +112,7 @@ export class PluggableComboChartDeprecated extends PluggableBaseChart {
 
             render(
                 <UnsupportedConfigurationPanel
-                    intl={this.intl}
+                    locale={this.locale}
                     pushData={this.callbacks.pushData}
                     properties={properties}
                 />,

--- a/src/internal/components/pluggableVisualizations/funnelChart/PluggableFunnelChart.tsx
+++ b/src/internal/components/pluggableVisualizations/funnelChart/PluggableFunnelChart.tsx
@@ -34,7 +34,7 @@ export class PluggableFunnelChart extends PluggablePieChart {
 
             render(
                 <UnsupportedConfigurationPanel
-                    intl={this.intl}
+                    locale={this.locale}
                     pushData={this.callbacks.pushData}
                     properties={properties}
                 />,

--- a/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
+++ b/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
@@ -182,7 +182,7 @@ export class PluggableHeadline extends AbstractPluggableVisualization {
 
             render(
                 <UnsupportedConfigurationPanel
-                    intl={this.intl}
+                    locale={this.locale}
                     pushData={this.callbacks.pushData}
                     properties={getSupportedProperties(properties, this.supportedPropertiesList)}
                 />,

--- a/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -100,12 +100,12 @@ export class PluggableHeatmap extends PluggableBaseChart {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <HeatMapConfigurationPanel
+                    locale={this.locale}
                     references={this.references}
                     properties={this.visualizationProperties}
                     propertiesMeta={this.propertiesMeta}
                     mdObject={this.mdObject}
                     colors={this.colors}
-                    intl={this.intl}
                     pushData={this.handlePushData}
                     type={this.type}
                     isError={this.isError}

--- a/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -125,12 +125,12 @@ export class PluggableLineChart extends PluggableBaseChart {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <LineChartBasedConfigurationPanel
+                    locale={this.locale}
                     references={this.references}
                     properties={this.visualizationProperties}
                     propertiesMeta={this.propertiesMeta}
                     mdObject={this.mdObject}
                     colors={this.colors}
-                    intl={this.intl}
                     pushData={this.handlePushData}
                     type={this.type}
                     isError={this.isError}

--- a/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
+++ b/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
@@ -104,10 +104,10 @@ export class PluggablePieChart extends PluggableBaseChart {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <PieChartConfigurationPanel
+                    locale={this.locale}
                     properties={this.visualizationProperties}
                     propertiesMeta={this.propertiesMeta}
                     mdObject={this.mdObject}
-                    intl={this.intl}
                     pushData={this.handlePushData}
                     colors={this.colors}
                     type={this.type}

--- a/src/internal/components/pluggableVisualizations/pieChart/tests/PluggablePieChart.spec.tsx
+++ b/src/internal/components/pluggableVisualizations/pieChart/tests/PluggablePieChart.spec.tsx
@@ -5,9 +5,11 @@ import * as referencePointMocks from "../../../../mocks/referencePointMocks";
 import * as uiConfigMocks from "../../../../mocks/uiConfigMocks";
 
 import { IBucket, IFilters } from "../../../../interfaces/Visualization";
+import { DEFAULT_LOCALE } from "../../../../../constants/localization";
 
 describe("PluggablePieChart", () => {
     const defaultProps = {
+        locale: DEFAULT_LOCALE,
         projectId: "PROJECTID",
         element: "body",
         configPanelElement: null as string,

--- a/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -492,7 +492,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
 
             render(
                 <UnsupportedConfigurationPanel
-                    intl={this.intl}
+                    locale={this.locale}
                     pushData={this.callbacks.pushData}
                     properties={sanitizedProperties}
                 />,

--- a/src/internal/components/pluggableVisualizations/scatterPlot/PluggableScatterPlot.tsx
+++ b/src/internal/components/pluggableVisualizations/scatterPlot/PluggableScatterPlot.tsx
@@ -108,11 +108,11 @@ export class PluggableScatterPlot extends PluggableBaseChart {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <ScatterPlotConfigurationPanel
+                    locale={this.locale}
                     references={this.references}
                     properties={this.visualizationProperties}
                     propertiesMeta={this.propertiesMeta}
                     mdObject={this.mdObject}
-                    intl={this.intl}
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}

--- a/src/internal/components/pluggableVisualizations/table/PluggableTable.tsx
+++ b/src/internal/components/pluggableVisualizations/table/PluggableTable.tsx
@@ -272,7 +272,7 @@ export class PluggableTable extends AbstractPluggableVisualization {
 
             render(
                 <UnsupportedConfigurationPanel
-                    intl={this.intl}
+                    locale={this.locale}
                     pushData={this.callbacks.pushData}
                     properties={properties}
                 />,

--- a/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
+++ b/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
@@ -108,11 +108,11 @@ export class PluggableTreemap extends PluggableBaseChart {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <TreeMapConfigurationPanel
+                    locale={this.locale}
                     references={this.references}
                     properties={this.visualizationProperties}
                     propertiesMeta={this.propertiesMeta}
                     mdObject={this.mdObject}
-                    intl={this.intl}
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}

--- a/src/internal/components/tests/DisabledBubbleMessage.spec.tsx
+++ b/src/internal/components/tests/DisabledBubbleMessage.spec.tsx
@@ -2,11 +2,12 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 
-import DisabledBubbleMessage from "../DisabledBubbleMessage";
+import { DisabledBubbleMessage } from "../DisabledBubbleMessage";
+import { createInternalIntl } from "../../utils/internalIntlProvider";
 
 function createComponent(showDisabledMessage: boolean = true) {
     return shallow(
-        <DisabledBubbleMessage showDisabledMessage={showDisabledMessage}>
+        <DisabledBubbleMessage intl={createInternalIntl()} showDisabledMessage={showDisabledMessage}>
             <div className={"bubble-trigger"}>{"Foo"}</div>
         </DisabledBubbleMessage>,
     );

--- a/src/internal/interfaces/MinMaxControl.ts
+++ b/src/internal/interfaces/MinMaxControl.ts
@@ -1,12 +1,10 @@
 // (C) 2019 GoodData Corporation
-import { InjectedIntl } from "react-intl";
 import { IVisualizationProperties } from "./Visualization";
 
 export interface IMinMaxControlProps {
     isDisabled: boolean;
     basePath: string;
     pushData: (data: any) => any;
-    intl: InjectedIntl;
     properties: IVisualizationProperties;
     propertiesMeta: any;
 }

--- a/src/internal/utils/controlsHelper.ts
+++ b/src/internal/utils/controlsHelper.ts
@@ -1,6 +1,7 @@
 // (C) 2019 GoodData Corporation
 import get = require("lodash/get");
 import set = require("lodash/set");
+import { InjectedIntlProps } from "react-intl";
 import { getTranslation } from "./translations";
 import { IMinMaxControlState, IMinMaxControlProps } from "../interfaces/MinMaxControl";
 
@@ -25,7 +26,7 @@ export function isInvalidOrMinMaxError(value: string, minNumberValue: number, ma
 export function maxInputValidateAndPushData(
     data: any,
     state: IMinMaxControlState,
-    props: IMinMaxControlProps,
+    props: IMinMaxControlProps & InjectedIntlProps,
     setState: any,
     defaultState: IMinMaxControlState,
 ) {
@@ -83,7 +84,7 @@ export function maxInputValidateAndPushData(
 export function minInputValidateAndPushData(
     data: any,
     state: IMinMaxControlState,
-    props: IMinMaxControlProps,
+    props: IMinMaxControlProps & InjectedIntlProps,
     setState: any,
     defaultState: IMinMaxControlState,
 ) {


### PR DESCRIPTION
Components for config panel inside `internal/` no longer pass intl properties downwards. Instead, they rely on IntlProvider and injectIntl to get correct intl from.

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2330
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2096

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->