### PR TITLE
BUGFIX: ONE-3939 Prevent double execution with wrong dataSource

### DIFF
--- a/src/components/afm/DataSourceProvider.tsx
+++ b/src/components/afm/DataSourceProvider.tsx
@@ -134,7 +134,12 @@ export function dataSourceProvider<T>(
                 !isEqual(resultSpec, this.props.resultSpec) ||
                 projectId !== this.props.projectId
             ) {
-                this.prepareDataSource(afm);
+                this.setState(
+                    {
+                        dataSource: null,
+                    },
+                    () => this.prepareDataSource(afm),
+                );
             }
         }
 

--- a/src/components/afm/tests/DataSourceProvider.spec.tsx
+++ b/src/components/afm/tests/DataSourceProvider.spec.tsx
@@ -124,6 +124,36 @@ describe("DataSourceProvider", () => {
         });
     });
 
+    it("should NOT rerender its child with old datasource after afm change", () => {
+        const renderCounter = jest.fn();
+        class FakeTable extends React.Component<any, any> {
+            public render() {
+                renderCounter(this.props.dataSource);
+                return <div />;
+            }
+        }
+        const wrapper = createComponent(FakeTable);
+
+        const newProps: IDataSourceProviderProps = {
+            afm: { measures: [], attributes: [] },
+            projectId: "projid",
+            resultSpec: {},
+        };
+
+        return testUtils.delay().then(() => {
+            wrapper.update();
+            let table = wrapper.find(FakeTable);
+            const tableProps: IDataSourceProviderInjectedProps = table.props();
+            const oldDataSource = tableProps.dataSource;
+            expect(renderCounter).toHaveBeenCalledWith(oldDataSource);
+            renderCounter.mockClear();
+            wrapper.setProps(newProps);
+            wrapper.update();
+            table = wrapper.find(FakeTable);
+            expect(renderCounter).not.toHaveBeenCalledWith(oldDataSource);
+        });
+    });
+
     it("should recreate dataSource only once when all props change", () => {
         const wrapper = createComponent(Table);
 


### PR DESCRIPTION

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2400
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2182

# Related Jira tasks
- ONE-3939: https://jira.intgdc.com/browse/ONE-3939