### PR TITLE
BUGFIX: SD-583 sort stacked bar chart by total values

### DIFF
--- a/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -36,7 +36,7 @@ import { BASE_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedPro
 
 import { BUCKETS } from "../../../constants/bucket";
 import { configurePercent, configureOverTimeComparison } from "../../../utils/bucketConfig";
-import { isStacked, isSimpleStackMeasures } from "../../../utils/mdObjectHelper";
+import { isStacked, canSortStackTotalValue } from "../../../utils/mdObjectHelper";
 
 import {
     sanitizeUnusedFilters,
@@ -267,7 +267,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
                 dataSource.getAfm(),
                 resultSpecWithDimensions,
                 allProperties,
-                isSimpleStackMeasures(mdObject, supportedControls),
+                canSortStackTotalValue(mdObject, supportedControls),
             );
 
             const resultSpecWithSorts = {

--- a/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -36,7 +36,7 @@ import { BASE_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedPro
 
 import { BUCKETS } from "../../../constants/bucket";
 import { configurePercent, configureOverTimeComparison } from "../../../utils/bucketConfig";
-import { isStacked } from "../../../utils/mdObjectHelper";
+import { isStacked, isSimpleStackMeasures } from "../../../utils/mdObjectHelper";
 
 import {
     sanitizeUnusedFilters,
@@ -255,7 +255,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
                 {},
             ) as IVisualizationProperties;
 
-            const supportedControls = this.getSupportedControls(mdObject);
+            const supportedControls: IVisualizationProperties = this.getSupportedControls(mdObject);
 
             const resultSpecWithDimensions: AFM.IResultSpec = {
                 ...options.resultSpec,
@@ -267,6 +267,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
                 dataSource.getAfm(),
                 resultSpecWithDimensions,
                 allProperties,
+                isSimpleStackMeasures(mdObject, supportedControls),
             );
 
             const resultSpecWithSorts = {

--- a/src/internal/utils/mdObjectHelper.ts
+++ b/src/internal/utils/mdObjectHelper.ts
@@ -26,6 +26,11 @@ export function haveManyViewItems(mdObject: VisualizationObject.IVisualizationOb
     return viewBucket && get(viewBucket, "items").length > 1;
 }
 
+export function hasOneViewItem(mdObject: VisualizationObject.IVisualizationObjectContent): boolean {
+    const viewBucket = mdObject && findBucketByLocalIdentifier(mdObject.buckets, BucketNames.VIEW);
+    return viewBucket && get(viewBucket, "items").length === 1;
+}
+
 export function hasTertiaryMeasures(mdObject: VisualizationObject.IVisualizationObjectContent): boolean {
     return mdObject.buckets
         .filter(bucket => [BucketNames.TERTIARY_MEASURES].indexOf(get(bucket, "localIdentifier")) >= 0)
@@ -57,13 +62,14 @@ function areAllMeasuresOnSingleAxis(
     return numberOfMeasureOnSecondaryAxis === 0 || measureCount === numberOfMeasureOnSecondaryAxis;
 }
 
-export function isSimpleStackMeasures(
+// don't support sort by total value for dual axis and group of categories
+export function canSortStackTotalValue(
     mdObject: VisualizationObject.IVisualizationObjectContent,
     supportedControls: IVisualizationProperties,
 ): boolean {
     return (
         get(supportedControls, "stackMeasures", false) &&
         areAllMeasuresOnSingleAxis(mdObject, get(supportedControls, "secondary_yaxis", false)) &&
-        !haveManyViewItems(mdObject)
+        hasOneViewItem(mdObject)
     );
 }

--- a/src/internal/utils/mdObjectHelper.ts
+++ b/src/internal/utils/mdObjectHelper.ts
@@ -48,7 +48,7 @@ export function hasMeasures(mdObject: VisualizationObject.IVisualizationObjectCo
     return mdObject && getMeasuresFromMdObject(mdObject).length > 0;
 }
 
-function isAllMeasuresOnSingleAxis(
+function areAllMeasuresOnSingleAxis(
     mdObject: VisualizationObject.IVisualizationObjectContent,
     secondaryYAxis: IAxisConfig,
 ): boolean {
@@ -63,7 +63,7 @@ export function isSimpleStackMeasures(
 ): boolean {
     return (
         get(supportedControls, "stackMeasures", false) &&
-        isAllMeasuresOnSingleAxis(mdObject, get(supportedControls, "secondary_yaxis", false)) &&
+        areAllMeasuresOnSingleAxis(mdObject, get(supportedControls, "secondary_yaxis", false)) &&
         !haveManyViewItems(mdObject)
     );
 }

--- a/src/internal/utils/mdObjectHelper.ts
+++ b/src/internal/utils/mdObjectHelper.ts
@@ -3,6 +3,8 @@ import get = require("lodash/get");
 import { VisualizationObject } from "@gooddata/typings";
 import { getMeasuresFromMdObject } from "./bucketHelper";
 import * as BucketNames from "../../constants/bucketNames";
+import { IAxisConfig } from "../../interfaces/Config";
+import { IVisualizationProperties } from "../interfaces/Visualization";
 
 function isAttribute(item: VisualizationObject.BucketItem): boolean {
     const attribute = item as VisualizationObject.IVisualizationAttribute;
@@ -44,4 +46,24 @@ export function isStacked(mdObject: VisualizationObject.IVisualizationObjectCont
 
 export function hasMeasures(mdObject: VisualizationObject.IVisualizationObjectContent): boolean {
     return mdObject && getMeasuresFromMdObject(mdObject).length > 0;
+}
+
+function isAllMeasuresOnSingleAxis(
+    mdObject: VisualizationObject.IVisualizationObjectContent,
+    secondaryYAxis: IAxisConfig,
+): boolean {
+    const measureCount = getMeasuresFromMdObject(mdObject).length;
+    const numberOfMeasureOnSecondaryAxis = secondaryYAxis ? secondaryYAxis.measures.length : 0;
+    return numberOfMeasureOnSecondaryAxis === 0 || measureCount === numberOfMeasureOnSecondaryAxis;
+}
+
+export function isSimpleStackMeasures(
+    mdObject: VisualizationObject.IVisualizationObjectContent,
+    supportedControls: IVisualizationProperties,
+): boolean {
+    return (
+        get(supportedControls, "stackMeasures", false) &&
+        isAllMeasuresOnSingleAxis(mdObject, get(supportedControls, "secondary_yaxis", false)) &&
+        !haveManyViewItems(mdObject)
+    );
 }

--- a/src/internal/utils/sort.ts
+++ b/src/internal/utils/sort.ts
@@ -106,12 +106,12 @@ export function getDefaultPivotTableSort(afm: AFM.IAfm): AFM.SortItem[] {
 function getDefaultBarChartSort(
     afm: AFM.IAfm,
     resultSpec: AFM.IResultSpec,
-    isSimpleStackMeasures: boolean = false,
+    canSortStackTotalValue: boolean = false,
 ): AFM.SortItem[] {
     const viewByAttributeIdentifier = getFirstAttributeIdentifier(resultSpec, VIEW_BY_DIMENSION);
     const stackByAttributeIdentifier = getFirstAttributeIdentifier(resultSpec, STACK_BY_DIMENSION);
 
-    if ((viewByAttributeIdentifier && stackByAttributeIdentifier) || isSimpleStackMeasures) {
+    if ((viewByAttributeIdentifier && stackByAttributeIdentifier) || canSortStackTotalValue) {
         return [getAttributeSortItem(viewByAttributeIdentifier, SORT_DIR_DESC, true)];
     }
 
@@ -136,7 +136,7 @@ export function createSorts(
     afm: AFM.IAfm,
     resultSpec: AFM.IResultSpec,
     visualizationProperties: IVisualizationProperties,
-    isSimpleStackMeasures: boolean = false,
+    canSortStackTotalValue: boolean = false,
 ): AFM.SortItem[] {
     const sortItems = get(visualizationProperties, "sortItems", []) as AFM.SortItem[];
     const sanitizedSortItems: AFM.SortItem[] = sanitizeSorts(afm, sortItems);
@@ -154,7 +154,7 @@ export function createSorts(
         case VisualizationTypes.LINE:
             return [];
         case VisualizationTypes.BAR:
-            return getDefaultBarChartSort(afm, resultSpec, isSimpleStackMeasures);
+            return getDefaultBarChartSort(afm, resultSpec, canSortStackTotalValue);
         case VisualizationTypes.TREEMAP:
             return SortsHelper.getDefaultTreemapSort(afm, resultSpec);
     }

--- a/src/internal/utils/sort.ts
+++ b/src/internal/utils/sort.ts
@@ -103,11 +103,15 @@ export function getDefaultPivotTableSort(afm: AFM.IAfm): AFM.SortItem[] {
     return [];
 }
 
-function getDefaultBarChartSort(afm: AFM.IAfm, resultSpec: AFM.IResultSpec): AFM.SortItem[] {
+function getDefaultBarChartSort(
+    afm: AFM.IAfm,
+    resultSpec: AFM.IResultSpec,
+    isSimpleStackMeasures: boolean = false,
+): AFM.SortItem[] {
     const viewByAttributeIdentifier = getFirstAttributeIdentifier(resultSpec, VIEW_BY_DIMENSION);
     const stackByAttributeIdentifier = getFirstAttributeIdentifier(resultSpec, STACK_BY_DIMENSION);
 
-    if (viewByAttributeIdentifier && stackByAttributeIdentifier) {
+    if ((viewByAttributeIdentifier && stackByAttributeIdentifier) || isSimpleStackMeasures) {
         return [getAttributeSortItem(viewByAttributeIdentifier, SORT_DIR_DESC, true)];
     }
 
@@ -132,6 +136,7 @@ export function createSorts(
     afm: AFM.IAfm,
     resultSpec: AFM.IResultSpec,
     visualizationProperties: IVisualizationProperties,
+    isSimpleStackMeasures: boolean = false,
 ): AFM.SortItem[] {
     const sortItems = get(visualizationProperties, "sortItems", []) as AFM.SortItem[];
     const sanitizedSortItems: AFM.SortItem[] = sanitizeSorts(afm, sortItems);
@@ -149,7 +154,7 @@ export function createSorts(
         case VisualizationTypes.LINE:
             return [];
         case VisualizationTypes.BAR:
-            return getDefaultBarChartSort(afm, resultSpec);
+            return getDefaultBarChartSort(afm, resultSpec, isSimpleStackMeasures);
         case VisualizationTypes.TREEMAP:
             return SortsHelper.getDefaultTreemapSort(afm, resultSpec);
     }

--- a/src/internal/utils/tests/mdObjectHelper.spec.ts
+++ b/src/internal/utils/tests/mdObjectHelper.spec.ts
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import { VisualizationObject } from "@gooddata/typings";
-import { hasAttribute, hasTertiaryMeasures, isStacked, isSimpleStackMeasures } from "../mdObjectHelper";
+import { hasAttribute, hasTertiaryMeasures, isStacked, canSortStackTotalValue } from "../mdObjectHelper";
 import { IVisualizationProperties } from "../../interfaces/Visualization";
 
 describe("mdObjectHelper", () => {
@@ -119,7 +119,7 @@ describe("mdObjectHelper", () => {
                     measures: ["m2"],
                 },
             };
-            expect(isSimpleStackMeasures(mdObject, supportedControls)).toBe(false);
+            expect(canSortStackTotalValue(mdObject, supportedControls)).toBe(false);
         });
 
         it("should return false if have two view by attribute", () => {
@@ -148,7 +148,7 @@ describe("mdObjectHelper", () => {
             const supportedControls: IVisualizationProperties = {
                 stackMeasures: true,
             };
-            expect(isSimpleStackMeasures(mdObject, supportedControls)).toBe(false);
+            expect(canSortStackTotalValue(mdObject, supportedControls)).toBe(false);
         });
 
         it("should return true if have one view by and many measures", () => {
@@ -168,7 +168,7 @@ describe("mdObjectHelper", () => {
             const supportedControls: IVisualizationProperties = {
                 stackMeasures: true,
             };
-            expect(isSimpleStackMeasures(mdObject, supportedControls)).toBe(true);
+            expect(canSortStackTotalValue(mdObject, supportedControls)).toBe(true);
         });
     });
 });

--- a/src/internal/utils/tests/mdObjectHelper.spec.ts
+++ b/src/internal/utils/tests/mdObjectHelper.spec.ts
@@ -1,6 +1,7 @@
 // (C) 2019 GoodData Corporation
 import { VisualizationObject } from "@gooddata/typings";
-import { hasAttribute, hasTertiaryMeasures, isStacked } from "../mdObjectHelper";
+import { hasAttribute, hasTertiaryMeasures, isStacked, isSimpleStackMeasures } from "../mdObjectHelper";
+import { IVisualizationProperties } from "../../interfaces/Visualization";
 
 describe("mdObjectHelper", () => {
     const visualizationAttribute = {
@@ -86,6 +87,88 @@ describe("mdObjectHelper", () => {
                 visualizationClass,
             };
             expect(isStacked(mdObject)).toEqual(true);
+        });
+    });
+
+    describe("simple stacked measures", () => {
+        const secondMeasure: VisualizationObject.BucketItem = {
+            measure: {
+                localIdentifier: "m2",
+                definition: {
+                    measureDefinition: {
+                        item: {
+                            uri: "/gdc/4",
+                        },
+                    },
+                },
+            },
+        };
+        it("should return false if have measures on both yAxes", () => {
+            const mdObject: VisualizationObject.IVisualizationObjectContent = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [measure, secondMeasure],
+                    },
+                ],
+                visualizationClass,
+            };
+            const supportedControls: IVisualizationProperties = {
+                stackMeasures: true,
+                secondary_yaxis: {
+                    measures: ["m2"],
+                },
+            };
+            expect(isSimpleStackMeasures(mdObject, supportedControls)).toBe(false);
+        });
+
+        it("should return false if have two view by attribute", () => {
+            const secondAttribute: VisualizationObject.BucketItem = {
+                visualizationAttribute: {
+                    localIdentifier: "a2",
+                    displayForm: {
+                        uri: "/gdc/3",
+                    },
+                },
+            };
+
+            const mdObject: VisualizationObject.IVisualizationObjectContent = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [measure, secondMeasure],
+                    },
+                    {
+                        localIdentifier: "view",
+                        items: [visualizationAttribute, secondAttribute],
+                    },
+                ],
+                visualizationClass,
+            };
+            const supportedControls: IVisualizationProperties = {
+                stackMeasures: true,
+            };
+            expect(isSimpleStackMeasures(mdObject, supportedControls)).toBe(false);
+        });
+
+        it("should return true if have one view by and many measures", () => {
+            const mdObject: VisualizationObject.IVisualizationObjectContent = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [measure, secondMeasure],
+                    },
+                    {
+                        localIdentifier: "view",
+                        items: [visualizationAttribute],
+                    },
+                ],
+                visualizationClass,
+            };
+            const supportedControls: IVisualizationProperties = {
+                stackMeasures: true,
+            };
+            expect(isSimpleStackMeasures(mdObject, supportedControls)).toBe(true);
         });
     });
 });


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2488
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2297

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
- SD-583: https://jira.intgdc.com/browse/SD-583