### PR TITLE
BUGFIX: ONE-4060 Reset search string after dropdown close, Select all on subset

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "yup": "^0.24.1"
   },
   "dependencies": {
-    "@gooddata/gooddata-js": "^11.19.1",
+    "@gooddata/gooddata-js": "^11.19.2",
     "@gooddata/goodstrap": "^63.4.0",
     "@gooddata/js-utils": "^3.5.0",
     "@gooddata/numberjs": "^3.1.2",

--- a/src/components/filters/AttributeFilter/tests/AttributeDropdown.spec.tsx
+++ b/src/components/filters/AttributeFilter/tests/AttributeDropdown.spec.tsx
@@ -16,6 +16,7 @@ import {
 
 const delayOffset = 250; // Magic constant inside Goodstrap FLEX_DIMENSIONS_THROTTLE :(
 const increment = 100;
+const maxDelay = 2000;
 
 describe("AttributeDropdown", () => {
     function renderComponent(props: any = {}) {
@@ -96,8 +97,8 @@ describe("AttributeDropdown", () => {
             done();
         };
 
-        const maxDelay = 5000;
-        await waitFor(waitForItemsLoaded, maxDelay, delayOffset, increment).then(testItems, testItems);
+        const longerMaxDelay = 5000;
+        await waitFor(waitForItemsLoaded, longerMaxDelay, delayOffset, increment).then(testItems, testItems);
     });
 
     it("should run onApply with current selection", async done => {
@@ -132,7 +133,6 @@ describe("AttributeDropdown", () => {
             done();
         };
 
-        const maxDelay = 2000;
         waitFor(waitForItemsLoaded, maxDelay, delayOffset, increment).then(testItems, testItems);
     });
 
@@ -143,7 +143,6 @@ describe("AttributeDropdown", () => {
         });
 
         wrapper.find(".s-country.dropdown-button").simulate("click");
-        const maxDelay = 2000;
         await waitFor(waitForItemsLoaded, maxDelay, delayOffset, increment);
         const dropdownItems = document.querySelectorAll(".s-attribute-filter-list-item");
         ReactTestUtils.Simulate.click(dropdownItems[0]);
@@ -166,7 +165,6 @@ describe("AttributeDropdown", () => {
         });
 
         wrapper.find(".s-country.dropdown-button").simulate("click");
-        const maxDelay = 2000;
         await waitFor(waitForItemsLoaded, maxDelay, delayOffset, increment);
         const dropdownItems = document.querySelectorAll(".s-attribute-filter-list-item");
         ReactTestUtils.Simulate.click(dropdownItems[0]);
@@ -180,6 +178,40 @@ describe("AttributeDropdown", () => {
             ".s-attribute-filter-list-item .gd-input-checkbox:checked",
         );
         expect(selectedItemElements.length).toBe(11);
+    });
+
+    it("should limit items by search string", async () => {
+        const attributeDisplayForm = createADF();
+        const wrapper = renderComponent({
+            attributeDisplayForm,
+        });
+
+        wrapper.find(".s-country.dropdown-button").simulate("click");
+        await waitFor(waitForItemsLoaded, maxDelay, delayOffset, increment);
+        wrapper.find("input").simulate("change", { target: { value: "Afghanistan" } });
+        await waitFor(waitForItemsLoaded, maxDelay, delayOffset, increment);
+        const dropdownItems = document.querySelectorAll(".s-attribute-filter-list-item");
+        expect(dropdownItems.length).toBe(1);
+    });
+
+    it("should reset search string on Cancel", async () => {
+        const attributeDisplayForm = createADF();
+        const wrapper = renderComponent({
+            attributeDisplayForm,
+        });
+
+        wrapper.find(".s-country.dropdown-button").simulate("click");
+
+        await waitFor(waitForItemsLoaded, maxDelay, delayOffset, increment);
+        (wrapper.find("AttributeDropdownWrapped").instance() as any).onSearch("Afghanistan");
+        // wait for debounce
+        await testUtils.delay(300);
+        wrapper.update();
+        expect(wrapper.find("InvertableList").prop("searchString")).toBe("Afghanistan");
+        wrapper.find("button.s-cancel").simulate("click");
+        wrapper.update();
+        wrapper.find(".s-country.dropdown-button").simulate("click");
+        expect(wrapper.find("InvertableList").prop("searchString")).toBe("");
     });
 
     describe("createAfmFilter", () => {

--- a/src/components/filters/AttributeFilter/tests/utils.ts
+++ b/src/components/filters/AttributeFilter/tests/utils.ts
@@ -389,10 +389,15 @@ export function createMetadataMock() {
                 [ATTRIBUTE_DISPLAY_FORM_IDENTIFIER_2]: SPELLS,
             };
             const allItems = get(itemMap, objectId, []);
+            let filteredItems = allItems;
+            if (options.filter) {
+                filteredItems = allItems.filter((item: string) => item === options.filter);
+            }
             const offset: number = options.offset;
             const limit: number | null = options.limit || null;
             const limitedItems =
-                limit !== null ? allItems.slice(offset, offset + limit) : allItems.slice(offset);
+                limit !== null ? filteredItems.slice(offset, offset + limit) : filteredItems.slice(offset);
+
             const items: IElement[] = limitedItems.map((item: string, index: number) => ({
                 element: {
                     uri: `/gdc/md/projectId/object/${objectId}?id=${offset + index}`,
@@ -400,12 +405,19 @@ export function createMetadataMock() {
                 },
             }));
 
+            const totalCountWithoutFiltersProp = options.includeTotalCountWithoutFilters
+                ? {
+                      totalCountWithoutFilters: allItems.length,
+                  }
+                : {};
+
             return Promise.resolve({
                 validElements: {
                     items,
                     paging: {
-                        total: allItems.length,
+                        total: filteredItems.length,
                     },
+                    ...totalCountWithoutFiltersProp,
                 },
             });
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,10 +1136,10 @@
     eslint-plugin-no-only-tests "^2.3.1"
     eslint-plugin-react "7.6.1"
 
-"@gooddata/gooddata-js@^11.19.1":
-  version "11.19.1"
-  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-11.19.1.tgz#4b19c3c7fbd20f3802f2272d96987a091be27f96"
-  integrity sha512-on99qRdFtCs6QmnYFvlh8pBIR7HeaLVO9EwB7bLctXp5iT7O7aVmVTk//eZL/2fCx/b6bvTwjGZoh0IKvpeuXg==
+"@gooddata/gooddata-js@^11.19.2":
+  version "11.19.2"
+  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-11.19.2.tgz#bc1f78ac3edc7a9bdd0f6c54f384ade22af5420a"
+  integrity sha512-9LhqMxhLV2h7Z0vvxIBnfzkLEurjr1VhzNbnz55MuF7mmhxs7T/0USMN2pVj48onH+BXd1Hv+jH+0DxXx+326w==
   dependencies:
     "@gooddata/typings" "^2.18.0"
     es6-promise "^3.0.2"


### PR DESCRIPTION
- Search string is reset when dropdown is closed (Apply, Cancel, click outside)
- Fixed use case when items are filtered by search string and user clicks Select All to match behavior of AD/KD

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- ONE-4060: https://jira.intgdc.com/browse/ONE-4060

 -->
