### PR TITLE
BUGFIX: SD-577 add default chart type on saving combo chart

### DIFF
--- a/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -188,21 +188,26 @@ export class PluggableComboChart extends PluggableBaseChart {
 
     private configureChartTypes(referencePoint: IReferencePoint): IVisualizationProperties {
         const buckets: IBucket[] = get(referencePoint, BUCKETS, []);
-        const primaryChartType = get(findBucket(buckets, BucketNames.MEASURES), "chartType");
-        const secondaryChartType = get(findBucket(buckets, BucketNames.SECONDARY_MEASURES), "chartType");
+        const controls = get(referencePoint, PROPERTY_CONTROLS, {});
+        const primaryChartType = get(
+            findBucket(buckets, BucketNames.MEASURES),
+            "chartType",
+            controls.primaryChartType || VisualizationTypes.COLUMN,
+        );
+        const secondaryChartType = get(
+            findBucket(buckets, BucketNames.SECONDARY_MEASURES),
+            "chartType",
+            controls.secondaryChartType || VisualizationTypes.LINE,
+        );
 
-        if (primaryChartType || secondaryChartType) {
-            return {
-                ...referencePoint.properties,
-                controls: {
-                    ...get(referencePoint, PROPERTY_CONTROLS, {}),
-                    primaryChartType,
-                    secondaryChartType,
-                },
-            };
-        }
-
-        return referencePoint.properties;
+        return {
+            ...referencePoint.properties,
+            controls: {
+                ...controls,
+                primaryChartType,
+                secondaryChartType,
+            },
+        };
     }
 
     private isPercentDisabled(extReferencePoint: IExtendedReferencePoint): boolean {

--- a/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.spec.tsx
+++ b/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.spec.tsx
@@ -1,6 +1,7 @@
 // (C) 2019 GoodData Corporation
 import noop = require("lodash/noop");
 import get = require("lodash/get");
+import merge = require("lodash/merge");
 import cloneDeep = require("lodash/cloneDeep");
 import { VisualizationObject } from "@gooddata/typings";
 import { PluggableComboChart } from "../PluggableComboChart";
@@ -16,6 +17,7 @@ import { UICONFIG_AXIS, COMBO_CHART_UICONFIG } from "../../../../constants/uiCon
 import { COMBO_CHART_SUPPORTED_PROPERTIES } from "../../../../constants/supportedProperties";
 import { VisualizationTypes } from "../../../../../constants/visualizationTypes";
 import { OverTimeComparisonTypes } from "../../../../../interfaces/OverTimeComparison";
+import { PROPERTY_CONTROLS } from "../../../../constants/properties";
 
 describe("PluggableComboChart", () => {
     const defaultProps = {
@@ -468,6 +470,65 @@ describe("PluggableComboChart", () => {
                 },
                 refPointMock.buckets[2],
             ]);
+        });
+    });
+
+    describe("default chart type", () => {
+        it("should return default chart type", async () => {
+            const refPointMock = referencePointMocks.multipleMetricBucketsAndCategoryReferencePoint;
+            const extRefPoint: IExtendedReferencePoint = await getExtendedReferencePoint(refPointMock);
+            const controls = get(extRefPoint, PROPERTY_CONTROLS, {});
+
+            expect(controls.primaryChartType).toBe("column");
+            expect(controls.secondaryChartType).toBe("line");
+        });
+
+        it("should return chart type in bucket", async () => {
+            const refPointMock = merge(
+                {},
+                referencePointMocks.multipleMetricBucketsAndCategoryReferencePoint,
+                {
+                    buckets: [
+                        {
+                            chartType: VisualizationTypes.LINE,
+                        },
+                        {
+                            chartType: VisualizationTypes.COLUMN,
+                        },
+                    ],
+                    properties: {
+                        controls: {
+                            primaryChartType: VisualizationTypes.COLUMN,
+                            secondaryChartType: VisualizationTypes.AREA,
+                        },
+                    },
+                },
+            );
+            const extRefPoint: IExtendedReferencePoint = await getExtendedReferencePoint(refPointMock);
+            const controls = get(extRefPoint, PROPERTY_CONTROLS, {});
+
+            expect(controls.primaryChartType).toBe("line");
+            expect(controls.secondaryChartType).toBe("column");
+        });
+
+        it("should return chart type in properties.controls", async () => {
+            const refPointMock = merge(
+                {},
+                referencePointMocks.multipleMetricBucketsAndCategoryReferencePoint,
+                {
+                    properties: {
+                        controls: {
+                            primaryChartType: VisualizationTypes.LINE,
+                            secondaryChartType: VisualizationTypes.AREA,
+                        },
+                    },
+                },
+            );
+            const extRefPoint: IExtendedReferencePoint = await getExtendedReferencePoint(refPointMock);
+            const controls = get(extRefPoint, PROPERTY_CONTROLS, {});
+
+            expect(controls.primaryChartType).toBe("line");
+            expect(controls.secondaryChartType).toBe("area");
         });
     });
 });


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2510
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2324

# Related Jira tasks
- SD-577: https://jira.intgdc.com/browse/SD-577