### PR TITLE
BUGFIX: ONE-4048 Remove negative filter with empty selection from AFM

### DIFF
--- a/src/helpers/conversion.ts
+++ b/src/helpers/conversion.ts
@@ -26,9 +26,5 @@ export function convertBucketsToAFM(
     filters?: VisualizationObject.VisualizationObjectFilter[],
 ): AFM.IAfm {
     const { afm } = DataLayer.toAfmResultSpec(convertBucketsToMdObject(buckets, filters));
-    if (filters) {
-        afm.filters = filters as AFM.FilterItem[];
-    }
-
     return afm;
 }

--- a/src/helpers/tests/conversion.spec.ts
+++ b/src/helpers/tests/conversion.spec.ts
@@ -18,6 +18,14 @@ const NegativeTextFilter: VisualizationInput.IFilter = {
     },
 };
 
+const SelectAllFilter: VisualizationInput.IFilter = {
+    negativeAttributeFilter: {
+        displayForm: { identifier: "foo" },
+        notIn: [],
+        textFilter: true,
+    },
+};
+
 /**
  * Tests here solidify the contract of text filters:
  *
@@ -93,6 +101,12 @@ describe("convertBucketsToAFM", () => {
                     },
                 },
             ],
+        });
+    });
+
+    it("should ignore (remove) negative filter with empty selection (Select All)", () => {
+        expect(convertBucketsToAFM([], [SelectAllFilter, PositiveTextFilter])).toEqual({
+            filters: [PositiveTextFilter],
         });
     });
 });


### PR DESCRIPTION
Use only filters from AFM conversion, without negative filter with empty selection
---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:  https://github.com/gooddata/gooddata-react-components/pull/1181#issue-321576187
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2303

# Related Jira tasks
Example:
- ONE-4084: https://jira.intgdc.com/browse/ONE-4084