### PR TITLE
BUGFIX: RAIL-1695 handle case when server returns [null] in Kpi

### DIFF
--- a/src/components/simple/Kpi.tsx
+++ b/src/components/simple/Kpi.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 import { SDK, DataLayer } from "@gooddata/gooddata-js";
 import { colors2Object, ISeparators, numberFormat } from "@gooddata/numberjs";
+import isNil = require("lodash/isNil");
 import noop = require("lodash/noop");
 import { AFM, Execution } from "@gooddata/typings";
 import { injectIntl, intlShape, InjectedIntlProps } from "react-intl";
@@ -153,7 +154,7 @@ export class KpiWrapped extends React.PureComponent<IKpiProps & InjectedIntlProp
     }
 
     private extractNumber(result: Execution.IExecutionResponses) {
-        if (isEmptyResult(result)) {
+        if (isEmptyResult(result) || isNil(result.executionResult.data[0])) {
             return "";
         }
         return parseFloat(result.executionResult.data[0].toString());

--- a/src/components/simple/tests/Kpi.spec.tsx
+++ b/src/components/simple/tests/Kpi.spec.tsx
@@ -11,6 +11,7 @@ import { ErrorStates } from "../../../constants/errorStates";
 import { RuntimeError } from "../../../errors/RuntimeError";
 import {
     emptyResponse,
+    emptyResponseWithNullData,
     oneMeasureOneDimensionResponse,
 } from "../../../execution/fixtures/ExecuteAfm.fixtures";
 
@@ -27,6 +28,12 @@ class DummyExecute extends React.Component<Partial<IExecuteProps>, null> {
 class DummyExecuteEmpty extends React.Component<Partial<IExecuteProps>, null> {
     public render() {
         return this.props.children({ result: emptyResponse, isLoading: false, error: null });
+    }
+}
+
+class DummyExecuteEmptyNullData extends React.Component<Partial<IExecuteProps>, null> {
+    public render() {
+        return this.props.children({ result: emptyResponseWithNullData, isLoading: false, error: null });
     }
 }
 
@@ -137,6 +144,18 @@ describe("Kpi", () => {
         const wrapper = createComponent({
             format: "[=Null][backgroundcolor=DDDDDD][red]No Value;",
             ExecuteComponent: DummyExecuteEmpty,
+        });
+        return testUtils.delay().then(() => {
+            expect(wrapper.find(".gdc-kpi").html()).toEqual(
+                '<span class="gdc-kpi"><span style="color: rgb(255, 0, 0); background-color: rgb(221, 221, 221);">No Value</span></span>',
+            ); // tslint:disable-line:max-line-length
+        });
+    });
+
+    it("should render null value in data array (RAIL-1695)", () => {
+        const wrapper = createComponent({
+            format: "[=Null][backgroundcolor=DDDDDD][red]No Value;",
+            ExecuteComponent: DummyExecuteEmptyNullData,
         });
         return testUtils.delay().then(() => {
             expect(wrapper.find(".gdc-kpi").html()).toEqual(

--- a/src/execution/fixtures/ExecuteAfm.fixtures.ts
+++ b/src/execution/fixtures/ExecuteAfm.fixtures.ts
@@ -80,6 +80,45 @@ const emptyResponse: Execution.IExecutionResponses = {
     },
 };
 
+const emptyResponseWithNullData: Execution.IExecutionResponses = {
+    executionResponse: {
+        dimensions: [
+            {
+                headers: [
+                    {
+                        measureGroupHeader: {
+                            items: [
+                                {
+                                    measureHeaderItem: {
+                                        name: "Lost",
+                                        format: "$#,##0.00",
+                                        localIdentifier: "1st_measure_local_identifier",
+                                        uri: "/gdc/md/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/obj/1283",
+                                        identifier: "af2Ewj9Re2vK",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        ],
+        links: {
+            // tslint:disable-next-line:max-line-length
+            executionResult:
+                "/gdc/app/projects/d20eyb3wfs0xe5l0lfscdnrnyhq1t42q/executionResults/2651138797087227392",
+        },
+    },
+    executionResult: {
+        data: [null],
+        paging: {
+            count: [1],
+            offset: [0],
+            total: [1],
+        },
+    },
+};
+
 const attributeOnlyResponse: Execution.IExecutionResponses = {
     executionResponse: {
         dimensions: [
@@ -744,6 +783,7 @@ const twoMeasuresOneDimensionResponse: Execution.IExecutionResponses = {
 export {
     emptyResponse,
     emptyResponseWithNull,
+    emptyResponseWithNullData,
     attributeOnlyResponse,
     tooLargeResponse,
     oneMeasureResponse,


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2434
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2217