### PR TITLE
BUGFIX: SD-556 move canStackInPercent to uiConfig

### DIFF
--- a/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -191,9 +191,6 @@ export class PluggableComboChart extends PluggableBaseChart {
         const primaryChartType = get(findBucket(buckets, BucketNames.MEASURES), "chartType");
         const secondaryChartType = get(findBucket(buckets, BucketNames.SECONDARY_MEASURES), "chartType");
 
-        const isDualAxis = get(referencePoint, "properties.controls.dualAxis", true);
-        const canStackInPercent = !(isDualAxis === false && isLineChart(secondaryChartType));
-
         if (primaryChartType || secondaryChartType) {
             return {
                 ...referencePoint.properties,
@@ -201,7 +198,6 @@ export class PluggableComboChart extends PluggableBaseChart {
                     ...get(referencePoint, PROPERTY_CONTROLS, {}),
                     primaryChartType,
                     secondaryChartType,
-                    canStackInPercent,
                 },
             };
         }

--- a/src/internal/constants/supportedProperties.ts
+++ b/src/internal/constants/supportedProperties.ts
@@ -30,7 +30,6 @@ const BAR_SECONDARY_AXIS_PROPERTIES = [
 ];
 
 export const OPTIONAL_STACKING_PROPERTIES = ["stackMeasures", "stackMeasuresToPercent"];
-export const OPTIONAL_STACKING_PROPERTIES_FOR_COMBO = ["canStackInPercent"];
 
 export const CHART_TYPE_PROPERTIES = ["primaryChartType", "secondaryChartType", "dualAxis"];
 
@@ -93,7 +92,6 @@ export const COMBO_CHART_SUPPORTED_PROPERTIES = {
         ...BASE_CHART_SUPPORTED_PROPERTIES,
         ...CHART_TYPE_PROPERTIES,
         ...OPTIONAL_STACKING_PROPERTIES,
-        ...OPTIONAL_STACKING_PROPERTIES_FOR_COMBO,
     ],
     [AXIS.SECONDARY]: [
         ...BASE_PROPERTIES,
@@ -107,7 +105,6 @@ export const COMBO_CHART_SUPPORTED_PROPERTIES = {
         ...BASE_SECONDARY_AXIS_PROPERTIES,
         ...CHART_TYPE_PROPERTIES,
         ...OPTIONAL_STACKING_PROPERTIES,
-        ...OPTIONAL_STACKING_PROPERTIES_FOR_COMBO,
     ],
 };
 

--- a/src/internal/interfaces/Visualization.ts
+++ b/src/internal/interfaces/Visualization.ts
@@ -171,6 +171,7 @@ export interface IOptionalStacking {
     disabled?: boolean;
     stackMeasures?: boolean;
     stackMeasuresToPercent?: boolean;
+    canStackInPercent?: boolean;
 }
 
 export interface IUiConfig {

--- a/src/internal/utils/uiConfigHelpers/comboChartUiConfigHelper.ts
+++ b/src/internal/utils/uiConfigHelpers/comboChartUiConfigHelper.ts
@@ -28,6 +28,7 @@ import {
 } from "../../constants/properties";
 import { UICONFIG } from "../../constants/uiConfig";
 import { ChartType, VisualizationTypes } from "../../../constants/visualizationTypes";
+import { isLineChart } from "../../../components/visualizations/utils/common";
 
 const { COLUMN, LINE, AREA } = VisualizationTypes;
 
@@ -51,6 +52,11 @@ const VIEW_BY_ICONS = {
     [`${AREA}-${AREA}`]: areaViewIcon,
 };
 
+function setCanStackInPercent(uiConfig: IUiConfig, secondaryChartType: string, isDualAxis: boolean) {
+    const canStackInPercent = !(isDualAxis === false && isLineChart(secondaryChartType));
+    set(uiConfig, "optionalStacking.canStackInPercent", canStackInPercent);
+}
+
 export function setComboChartUiConfig(
     referencePoint: IExtendedReferencePoint,
     intl: InjectedIntl,
@@ -65,7 +71,11 @@ export function setComboChartUiConfig(
         get(referencePointConfigured, PROPERTY_CONTROLS_PRIMARY_CHART_TYPE, COLUMN),
         get(referencePointConfigured, PROPERTY_CONTROLS_SECONDARY_CHART_TYPE, LINE),
     ];
+
     const updatedUiConfig: IUiConfig = setBucketTitles(referencePointConfigured, visualizationType, intl);
+
+    const isDualAxis = get(referencePointConfigured, "properties.controls.dualAxis", true);
+    setCanStackInPercent(updatedUiConfig, chartTypes[1], isDualAxis);
 
     measureBuckets.forEach((bucket: IBucket, index: number) => {
         const type = chartTypes[index];

--- a/src/internal/utils/uiConfigHelpers/tests/comboChartUiConfigHelper.spec.ts
+++ b/src/internal/utils/uiConfigHelpers/tests/comboChartUiConfigHelper.spec.ts
@@ -53,5 +53,24 @@ describe("comboChartUiConfigHelper", () => {
                 expect(secondaryMeasureBucket.subtitle).toEqual(secondarySubtitle);
             },
         );
+
+        it.each([[true, true], [false, false]])(
+            "should set canStackInPercent as %s when dual axis is %s",
+            (expectation: boolean, dualAxis: boolean) => {
+                const refPoint = {
+                    ...refPointMock,
+                    properties: {
+                        controls: {
+                            dualAxis,
+                            primaryChartType: COLUMN,
+                            secondaryChartType: LINE,
+                        },
+                    },
+                };
+                const referencePoint = setComboChartUiConfig(refPoint, intl, VisualizationTypes.COMBO);
+                const canStackInPercent = get(referencePoint, "uiConfig.optionalStacking.canStackInPercent");
+                expect(canStackInPercent).toBe(expectation);
+            },
+        );
     });
 });


### PR DESCRIPTION
---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [ ] Squash commits

# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2367
- gdc-dashboards: TBD

# Related Jira tasks
- SD-556: https://jira.intgdc.com/browse/SD-556
