### PR TITLE
RELATED: ONE-3883 Stop onMouseDown propagation during column resizing

### DIFF
--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -251,6 +251,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
                     overflow: "hidden",
                 }}
                 ref={this.setContainerRef}
+                onMouseDown={this.onMouseDown}
             >
                 {tableLoadingOverlay}
                 <AgGridReact
@@ -523,6 +524,12 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
 
     private onBodyScroll = (event: BodyScrollEvent) => {
         this.updateStickyRow(Math.max(event.top, 0), event.left);
+    };
+
+    private onMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (event.target && this.isHeaderResizer(event.target as HTMLElement)) {
+            event.stopPropagation();
+        }
     };
 
     //
@@ -798,6 +805,10 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
         if (this.state.desiredHeight !== desiredHeight) {
             this.setState({ desiredHeight });
         }
+    }
+
+    private isHeaderResizer(target: HTMLElement) {
+        return target.classList.contains("ag-header-cell-resize");
     }
 }
 


### PR DESCRIPTION
Stop onMouseEvent during table column resize to prevent widget move in KD edit mode

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2356
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2127

# Related Jira tasks
https://jira.intgdc.com/browse/ONE-3883
