### PR TITLE
BUGFIX: SD-632 use absolute position for tooltip

### DIFF
--- a/src/components/visualizations/chart/highcharts/test/customConfiguration.spec.ts
+++ b/src/components/visualizations/chart/highcharts/test/customConfiguration.spec.ts
@@ -8,8 +8,10 @@ import {
     formatOverlappingForParentAttribute,
     getCustomizedConfiguration,
     percentageDataLabelFormatter,
+    getTooltipPositionInViewPort,
+    getTooltipPositionInChartContainer,
 } from "../customConfiguration";
-import { ISeriesDataItem } from "../../../../../interfaces/Config";
+import { ISeriesDataItem, IPointData } from "../../../../../interfaces/Config";
 import { VisualizationTypes } from "../../../../../constants/visualizationTypes";
 import { immutableSet } from "../../../utils/common";
 import {
@@ -608,6 +610,59 @@ describe("getCustomizedConfiguration", () => {
             });
 
             expect(result.tooltip.followPointer).toBeFalsy();
+        });
+    });
+
+    describe("tooltip position", () => {
+        it("should be positioned by absolute position", () => {
+            const highchartContext: any = {
+                chart: {
+                    plotLeft: 0,
+                    plotTop: 0,
+                    container: {
+                        getBoundingClientRect: jest.fn().mockReturnValue({
+                            top: 10,
+                            left: 20,
+                        }),
+                    },
+                },
+            };
+            const mockDataPoint: IPointData = {
+                negative: false,
+                plotX: 50,
+                plotY: 50,
+                h: 10,
+            };
+            // array: [chartType, stacking, labelWidth, labelHeight, point]
+            let mockChartParameters = ["bar", false, 10, 10, mockDataPoint];
+
+            // use .apply function here to mock for tooltip callback from highchart
+            let relativePosition = getTooltipPositionInChartContainer.apply(
+                highchartContext,
+                mockChartParameters,
+            );
+            expect(relativePosition).toEqual({ x: 45, y: 35 });
+
+            let position = getTooltipPositionInViewPort.apply(highchartContext, mockChartParameters);
+            // offset: pageOffset + containerPosition - highchart off set
+            // bar
+            expect(position).toEqual({
+                x: 15, // 0 + 20 - 5
+                y: 2 + relativePosition.y, // 0 + 10 -8 + 35
+            });
+
+            // line
+            mockChartParameters = ["line", false, 10, 10, mockDataPoint];
+            relativePosition = getTooltipPositionInChartContainer.apply(
+                highchartContext,
+                mockChartParameters,
+            );
+            expect(relativePosition).toEqual({ x: 45, y: 26 });
+            position = getTooltipPositionInViewPort.apply(highchartContext, mockChartParameters);
+            expect(position).toEqual({
+                x: 4, // 0 + 20 - 16
+                y: -6 + relativePosition.y, // 0 + 10 - 16 + 26
+            });
         });
     });
 

--- a/src/components/visualizations/chart/test/highChartsCreators.spec.ts
+++ b/src/components/visualizations/chart/test/highChartsCreators.spec.ts
@@ -132,7 +132,7 @@ describe("highChartCreators", () => {
 
     describe("Column chart stacked configuration", () => {
         const config = getHighchartsOptions(
-            { ...chartOptions, type: VisualizationTypes.COLUMN, stacking: true },
+            { ...chartOptions, type: VisualizationTypes.COLUMN, stacking: "normal" },
             {},
         );
 

--- a/src/components/visualizations/styles/charts.scss
+++ b/src/components/visualizations/styles/charts.scss
@@ -37,6 +37,10 @@ $paging-button-small-size: 22px;
 }
 
 .highcharts-container {
+    // If the outer container have scroll bar, the chart can be showed by scrolling.
+    // stylelint-disable-next-line declaration-no-important
+    overflow: visible !important;
+
     // This makes highcharts resizable and shrinkable!
     // stylelint-disable-next-line declaration-no-important
     width: 100% !important;

--- a/src/components/visualizations/styles/tooltip.scss
+++ b/src/components/visualizations/styles/tooltip.scss
@@ -1,43 +1,4 @@
 // (C) 2007-2018 GoodData Corporation
-// override highcharts default overflow for chart container
-// to allow tooltip overlap chart container area
-
-.gd-viz-highchart-wrap {
-    .highcharts-container {
-        // overwrite
-        // stylelint-disable-next-line declaration-no-important
-        z-index: auto !important;
-        // overwrite
-        // stylelint-disable-next-line declaration-no-important
-        overflow: visible !important;
-    }
-
-    // hide default highcharts svg tooltip when using html-based one
-    g.highcharts-tooltip {
-        visibility: hidden;
-    }
-
-    // without this, the max-width settings for .value and .title
-    // are ineffective
-    .highcharts-tooltip {
-        z-index: 3005;
-        display: flex;
-
-        > span {
-            flex: 0 0 auto;
-        }
-
-        &,
-        > span {
-            @media #{$insight-small-only} {
-                right: 0;
-                // overwrite
-                // stylelint-disable-next-line declaration-no-important
-                left: 0 !important;
-            }
-        }
-    }
-}
 
 .gd-viz-tooltip {
     position: relative;
@@ -179,4 +140,12 @@
             content: none;
         }
     }
+}
+
+// hide default highcharts svg tooltip when using html-based one
+.highcharts-tooltip-container {
+    g.highcharts-tooltip {
+        visibility: hidden;
+    }
+    z-index: 3005;
 }

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -167,7 +167,7 @@ export interface IShapeArgsConfig {
 
 export interface IChartOptions {
     type?: string;
-    stacking?: any;
+    stacking?: string;
     hasStackByAttribute?: boolean;
     hasViewByAttribute?: boolean;
     isViewByTwoAttributes?: boolean;


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)
- [ ] squashed commit


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2480
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2288

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
- SD-632: https://jira.intgdc.com/browse/SD-632