### PR TITLE
BUGFIX: SD-661 Scatter/Bubble chart - Name toggle is enabled

### DIFF
--- a/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
@@ -123,9 +123,10 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
 
     protected getBaseChartAxisSection(axes: IAxisProperties[]) {
         const { type, properties, propertiesMeta, pushData, mdObject } = this.props;
+        const controls = properties && properties.controls;
         const controlsDisabled = this.isControlDisabled();
         const isViewedBy = this.isViewedBy();
-        const itemsOnAxes = countItemsOnAxes(type, properties.controls, mdObject);
+        const itemsOnAxes = countItemsOnAxes(type, controls, mdObject);
 
         return axes.map((axis: IAxisProperties) => {
             const disabled = controlsDisabled || (!axis.primary && !isViewedBy);

--- a/src/internal/components/configurationPanels/BubbleChartConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/BubbleChartConfigurationPanel.tsx
@@ -13,7 +13,7 @@ import ConfigSection from "../configurationControls/ConfigSection";
 import DataLabelsControl from "../configurationControls/DataLabelsControl";
 import CheckboxControl from "../configurationControls/CheckboxControl";
 import MinMaxControl from "../configurationControls//MinMaxControl";
-import { hasTertiaryMeasures } from "../../utils/mdObjectHelper";
+import { countItemsOnAxes, hasTertiaryMeasures } from "../../utils/mdObjectHelper";
 import {
     SHOW_DELAY_DEFAULT,
     HIDE_DELAY_DEFAULT,
@@ -25,8 +25,10 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
     protected renderConfigurationPanel() {
         const { xAxisVisible, yAxisVisible, gridEnabled } = this.getControlProperties();
 
-        const { propertiesMeta, properties, pushData } = this.props;
+        const { propertiesMeta, properties, pushData, type, mdObject } = this.props;
+        const controls = properties && properties.controls;
         const controlsDisabled = this.isControlDisabled();
+        const itemsOnAxes = countItemsOnAxes(type, controls, mdObject);
 
         return (
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
@@ -71,7 +73,7 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                         pushData={pushData}
                     >
                         <NameSubsection
-                            disabled={controlsDisabled}
+                            disabled={controlsDisabled || itemsOnAxes.yaxis !== 1}
                             configPanelDisabled={controlsDisabled}
                             axis={"yaxis"}
                             properties={properties}

--- a/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
@@ -14,7 +14,7 @@ import ConfigSection from "../configurationControls/ConfigSection";
 import DataLabelsControl from "../configurationControls/DataLabelsControl";
 import CheckboxControl from "../configurationControls/CheckboxControl";
 import { getMeasuresFromMdObject } from "../../utils/bucketHelper";
-import { hasAttribute } from "../../utils/mdObjectHelper";
+import { countItemsOnAxes, hasAttribute } from "../../utils/mdObjectHelper";
 import {
     SHOW_DELAY_DEFAULT,
     HIDE_DELAY_DEFAULT,
@@ -32,8 +32,10 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
     protected renderConfigurationPanel() {
         const { xAxisVisible, gridEnabled, yAxisVisible } = this.getControlProperties();
 
-        const { propertiesMeta, properties, pushData } = this.props;
+        const { propertiesMeta, properties, pushData, mdObject, type } = this.props;
+        const controls = properties && properties.controls;
         const controlsDisabled = this.isControlDisabled();
+        const itemsOnAxes = countItemsOnAxes(type, controls, mdObject);
 
         return (
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
@@ -78,7 +80,7 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                         pushData={pushData}
                     >
                         <NameSubsection
-                            disabled={controlsDisabled}
+                            disabled={controlsDisabled || itemsOnAxes.yaxis !== 1}
                             configPanelDisabled={controlsDisabled}
                             axis={"yaxis"}
                             properties={properties}

--- a/src/internal/components/configurationPanels/tests/BaseChartConfigurationPanel.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/BaseChartConfigurationPanel.spec.tsx
@@ -1,0 +1,196 @@
+// (C) 2019 GoodData Corporation
+import * as React from "react";
+import { shallow } from "enzyme";
+import { VisualizationObject } from "@gooddata/typings";
+import BaseChartConfigurationPanel from "../BaseChartConfigurationPanel";
+import { IConfigurationPanelContentProps } from "../ConfigurationPanelContent";
+import NameSubsection from "../../configurationControls/axis/NameSubsection";
+import { DEFAULT_LOCALE } from "../../../../constants/localization";
+import { VisualizationTypes } from "../../../..";
+
+describe("BaseChartConfigurationPanel", () => {
+    describe("axis name configuration", () => {
+        function createComponent(props: IConfigurationPanelContentProps) {
+            return shallow<IConfigurationPanelContentProps, null>(
+                <BaseChartConfigurationPanel {...props} />,
+                {
+                    lifecycleExperimental: true,
+                },
+            );
+        }
+
+        const visualizationClass: VisualizationObject.IObjUriQualifier = {
+            uri: "/gdc/md/projectId/obj/75535",
+        };
+
+        const productAttribute = {
+            visualizationAttribute: {
+                localIdentifier: "viewId",
+                displayForm: { uri: "/gdc/md/projectId/obj/1024" },
+            },
+        };
+
+        const regionAttribute = {
+            visualizationAttribute: {
+                localIdentifier: "viewId2",
+                displayForm: { uri: "/gdc/md/projectId/obj/1025" },
+            },
+        };
+
+        const closeBOPMeasure = {
+            measure: {
+                localIdentifier: "measureId",
+                definition: {
+                    measureDefinition: {
+                        item: { uri: "/gdc/md/projectId/obj/9211" },
+                    },
+                },
+            },
+        };
+
+        const closeEOPMeasure = {
+            measure: {
+                localIdentifier: "measureId2",
+                definition: {
+                    measureDefinition: {
+                        item: { uri: "/gdc/md/projectId/obj/9203" },
+                    },
+                },
+            },
+        };
+
+        const defaultProps: IConfigurationPanelContentProps = {
+            isError: false,
+            isLoading: false,
+            locale: DEFAULT_LOCALE,
+            type: VisualizationTypes.COLUMN,
+        };
+
+        it("should render configuration panel with enabled name sections in single axis chart", () => {
+            const mdObject = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [closeBOPMeasure],
+                    },
+                    {
+                        localIdentifier: "view",
+                        items: [productAttribute],
+                    },
+                ],
+                visualizationClass,
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+
+            const xAxisSection = axisSections.at(0);
+            expect(xAxisSection.props().disabled).toEqual(false);
+
+            const yAxisSection = axisSections.at(1);
+            expect(yAxisSection.props().disabled).toEqual(false);
+        });
+
+        it("should render configuration panel with enabled name sections in dual axis chart", () => {
+            const mdObject = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [closeBOPMeasure, closeEOPMeasure],
+                    },
+                    {
+                        localIdentifier: "view",
+                        items: [productAttribute],
+                    },
+                ],
+                visualizationClass,
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                mdObject,
+                axis: "dual",
+                properties: {
+                    controls: {
+                        secondary_yaxis: {
+                            measures: ["measureId2"],
+                        },
+                    },
+                },
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+
+            const xAxisSection = axisSections.at(0);
+            expect(xAxisSection.props().disabled).toEqual(false);
+
+            const yAxisSection = axisSections.at(1);
+            expect(yAxisSection.props().disabled).toEqual(false);
+
+            const secondaryYAxisSection = axisSections.at(2);
+            expect(secondaryYAxisSection.props().disabled).toEqual(false);
+        });
+
+        it("should render configuration panel with enabled X axis name section and disabled Y axis name section in single axis chart", () => {
+            const mdObject = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [closeBOPMeasure, closeEOPMeasure],
+                    },
+                    {
+                        localIdentifier: "view",
+                        items: [productAttribute],
+                    },
+                ],
+                visualizationClass,
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+
+            const xAxisSection = axisSections.at(0);
+            expect(xAxisSection.props().disabled).toEqual(false);
+
+            const yAxisSection = axisSections.at(1);
+            expect(yAxisSection.props().disabled).toEqual(true); // because of 2 measures on Y axis
+        });
+
+        it("should render configuration panel with disabled X axis name section and disabled Y axis name section in group-category chart", () => {
+            const mdObject = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [closeBOPMeasure, closeEOPMeasure],
+                    },
+                    {
+                        localIdentifier: "view",
+                        items: [productAttribute, regionAttribute],
+                    },
+                ],
+                visualizationClass,
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+
+            const xAxisSection = axisSections.at(0);
+            expect(xAxisSection.props().disabled).toEqual(true); // because of 2 attributes on X axis
+
+            const yAxisSection = axisSections.at(1);
+            expect(yAxisSection.props().disabled).toEqual(true); // because of 2 measures on Y axis
+        });
+    });
+});

--- a/src/internal/components/configurationPanels/tests/BubbleChartConfigurationPanel.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/BubbleChartConfigurationPanel.spec.tsx
@@ -3,8 +3,10 @@ import * as React from "react";
 import { shallow } from "enzyme";
 import BubbleChartConfigurationPanel from "../BubbleChartConfigurationPanel";
 import { IConfigurationPanelContentProps } from "../ConfigurationPanelContent";
+import NameSubsection from "../../configurationControls/axis/NameSubsection";
 import ConfigSection from "../../configurationControls/ConfigSection";
 import { DEFAULT_LOCALE } from "../../../../constants/localization";
+import { VisualizationTypes } from "../../../../constants/visualizationTypes";
 
 describe("BubbleChartconfigurationPanel", () => {
     function createComponent(props: IConfigurationPanelContentProps) {
@@ -127,5 +129,127 @@ describe("BubbleChartconfigurationPanel", () => {
         const wrapper = createComponent(props);
         const section = wrapper.find(ConfigSection).first();
         expect(section.props().toggleDisabled).toEqual(true);
+    });
+
+    describe("axis name configuration", () => {
+        const defaultProps: IConfigurationPanelContentProps = {
+            isError: false,
+            isLoading: false,
+            locale: DEFAULT_LOCALE,
+            type: VisualizationTypes.BUBBLE,
+        };
+
+        it("should render configuration panel with enabled name sections", () => {
+            const mdObject = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [
+                            {
+                                measure: {
+                                    localIdentifier: "measureId",
+                                    definition: {
+                                        measureDefinition: {
+                                            item: {
+                                                uri: "/gdc/md/projectId/obj/9211",
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        localIdentifier: "secondary_measures",
+                        items: [
+                            {
+                                measure: {
+                                    localIdentifier: "secondary_measureId",
+                                    definition: {
+                                        measureDefinition: {
+                                            item: {
+                                                uri: "/gdc/md/projectId/obj/9203",
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+
+            const xAxisSection = axisSections.at(0);
+            expect(xAxisSection.props().disabled).toEqual(false);
+
+            const yAxisSection = axisSections.at(1);
+            expect(yAxisSection.props().disabled).toEqual(false);
+        });
+
+        it("should render configuration panel with disabled name sections", () => {
+            const mdObject = {
+                buckets: [] as any,
+                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+
+            const xAxisSection = axisSections.at(0);
+            expect(xAxisSection.props().disabled).toBe(true);
+
+            const yAxisSection = axisSections.at(1);
+            expect(yAxisSection.props().disabled).toBe(true);
+        });
+
+        it("should render configuration panel with enabled X axis name section and disabled Y axis name section", () => {
+            const mdObject = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [
+                            {
+                                measure: {
+                                    localIdentifier: "measureId",
+                                    definition: {
+                                        measureDefinition: {
+                                            item: {
+                                                uri: "/gdc/md/projectId/obj/9211",
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+
+            const xAxisSection = axisSections.at(0);
+            expect(xAxisSection.props().disabled).toBe(false);
+
+            const yAxisSection = axisSections.at(1);
+            expect(yAxisSection.props().disabled).toBe(true);
+        });
     });
 });

--- a/src/internal/components/configurationPanels/tests/ScatterPlotConfigurationPanel.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/ScatterPlotConfigurationPanel.spec.tsx
@@ -4,7 +4,9 @@ import { shallow } from "enzyme";
 import ScatterPlotConfigurationPanel from "../ScatterPlotConfigurationPanel";
 import { IConfigurationPanelContentProps } from "../ConfigurationPanelContent";
 import ConfigSection from "../../configurationControls/ConfigSection";
+import NameSubsection from "../../configurationControls/axis/NameSubsection";
 import { DEFAULT_LOCALE } from "../../../../constants/localization";
+import { VisualizationTypes } from "../../../..";
 
 describe("ScatterPlotConfigurationPanel", () => {
     function createComponent(
@@ -21,5 +23,127 @@ describe("ScatterPlotConfigurationPanel", () => {
         const wrapper = createComponent();
 
         expect(wrapper.find(ConfigSection).length).toBe(3);
+    });
+
+    describe("axis name configuration", () => {
+        const defaultProps: IConfigurationPanelContentProps = {
+            isError: false,
+            isLoading: false,
+            locale: DEFAULT_LOCALE,
+            type: VisualizationTypes.SCATTER,
+        };
+
+        it("should render configuration panel with enabled name sections", () => {
+            const mdObject = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [
+                            {
+                                measure: {
+                                    localIdentifier: "measureId",
+                                    definition: {
+                                        measureDefinition: {
+                                            item: {
+                                                uri: "/gdc/md/projectId/obj/9211",
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        localIdentifier: "secondary_measures",
+                        items: [
+                            {
+                                measure: {
+                                    localIdentifier: "secondary_measureId",
+                                    definition: {
+                                        measureDefinition: {
+                                            item: {
+                                                uri: "/gdc/md/projectId/obj/9203",
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+
+            const xAxisSection = axisSections.at(0);
+            expect(xAxisSection.props().disabled).toEqual(false);
+
+            const yAxisSection = axisSections.at(1);
+            expect(yAxisSection.props().disabled).toEqual(false);
+        });
+
+        it("should render configuration panel with disabled name sections", () => {
+            const mdObject = {
+                buckets: [] as any,
+                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+
+            const xAxisSection = axisSections.at(0);
+            expect(xAxisSection.props().disabled).toBe(true);
+
+            const yAxisSection = axisSections.at(1);
+            expect(yAxisSection.props().disabled).toBe(true);
+        });
+
+        it("should render configuration panel with enabled X axis name section and disabled Y axis name section", () => {
+            const mdObject = {
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [
+                            {
+                                measure: {
+                                    localIdentifier: "measureId",
+                                    definition: {
+                                        measureDefinition: {
+                                            item: {
+                                                uri: "/gdc/md/projectId/obj/9211",
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ],
+                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+
+            const xAxisSection = axisSections.at(0);
+            expect(xAxisSection.props().disabled).toEqual(false);
+
+            const yAxisSection = axisSections.at(1);
+            expect(yAxisSection.props().disabled).toEqual(true);
+        });
     });
 });

--- a/src/internal/utils/mdObjectHelper.ts
+++ b/src/internal/utils/mdObjectHelper.ts
@@ -5,7 +5,7 @@ import { getMeasuresFromMdObject } from "./bucketHelper";
 import * as BucketNames from "../../constants/bucketNames";
 import { IAxisConfig } from "../../interfaces/Config";
 import { IVisualizationProperties } from "../interfaces/Visualization";
-import { isBarChart } from "../../components/visualizations/utils/common";
+import { isBarChart, isBubbleChart, isScatterPlot } from "../../components/visualizations/utils/common";
 import { getBucketItems } from "../../helpers/mdObjBucketHelper";
 
 function isAttribute(item: VisualizationObject.BucketItem): boolean {
@@ -77,6 +77,10 @@ export function canSortStackTotalValue(
 }
 
 export function countItemsInMdObject(mdObject: VisualizationObject.IVisualizationObjectContent) {
+    if (!mdObject) {
+        return {};
+    }
+
     const { buckets } = mdObject;
 
     const viewByItemCount: number = getBucketItems(buckets, BucketNames.VIEW).length;
@@ -110,6 +114,13 @@ export function countItemsOnAxes(
             yaxis: viewByItemCount,
             xaxis: totalMeasureItemCount - secondaryMeasureCountInConfig,
             secondary_xaxis: secondaryMeasureCountInConfig,
+        };
+    }
+
+    if (isScatterPlot(type) || isBubbleChart(type)) {
+        return {
+            xaxis: measureItemCount,
+            yaxis: secondaryMeasureItemCount,
         };
     }
 


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2517
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2327

# Related Jira tasks
- SD-661: https://jira.intgdc.com/browse/SD-661
