### PR TITLE
BUGFIX: SD-508 handle overlap label for combo

### DIFF
--- a/src/components/visualizations/chart/highcharts/plugins/autohideLabels/autohideColumnLabels.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/autohideLabels/autohideColumnLabels.ts
@@ -4,6 +4,7 @@ import zip = require("lodash/zip");
 import values = require("lodash/values");
 import flatten = require("lodash/flatten");
 import identity = require("lodash/identity");
+import isEmpty = require("lodash/isEmpty");
 
 import {
     isStacked,
@@ -27,7 +28,14 @@ import {
     hasShape,
     hasLabelInside,
 } from "../../dataLabelsHelpers";
-import { IPointData } from "../../../../../../interfaces/Config";
+import {
+    IPointData,
+    IAxisConfig,
+    ISeriesItem,
+    IStackItem,
+    IClientRect,
+    IDataLabelsConfig,
+} from "../../../../../../interfaces/Config";
 
 const toggleNonStackedChartLabels = (
     visiblePoints: any,
@@ -104,17 +112,17 @@ export function isOverlappingWidth(visiblePoints: IPointData[]) {
     });
 }
 
-function areNeighborsOverlapping(neighbors: any[]) {
+export function areNeighborsOverlapping(neighbors: IDataLabelsConfig[][]) {
     return neighbors.some(labelsPair => {
-        const [firstLabel, nextLabel]: any[] = labelsPair || [];
+        const [firstLabel, nextLabel]: IDataLabelsConfig[] = labelsPair || [];
 
-        if (firstLabel && nextLabel) {
-            if (firstLabel.alignAttr && nextLabel.alignAttr) {
-                // We need to calculate this from getBBox, because FireFox does not
-                // provide clientWidth attribute
-                const firstLabelWidth = firstLabel.element.getBBox().width;
-                const firstLabelRight = firstLabel.alignAttr.x + firstLabelWidth;
-                const nextLabelLeft = nextLabel.alignAttr.x;
+        if (!isEmpty(firstLabel) && !isEmpty(nextLabel)) {
+            const firstClientRect: IClientRect = firstLabel.element.getBoundingClientRect();
+            const nextClientRect: IClientRect = nextLabel.element.getBoundingClientRect();
+            if (firstClientRect && nextClientRect) {
+                const firstLabelWidth = firstClientRect.width;
+                const firstLabelRight = firstClientRect.x + firstLabelWidth;
+                const nextLabelLeft = nextClientRect.x;
                 return firstLabelRight > nextLabelLeft;
             }
         }
@@ -145,28 +153,35 @@ export function getStackLabelPointsForDualAxis(stacks: any[]) {
     ).filter(identity);
 }
 
-function getStackTotalGroups(yAxis: any[]) {
-    return yAxis.map((axis: any) => axis.stackTotalGroup).filter(identity);
+export function getStackTotalGroups(yAxis: IAxisConfig[]): Highcharts.SVGAttributes[] {
+    return flatten(
+        yAxis.map((axis: IAxisConfig) => {
+            if (!isEmpty(axis.stacks)) {
+                return axis.stackTotalGroup;
+            }
+            return axis.series.map((serie: ISeriesItem) => serie.dataLabelsGroup);
+        }),
+    ).filter(identity);
 }
 
 function toggleStackedLabelsForDualAxis() {
     const { yAxis } = this;
 
     const stackTotalGroups = getStackTotalGroups(yAxis);
-    const stacks = yAxis.map((axis: any) => axis.stacks);
+    const stacks = getStackItems(yAxis);
 
     if (stacks && stackTotalGroups) {
         const points = getStackLabelPointsForDualAxis(stacks);
-        const labels = points.map((point: any) => point.label);
+        const labels = getLabelOrDataLabelForPoints(points);
         const neighbors = toNeighbors(labels);
         const areOverlapping = areNeighborsOverlapping(neighbors);
 
         if (areOverlapping) {
             this.userOptions.stackLabelsVisibility = "hidden";
-            stackTotalGroups.forEach((stackTotalGroup: any) => stackTotalGroup.hide());
+            stackTotalGroups.forEach((stackTotalGroup: Highcharts.SVGAttributes) => stackTotalGroup.hide());
         } else {
             this.userOptions.stackLabelsVisibility = "visible";
-            stackTotalGroups.forEach((stackTotalGroup: any) => stackTotalGroup.show());
+            stackTotalGroups.forEach((stackTotalGroup: Highcharts.SVGAttributes) => stackTotalGroup.show());
         }
     }
 }
@@ -239,3 +254,26 @@ export const handleColumnLabelsOutsideChart = (chart: any) => {
         }
     });
 };
+
+export function getLabelOrDataLabelForPoints(points: IPointData[]): IPointData[] {
+    return points.map((point: IPointData) => {
+        return point.label || point.dataLabel || {};
+    });
+}
+
+export function getStackItems(yAxis: IAxisConfig[]): IStackItem[] {
+    return flatten(
+        yAxis.map((axis: IAxisConfig) => {
+            if (!isEmpty(axis.stacks)) {
+                return axis.stacks;
+            }
+            const series = axis.series;
+            const dataLabels: IStackItem[] = series.map((serie: ISeriesItem) => {
+                return {
+                    column: { ...serie.data },
+                };
+            });
+            return dataLabels;
+        }),
+    );
+}

--- a/src/components/visualizations/chart/highcharts/plugins/autohideLabels/test/autohideColumnLabels.spec.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/autohideLabels/test/autohideColumnLabels.spec.ts
@@ -1,6 +1,12 @@
 // (C) 2007-2019 GoodData Corporation
-import { getStackLabelPointsForDualAxis, isOverlappingWidth } from "../autohideColumnLabels";
-import { IPointData } from "../../../../../../../interfaces/Config";
+import * as autohideColumnLabels from "../autohideColumnLabels";
+import {
+    IPointData,
+    IDataLabelsConfig,
+    IAxisConfig,
+    ISeriesDataItem,
+} from "../../../../../../../interfaces/Config";
+import { VisualizationTypes } from "../../../../../../../constants/visualizationTypes";
 
 describe("getStackLabelPointsForDualAxis", () => {
     it("should return points for column0 and column", () => {
@@ -8,7 +14,7 @@ describe("getStackLabelPointsForDualAxis", () => {
             { column0: { 0: { x: 0, total: 678 }, 1: { x: 1, total: 958 } } },
             { column: { 0: { x: 0, total: 907 }, 1: { x: 1, total: 525 } } },
         ];
-        const points = getStackLabelPointsForDualAxis(stacks);
+        const points = autohideColumnLabels.getStackLabelPointsForDualAxis(stacks);
 
         expect(points).toEqual([
             stacks[0].column0[0],
@@ -23,7 +29,7 @@ describe("getStackLabelPointsForDualAxis", () => {
             { column0: { 0: { x: 0, total: 678 }, 1: { x: 1, total: 958 } } },
             { column1: { 0: { x: 0, total: 907 }, 1: { x: 1, total: 525 } } },
         ];
-        const points = getStackLabelPointsForDualAxis(stacks);
+        const points = autohideColumnLabels.getStackLabelPointsForDualAxis(stacks);
 
         expect(points).toEqual([
             stacks[0].column0[0],
@@ -54,7 +60,7 @@ describe("isOverlappingWidth", () => {
                 },
             },
         ];
-        expect(isOverlappingWidth(visiblePointsWithShape)).toEqual(true);
+        expect(autohideColumnLabels.isOverlappingWidth(visiblePointsWithShape)).toEqual(true);
     });
 
     it("should return false when point has datalabel width less than shape width", () => {
@@ -66,10 +72,147 @@ describe("isOverlappingWidth", () => {
                 },
             },
         ];
-        expect(isOverlappingWidth(visiblePointsWithShape)).toEqual(false);
+        expect(autohideColumnLabels.isOverlappingWidth(visiblePointsWithShape)).toEqual(false);
     });
 
     it("should return false when shapeArgs is undefined", () => {
-        expect(isOverlappingWidth(visiblePointsWithoutShape)).toEqual(false);
+        expect(autohideColumnLabels.isOverlappingWidth(visiblePointsWithoutShape)).toEqual(false);
     });
+});
+
+describe("getLabelOrDataLabelForPoints", () => {
+    const label: IDataLabelsConfig = {
+        width: 98,
+        padding: 1,
+    };
+    const dataLabel: IDataLabelsConfig = {
+        width: 100,
+        padding: 10,
+    };
+    const visiblePoints: IPointData[] = [
+        {
+            x: 0,
+            y: 1,
+        },
+        {
+            x: 0,
+            y: 2,
+            label,
+        },
+        {
+            x: 0,
+            y: 3,
+            dataLabel,
+        },
+    ];
+
+    it.each([
+        [visiblePoints, [{}, label, dataLabel]],
+        [[{ ...visiblePoints[0] }, { ...visiblePoints[1] }], [{}, label]],
+        [
+            [
+                {
+                    ...visiblePoints[0],
+                },
+                { ...visiblePoints[2] },
+            ],
+            [{}, dataLabel],
+        ],
+    ])("should return label/dataLabel of data points", (visiblePoints, expected) => {
+        const labels = autohideColumnLabels.getLabelOrDataLabelForPoints(visiblePoints);
+        expect(labels).toEqual(expected);
+    });
+});
+
+describe("getStackTotalGroups", () => {
+    it("should return stack total group", () => {
+        const stackTotalGroup: Highcharts.SVGAttributes = {
+            translateX: 51,
+            translateY: 20,
+            zIndex: 6,
+        };
+        const yAxis: IAxisConfig[] = [
+            {
+                stacks: { column0: [{ x: 0, total: 678 }, { x: 1, total: 958 }] },
+                stackTotalGroup,
+            },
+        ] as any;
+        const stackLabels = autohideColumnLabels.getStackTotalGroups(yAxis);
+
+        expect(stackLabels).toEqual([stackTotalGroup]);
+    });
+
+    it("should return data labels group", () => {
+        const dataLabelsGroup: Highcharts.SVGAttributes = {
+            translateX: 51,
+            translateY: 20,
+            zIndex: 6,
+        };
+        const yAxis: IAxisConfig[] = [
+            {
+                stacks: {},
+                series: [{ dataLabelsGroup }],
+            },
+        ];
+        const stackLabels = autohideColumnLabels.getStackTotalGroups(yAxis);
+
+        expect(stackLabels).toEqual([dataLabelsGroup]);
+    });
+});
+
+describe("getStackItems", () => {
+    it("should return stack items", () => {
+        const yAxis: IAxisConfig[] = [
+            {
+                stacks: { column0: [{ x: 0, total: 678 }, { x: 1, total: 958 }] },
+            },
+        ] as any[];
+        const stackItems = autohideColumnLabels.getStackItems(yAxis);
+
+        expect(stackItems).toEqual([yAxis[0].stacks]);
+    });
+
+    it("should return data label items", () => {
+        const data: ISeriesDataItem[] = [{ x: 6, y: 7 }, { x: 8, y: 9 }];
+        const yAxis: IAxisConfig[] = [
+            {
+                stacks: {},
+                series: [{ data, type: VisualizationTypes.COLUMN }],
+            },
+        ];
+        const stackItems = autohideColumnLabels.getStackItems(yAxis);
+
+        expect(stackItems).toEqual([
+            {
+                column: {
+                    0: data[0],
+                    1: data[1],
+                },
+            },
+        ]);
+    });
+});
+
+describe("areNeighborsOverlapping", () => {
+    const clientRect = [{ width: 100, x: 10 }, { width: 101, x: 100 }, { width: 102, x: 250 }];
+    function getElement(index: number) {
+        return {
+            getBoundingClientRect: () => {
+                return clientRect[index];
+            },
+        };
+    }
+    const overlaplabels: IDataLabelsConfig[][] = [
+        [{ element: getElement(0) }, { element: getElement(1) }],
+    ] as any[];
+    const withoutOverlapLabel: IDataLabelsConfig[][] = [
+        [{ element: getElement(1) }, { element: getElement(2) }],
+    ] as any;
+    it.each([[true, overlaplabels], [false, withoutOverlapLabel]])(
+        "should return overlap is %s",
+        (isOverlap: number, labels: IDataLabelsConfig[][]) => {
+            const areNeighborsOverlapping = autohideColumnLabels.areNeighborsOverlapping(labels);
+            expect(areNeighborsOverlapping).toEqual(isOverlap);
+        },
+    );
 });

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -16,6 +16,7 @@ export interface IDataLabelsConfig {
     visible?: IDataLabelsVisible;
     width?: number;
     padding?: number;
+    element?: Highcharts.HTMLDOMElement | Highcharts.SVGDOMElement;
 }
 
 export interface IColorMapping {
@@ -115,6 +116,9 @@ export interface IAxisConfig {
     min?: string;
     max?: string;
     measures?: string[];
+    stacks?: IStackItem;
+    series?: ISeriesItem[];
+    stackTotalGroup?: Highcharts.SVGAttributes;
 }
 
 export interface IAxis {
@@ -129,6 +133,11 @@ export interface ISeriesDataItem {
     y: number;
     value?: number;
     name?: string;
+}
+
+export interface IStackItem {
+    column0?: Highcharts.StackItemObject[];
+    column?: ISeriesDataItem[];
 }
 
 export interface ISeriesItem {
@@ -146,6 +155,7 @@ export interface ISeriesItem {
     stack?: number;
     stacking?: string;
     dataLabels?: Highcharts.DataLabelsOptionsObject;
+    dataLabelsGroup?: Highcharts.SVGAttributes;
 }
 
 export interface IShapeArgsConfig {
@@ -230,4 +240,11 @@ export interface ISeriesItemConfig {
     name?: string;
     yAxis?: number;
     xAxis?: number;
+}
+
+export interface IClientRect {
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
 }


### PR DESCRIPTION
Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2341
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
