### PR TITLE
RELATED: ONE-3883 Better preventing of mouse down on resizer

### DIFF
--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -174,6 +174,17 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
         this.createAGGridDataSource();
     }
 
+    public componentDidMount() {
+        if (this.containerRef) {
+            this.containerRef.addEventListener("mousedown", this.preventHeaderResizerEvents);
+        }
+    }
+    public componentWillUnmount() {
+        if (this.containerRef) {
+            this.containerRef.removeEventListener("mousedown", this.preventHeaderResizerEvents);
+        }
+    }
+
     public componentWillUpdate(nextProps: IPivotTableInnerProps, nextState: IPivotTableState) {
         if (
             this.props.groupRows !== nextProps.groupRows ||
@@ -251,7 +262,6 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
                     overflow: "hidden",
                 }}
                 ref={this.setContainerRef}
-                onMouseDown={this.onMouseDown}
             >
                 {tableLoadingOverlay}
                 <AgGridReact
@@ -526,7 +536,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
         this.updateStickyRow(Math.max(event.top, 0), event.left);
     };
 
-    private onMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    private preventHeaderResizerEvents = (event: Event) => {
         if (event.target && this.isHeaderResizer(event.target as HTMLElement)) {
             event.stopPropagation();
         }


### PR DESCRIPTION
Different way of handler registration to work with DnD backend
---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2364
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2137

# Related Jira tasks
https://jira.intgdc.com/browse/ONE-3883
