### PR TITLE
RELATED: SD-469 - Apply custom props for Combo chart only

### DIFF
--- a/src/components/visualizations/utils/drilldownEventing.ts
+++ b/src/components/visualizations/utils/drilldownEventing.ts
@@ -23,7 +23,7 @@ import {
     IDrillEventContext,
 } from "../../../interfaces/DrillEvents";
 import { OnFiredDrillEvent } from "../../../interfaces/Events";
-import { isHeatmap, isTreemap } from "./common";
+import { isComboChart, isHeatmap, isTreemap } from "./common";
 import { getVisualizationType } from "../../../helpers/visualizationType";
 
 export function getClickableElementNameByChartType(type: VisType): ChartElementType {
@@ -67,8 +67,9 @@ function composeDrillContextGroup(
     chartType: ChartType,
 ): IDrillEventContextGroup {
     const contextPoints: IDrillPoint[] = points.map((point: IHighchartsPointObject) => {
-        const seriesType: ChartType = get(point, "series.type");
-        const customProps: Partial<IDrillPoint> = seriesType ? { type: seriesType } : {};
+        const customProps: Partial<IDrillPoint> = isComboChart(chartType)
+            ? { type: get(point, "series.type") }
+            : {};
 
         return {
             x: point.x,
@@ -103,8 +104,8 @@ function composeDrillContextPoint(
               y: point.y,
           };
 
-    const elementChartType: ChartType = get(point, "series.type");
-    const customProp: Partial<IDrillEventContextPoint> = elementChartType
+    const elementChartType: ChartType = get(point, "series.type", chartType);
+    const customProp: Partial<IDrillEventContextPoint> = isComboChart(chartType)
         ? {
               elementChartType,
           }
@@ -112,7 +113,7 @@ function composeDrillContextPoint(
 
     return {
         type: chartType,
-        element: getClickableElementNameByChartType(elementChartType || chartType),
+        element: getClickableElementNameByChartType(elementChartType),
         intersection: point.drillIntersection,
         ...xyProp,
         ...zProp,

--- a/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
+++ b/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
@@ -607,5 +607,58 @@ describe("Drilldown Eventing", () => {
                 },
             });
         });
+
+        it("should NOT add chart type for each point if it is not Combo chart", () => {
+            const drillConfig: IDrillConfig = { afm, onFiredDrillEvent: jest.fn() };
+            const target: any = { dispatchEvent: jest.fn() };
+            const pointClickEventData: Highcharts.DrilldownEventObject = {
+                point: columnPoint,
+                points: [columnPoint],
+            } as any;
+
+            chartClick(drillConfig, pointClickEventData, target as EventTarget, VisualizationTypes.COLUMN);
+
+            jest.runAllTimers();
+
+            const drillContext = target.dispatchEvent.mock.calls[0][0].detail.drillContext;
+
+            expect(drillConfig.onFiredDrillEvent).toHaveBeenCalled();
+            expect(drillContext).toEqual({
+                type: VisualizationTypes.COLUMN,
+                element: "label",
+                points: [
+                    {
+                        x: columnPoint.x,
+                        y: columnPoint.y,
+                        intersection: columnPoint.drillIntersection,
+                    },
+                ],
+            });
+        });
+
+        it("should NOT add elementChartType on cell click if it is not Combo chart", () => {
+            const drillConfig: IDrillConfig = { afm, onFiredDrillEvent: () => true };
+            const target: any = { dispatchEvent: jest.fn() };
+            const pointClickEventData: Highcharts.DrilldownEventObject = {
+                point: linePoint,
+                points: null,
+            } as any;
+
+            chartClick(drillConfig, pointClickEventData, target as EventTarget, VisualizationTypes.LINE);
+
+            jest.runAllTimers();
+
+            expect(target.dispatchEvent).toHaveBeenCalled();
+            expect(target.dispatchEvent.mock.calls[0][0].detail).toEqual({
+                executionContext: afm,
+                drillContext: {
+                    type: VisualizationTypes.LINE,
+                    element: "point",
+                    x: linePoint.x,
+                    y: linePoint.y,
+                    intersection: linePoint.drillIntersection,
+                },
+            });
+        });
     });
 });


### PR DESCRIPTION
Related to the changes in PR: https://github.com/gooddata/gooddata-react-components/pull/1038
Should add new props (in drill down event) for combo chart only

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2347
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2081

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
