### PR TITLE
BUGFIX: ONE-3970 Import typings from Highcharts where needed

### DIFF
--- a/src/components/visualizations/Visualization.tsx
+++ b/src/components/visualizations/Visualization.tsx
@@ -6,7 +6,7 @@ import isEqual = require("lodash/isEqual");
 import noop = require("lodash/noop");
 import isFunction = require("lodash/isFunction");
 import omitBy = require("lodash/omitBy");
-import { Highcharts } from "./chart/Chart";
+import Highcharts from "./chart/highcharts/highchartsEntryPoint";
 import { IChartConfig } from "../../interfaces/Config";
 import { OnFiredDrillEvent } from "../../interfaces/Events";
 

--- a/src/components/visualizations/chart/Chart.tsx
+++ b/src/components/visualizations/chart/Chart.tsx
@@ -4,11 +4,9 @@ import noop = require("lodash/noop");
 import * as React from "react";
 import { initChartPlugins } from "./highcharts/chartPlugins";
 import { IChartConfig } from "../../../interfaces/Config";
+import Highcharts from "./highcharts/highchartsEntryPoint";
 
-// Have only one entrypoint to highcharts and drill module
-// tslint:disable-next-line
-export const HighchartsMore = require("highcharts/highcharts-more");
-export const Highcharts = require("highcharts/highcharts"); // tslint:disable-line
+const HighchartsMore = require("highcharts/highcharts-more"); // tslint:disable-line
 const drillmodule = require("highcharts/modules/drilldown"); // tslint:disable-line
 const treemapModule = require("highcharts/modules/treemap"); // tslint:disable-line
 const funnelModule = require("highcharts/modules/funnel"); // tslint:disable-line

--- a/src/components/visualizations/chart/HighChartsRenderer.tsx
+++ b/src/components/visualizations/chart/HighChartsRenderer.tsx
@@ -16,6 +16,7 @@ import { isPieOrDonutChart, isOneOfTypes } from "../utils/common";
 import { VisualizationTypes } from "../../../constants/visualizationTypes";
 import { OnLegendReady } from "../../../interfaces/Events";
 import { IChartConfig } from "../../../interfaces/Config";
+import Highcharts from "./highcharts/highchartsEntryPoint";
 
 export const FLUID_LEGEND_THRESHOLD = 768;
 

--- a/src/components/visualizations/chart/chartOptionsBuilder.ts
+++ b/src/components/visualizations/chart/chartOptionsBuilder.ts
@@ -15,6 +15,7 @@ import range = require("lodash/range");
 import unescape = require("lodash/unescape");
 import without = require("lodash/without");
 import isNil = require("lodash/isNil");
+import Highcharts from "./highcharts/highchartsEntryPoint";
 
 import {
     MEASURES,

--- a/src/components/visualizations/chart/events/setupDrilldownToParentAttribute.ts
+++ b/src/components/visualizations/chart/events/setupDrilldownToParentAttribute.ts
@@ -1,6 +1,7 @@
 // (C) 2007-2019 GoodData Corporation
 import get = require("lodash/get");
 import partial = require("lodash/partial");
+import Highcharts from "../highcharts/highchartsEntryPoint";
 import { styleVariables } from "../../styles/variables";
 import { tickLabelClick } from "../../utils/drilldownEventing";
 import { ChartType } from "../../../../constants/visualizationTypes";

--- a/src/components/visualizations/chart/highcharts/commonConfiguration.ts
+++ b/src/components/visualizations/chart/highcharts/commonConfiguration.ts
@@ -4,7 +4,7 @@ import invoke = require("lodash/invoke");
 import get = require("lodash/get");
 import set = require("lodash/set");
 import isEmpty = require("lodash/isEmpty");
-import { css } from "highcharts";
+import Highcharts from "./highchartsEntryPoint";
 import { chartClick } from "../../utils/drilldownEventing";
 import { styleVariables } from "../../styles/variables";
 import { isOneOfTypes } from "../../utils/common";
@@ -24,7 +24,7 @@ export const MINIMUM_HC_SAFE_BRIGHTNESS = Number.MIN_VALUE;
 
 function handleTooltipOffScreen(renderTo: Highcharts.HTMLDOMElement) {
     // allow tooltip over the container wrapper
-    css(renderTo, { overflow: "visible" });
+    Highcharts.css(renderTo, { overflow: "visible" });
 }
 
 function fixNumericalAxisOutOfMinMaxRange(axis: IHighchartsAxisExtend) {

--- a/src/components/visualizations/chart/highcharts/dataLabelsHelpers.ts
+++ b/src/components/visualizations/chart/highcharts/dataLabelsHelpers.ts
@@ -1,6 +1,7 @@
 // (C) 2007-2019 GoodData Corporation
 import flatMap = require("lodash/flatMap");
 import get = require("lodash/get");
+import Highcharts from "./highchartsEntryPoint";
 
 import {
     isStacked,

--- a/src/components/visualizations/chart/highcharts/heatmapConfiguration.ts
+++ b/src/components/visualizations/chart/highcharts/heatmapConfiguration.ts
@@ -1,6 +1,7 @@
 // (C) 2007-2019 GoodData Corporation
 import cloneDeep = require("lodash/cloneDeep");
 import last = require("lodash/last");
+import Highcharts from "./highchartsEntryPoint";
 import {
     IHighchartsAxisExtend,
     IHighchartsSeriesExtend,

--- a/src/components/visualizations/chart/highcharts/highchartsEntryPoint.ts
+++ b/src/components/visualizations/chart/highcharts/highchartsEntryPoint.ts
@@ -1,0 +1,6 @@
+// (C) 2019 GoodData Corporation
+// Have only one entrypoint to highcharts and drill module
+// Import this reexported variable in other files instead of direct import from highcharts
+import * as Highcharts from "highcharts";
+
+export default Highcharts;

--- a/src/components/visualizations/chart/highcharts/plugins/adjustTickAmount.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/adjustTickAmount.ts
@@ -9,7 +9,7 @@
 
 import isNil = require("lodash/isNil");
 import get = require("lodash/get");
-import { correctFloat, wrap, WrapProceedFunction } from "highcharts";
+import Highcharts from "../highchartsEntryPoint";
 import { IHighchartsAxisExtend } from "../../../../../interfaces/HighchartsExtend";
 import { isLineChart } from "../../../utils/common";
 
@@ -93,8 +93,8 @@ export function getDirection(
  */
 function addTick(tickPositions: number[], tickInterval: number, isAddFirst: boolean): number[] {
     const tick: number = isAddFirst
-        ? correctFloat(tickPositions[0] - tickInterval)
-        : correctFloat(tickPositions[tickPositions.length - 1] + tickInterval);
+        ? Highcharts.correctFloat(tickPositions[0] - tickInterval)
+        : Highcharts.correctFloat(tickPositions[tickPositions.length - 1] + tickInterval);
 
     return isAddFirst ? [tick, ...tickPositions] : [...tickPositions, tick];
 }
@@ -343,8 +343,10 @@ export function shouldBeHandledByHighcharts(axis: IHighchartsAxisExtend): boolea
     return yAxes.some((axis: IHighchartsAxisExtend) => axis.visible === false);
 }
 
-export const adjustTickAmount = (HighCharts: any) => {
-    wrap(HighCharts.Axis.prototype, "adjustTickAmount", function(proceed: WrapProceedFunction) {
+export const adjustTickAmount = (HighchartsInstance: any) => {
+    Highcharts.wrap(HighchartsInstance.Axis.prototype, "adjustTickAmount", function(
+        proceed: Highcharts.WrapProceedFunction,
+    ) {
         const axis = this;
 
         if (shouldBeHandledByHighcharts(axis)) {

--- a/src/components/visualizations/chart/highcharts/plugins/autohideLabels/autohideColumnLabels.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/autohideLabels/autohideColumnLabels.ts
@@ -6,6 +6,7 @@ import values = require("lodash/values");
 import flatten = require("lodash/flatten");
 import identity = require("lodash/identity");
 import isEmpty = require("lodash/isEmpty");
+import Highcharts from "../../highchartsEntryPoint";
 
 import {
     isStacked,

--- a/src/components/visualizations/chart/highcharts/plugins/autohideLabels/test/autohideColumnLabels.spec.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/autohideLabels/test/autohideColumnLabels.spec.ts
@@ -1,4 +1,5 @@
 // (C) 2007-2019 GoodData Corporation
+import Highcharts from "../../../highchartsEntryPoint";
 import * as autohideColumnLabels from "../autohideColumnLabels";
 import {
     IPointData,

--- a/src/components/visualizations/chart/highcharts/plugins/renderBubbles.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/renderBubbles.ts
@@ -10,6 +10,7 @@
  *  - Fix bubbles is not rendered with min/max config
  */
 import isNil = require("lodash/isNil");
+import Highcharts from "../highchartsEntryPoint";
 import { IHighchartsAxisExtend } from "../../../../../interfaces/HighchartsExtend";
 export interface IBubbleAxis extends IHighchartsAxisExtend {
     allowZoomOutside?: boolean;
@@ -29,17 +30,17 @@ export interface IBubbleSeries extends Highcharts.Series {
     getRadii(zMin: number, zMax: number, series: Highcharts.Series): number | null;
 }
 
-export function renderBubbles(Highcharts: any) {
-    const wrap = Highcharts.wrap;
-    const pInt = Highcharts.pInt;
-    const arrayMax = Highcharts.arrayMax;
-    const arrayMin = Highcharts.arrayMin;
-    const pick = Highcharts.pick;
-    const isNumber = Highcharts.isNumber;
+export function renderBubbles(HighchartsInstance: any) {
+    const wrap = HighchartsInstance.wrap;
+    const pInt = HighchartsInstance.pInt;
+    const arrayMax = HighchartsInstance.arrayMax;
+    const arrayMin = HighchartsInstance.arrayMin;
+    const pick = HighchartsInstance.pick;
+    const isNumber = HighchartsInstance.isNumber;
 
-    if (Highcharts.seriesTypes.bubble) {
+    if (HighchartsInstance.seriesTypes.bubble) {
         // Set default size for bubbles in bubble chart where size value is not provided
-        wrap(Highcharts.seriesTypes.bubble.prototype, "getRadius", function(
+        wrap(HighchartsInstance.seriesTypes.bubble.prototype, "getRadius", function(
             proceed: any,
             zMin: number,
             zMax: number,
@@ -57,7 +58,7 @@ export function renderBubbles(Highcharts: any) {
         });
 
         // #SD-479 fix bubbles is not rendered with min/max config
-        wrap(Highcharts.Axis.prototype, "beforePadding", function(_proceed: any) {
+        wrap(HighchartsInstance.Axis.prototype, "beforePadding", function(_proceed: any) {
             const axis: IBubbleAxis = this;
             const axisLength: number = this.len;
             const chart: Highcharts.Chart = this.chart;

--- a/src/components/visualizations/chart/highcharts/test/getOptionalStackingConfiguration.spec.ts
+++ b/src/components/visualizations/chart/highcharts/test/getOptionalStackingConfiguration.spec.ts
@@ -1,5 +1,6 @@
 // (C) 2007-2018 GoodData Corporation
 import { AFM } from "@gooddata/typings";
+import Highcharts from "../highchartsEntryPoint";
 import getOptionalStackingConfiguration, {
     convertMinMaxFromPercentToNumber,
     getParentAttributeConfiguration,

--- a/src/components/visualizations/chart/legend/legendBuilder.ts
+++ b/src/components/visualizations/chart/legend/legendBuilder.ts
@@ -2,6 +2,7 @@
 import pick = require("lodash/pick");
 import set = require("lodash/set");
 import get = require("lodash/get");
+import Highcharts from "../highcharts/highchartsEntryPoint";
 import {
     isBubbleChart,
     isComboChart,

--- a/src/components/visualizations/chart/test/Chart.spec.tsx
+++ b/src/components/visualizations/chart/test/Chart.spec.tsx
@@ -2,7 +2,8 @@
 import * as React from "react";
 import { mount } from "enzyme";
 
-import Chart, { Highcharts } from "../Chart";
+import Highcharts from "../highcharts/highchartsEntryPoint";
+import Chart from "../Chart";
 
 jest.mock("highcharts", () => {
     return {
@@ -52,7 +53,7 @@ describe("Chart", () => {
     }
 
     it("should render highcharts", () => {
-        const spy = jest.spyOn(Highcharts, "Chart");
+        const spy = jest.spyOn(Highcharts as any, "Chart");
         const wrapper = createComponent();
         const component: any = wrapper.instance();
         expect(component.chart).toBeTruthy();

--- a/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
+++ b/src/components/visualizations/chart/test/chartOptionsBuilder.spec.ts
@@ -5,6 +5,7 @@ import set = require("lodash/set");
 import isNil = require("lodash/isNil");
 import cloneDeep = require("lodash/cloneDeep");
 import { Execution } from "@gooddata/typings";
+import Highcharts from "../highcharts/highchartsEntryPoint";
 import { findMeasureGroupInDimensions } from "../../../../helpers/executionResultHelper";
 import { immutableSet } from "../../utils/common";
 import {

--- a/src/components/visualizations/utils/drilldownEventing.ts
+++ b/src/components/visualizations/utils/drilldownEventing.ts
@@ -3,6 +3,7 @@ import get = require("lodash/get");
 import debounce = require("lodash/debounce");
 import * as CustomEvent from "custom-event";
 import * as invariant from "invariant";
+import Highcharts from "../chart/highcharts/highchartsEntryPoint";
 import {
     ChartElementType,
     ChartType,

--- a/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
+++ b/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
@@ -1,6 +1,7 @@
 // (C) 2007-2019 GoodData Corporation
 import cloneDeep = require("lodash/cloneDeep");
 import { AFM } from "@gooddata/typings";
+import Highcharts from "../../chart/highcharts/highchartsEntryPoint";
 import {
     getClickableElementNameByChartType,
     chartClick,

--- a/src/constants/label.ts
+++ b/src/constants/label.ts
@@ -1,4 +1,5 @@
 // (C) 2019 GoodData Corporation
+import Highcharts from "../components/visualizations/chart/highcharts/highchartsEntryPoint";
 import { VisualizationTypes } from "./visualizationTypes";
 
 export const WHITE_LABEL: Highcharts.CSSObject = {

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -2,6 +2,7 @@
 import { ISeparators } from "@gooddata/numberjs";
 import { VisualizationObject } from "@gooddata/typings";
 import { IColorItem, IColor } from "@gooddata/gooddata-js";
+import Highcharts from "../components/visualizations/chart/highcharts/highchartsEntryPoint";
 import { PositionType } from "../components/visualizations/typings/legend";
 import { VisType } from "../constants/visualizationTypes";
 import { IDataLabelsConfig } from "../interfaces/Config";

--- a/src/interfaces/DrillEvents.ts
+++ b/src/interfaces/DrillEvents.ts
@@ -1,5 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 import { AFM } from "@gooddata/typings";
+import Highcharts from "../components/visualizations/chart/highcharts/highchartsEntryPoint";
 import {
     ChartElementType,
     ChartType,

--- a/src/interfaces/HighchartsExtend.ts
+++ b/src/interfaces/HighchartsExtend.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2019 GoodData Corporation
-import * as Highcharts from "highcharts";
+import Highcharts from "../components/visualizations/chart/highcharts/highchartsEntryPoint";
 
 export type IHighchartsAxis = Partial<Highcharts.Axis> &
     Partial<Highcharts.ExtremesObject> &


### PR DESCRIPTION
Explicitly import HCH typings wherever it is used
---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2424
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2213

# Related Jira tasks
- ONE-3970: https://jira.intgdc.com/browse/ONE-3970