### PR TITLE
BUGFIX: SD-661 disable Name section on empty X axis of Scatter/Bubble chart

### DIFF
--- a/src/internal/components/configurationPanels/BubbleChartConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/BubbleChartConfigurationPanel.tsx
@@ -28,7 +28,9 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
         const { propertiesMeta, properties, pushData, type, mdObject } = this.props;
         const controls = properties && properties.controls;
         const controlsDisabled = this.isControlDisabled();
-        const itemsOnAxes = countItemsOnAxes(type, controls, mdObject);
+        const { xaxis: itemsOnXAxis, yaxis: itemsOnYAxis } = countItemsOnAxes(type, controls, mdObject);
+        const xAxisNameSectionDisabled = controlsDisabled || itemsOnXAxis !== 1;
+        const yAxisNameSectionDisabled = controlsDisabled || itemsOnYAxis !== 1;
 
         return (
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
@@ -46,7 +48,7 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                         pushData={pushData}
                     >
                         <NameSubsection
-                            disabled={controlsDisabled}
+                            disabled={xAxisNameSectionDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={"xaxis"}
                             properties={properties}
@@ -73,7 +75,7 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                         pushData={pushData}
                     >
                         <NameSubsection
-                            disabled={controlsDisabled || itemsOnAxes.yaxis !== 1}
+                            disabled={yAxisNameSectionDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={"yaxis"}
                             properties={properties}

--- a/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
@@ -35,7 +35,9 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
         const { propertiesMeta, properties, pushData, mdObject, type } = this.props;
         const controls = properties && properties.controls;
         const controlsDisabled = this.isControlDisabled();
-        const itemsOnAxes = countItemsOnAxes(type, controls, mdObject);
+        const { xaxis: itemsOnXAxis, yaxis: itemsOnYAxis } = countItemsOnAxes(type, controls, mdObject);
+        const xAxisNameSectionDisabled = controlsDisabled || itemsOnXAxis !== 1;
+        const yAxisNameSectionDisabled = controlsDisabled || itemsOnYAxis !== 1;
 
         return (
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
@@ -53,7 +55,7 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                         pushData={pushData}
                     >
                         <NameSubsection
-                            disabled={controlsDisabled}
+                            disabled={xAxisNameSectionDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={"xaxis"}
                             properties={properties}
@@ -80,7 +82,7 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                         pushData={pushData}
                     >
                         <NameSubsection
-                            disabled={controlsDisabled || itemsOnAxes.yaxis !== 1}
+                            disabled={yAxisNameSectionDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={"yaxis"}
                             properties={properties}

--- a/src/internal/components/configurationPanels/tests/BubbleChartConfigurationPanel.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/BubbleChartConfigurationPanel.spec.tsx
@@ -139,45 +139,47 @@ describe("BubbleChartconfigurationPanel", () => {
             type: VisualizationTypes.BUBBLE,
         };
 
+        const closeBOPMeasure = {
+            measure: {
+                localIdentifier: "measure1",
+                definition: {
+                    measureDefinition: {
+                        item: {
+                            uri: "/gdc/md/projectId/obj/9211",
+                        },
+                    },
+                },
+            },
+        };
+
+        const closeEOPMeasure = {
+            measure: {
+                localIdentifier: "measure2",
+                definition: {
+                    measureDefinition: {
+                        item: {
+                            uri: "/gdc/md/projectId/obj/9203",
+                        },
+                    },
+                },
+            },
+        };
+
+        const visualizationClass = { uri: "/gdc/md/projectId/obj/76297" };
+
         it("should render configuration panel with enabled name sections", () => {
             const mdObject = {
                 buckets: [
                     {
                         localIdentifier: "measures",
-                        items: [
-                            {
-                                measure: {
-                                    localIdentifier: "measureId",
-                                    definition: {
-                                        measureDefinition: {
-                                            item: {
-                                                uri: "/gdc/md/projectId/obj/9211",
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        ],
+                        items: [closeBOPMeasure],
                     },
                     {
                         localIdentifier: "secondary_measures",
-                        items: [
-                            {
-                                measure: {
-                                    localIdentifier: "secondary_measureId",
-                                    definition: {
-                                        measureDefinition: {
-                                            item: {
-                                                uri: "/gdc/md/projectId/obj/9203",
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        ],
+                        items: [closeEOPMeasure],
                     },
                 ],
-                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+                visualizationClass,
             };
 
             const wrapper = createComponent({
@@ -197,7 +199,7 @@ describe("BubbleChartconfigurationPanel", () => {
         it("should render configuration panel with disabled name sections", () => {
             const mdObject = {
                 buckets: [] as any,
-                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+                visualizationClass,
             };
 
             const wrapper = createComponent({
@@ -219,23 +221,10 @@ describe("BubbleChartconfigurationPanel", () => {
                 buckets: [
                     {
                         localIdentifier: "measures",
-                        items: [
-                            {
-                                measure: {
-                                    localIdentifier: "measureId",
-                                    definition: {
-                                        measureDefinition: {
-                                            item: {
-                                                uri: "/gdc/md/projectId/obj/9211",
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        ],
+                        items: [closeBOPMeasure],
                     },
                 ],
-                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+                visualizationClass,
             };
 
             const wrapper = createComponent({
@@ -251,5 +240,37 @@ describe("BubbleChartconfigurationPanel", () => {
             const yAxisSection = axisSections.at(1);
             expect(yAxisSection.props().disabled).toBe(true);
         });
+
+        it.each([[false, true, "measures"], [true, false, "secondary_measures"]])(
+            "should render configuration panel with X axis name section is disabled=%s and Y axis name section is disabled=%s",
+            (
+                expectedXAxisSectionDisabled: boolean,
+                expectedYAxisSectionDisabled: boolean,
+                measureIdentifier: string,
+            ) => {
+                const mdObject = {
+                    buckets: [
+                        {
+                            localIdentifier: measureIdentifier,
+                            items: [closeBOPMeasure],
+                        },
+                    ],
+                    visualizationClass,
+                };
+
+                const wrapper = createComponent({
+                    ...defaultProps,
+                    mdObject,
+                });
+
+                const axisSections = wrapper.find(NameSubsection);
+
+                const xAxisSection = axisSections.at(0);
+                expect(xAxisSection.props().disabled).toEqual(expectedXAxisSectionDisabled);
+
+                const yAxisSection = axisSections.at(1);
+                expect(yAxisSection.props().disabled).toEqual(expectedYAxisSectionDisabled);
+            },
+        );
     });
 });

--- a/src/internal/components/configurationPanels/tests/ScatterPlotConfigurationPanel.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/ScatterPlotConfigurationPanel.spec.tsx
@@ -33,45 +33,47 @@ describe("ScatterPlotConfigurationPanel", () => {
             type: VisualizationTypes.SCATTER,
         };
 
+        const closeBOPMeasure = {
+            measure: {
+                localIdentifier: "measure1",
+                definition: {
+                    measureDefinition: {
+                        item: {
+                            uri: "/gdc/md/projectId/obj/9211",
+                        },
+                    },
+                },
+            },
+        };
+
+        const closeEOPMeasure = {
+            measure: {
+                localIdentifier: "measure2",
+                definition: {
+                    measureDefinition: {
+                        item: {
+                            uri: "/gdc/md/projectId/obj/9203",
+                        },
+                    },
+                },
+            },
+        };
+
+        const visualizationClass = { uri: "/gdc/md/projectId/obj/76297" };
+
         it("should render configuration panel with enabled name sections", () => {
             const mdObject = {
                 buckets: [
                     {
                         localIdentifier: "measures",
-                        items: [
-                            {
-                                measure: {
-                                    localIdentifier: "measureId",
-                                    definition: {
-                                        measureDefinition: {
-                                            item: {
-                                                uri: "/gdc/md/projectId/obj/9211",
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        ],
+                        items: [closeBOPMeasure],
                     },
                     {
                         localIdentifier: "secondary_measures",
-                        items: [
-                            {
-                                measure: {
-                                    localIdentifier: "secondary_measureId",
-                                    definition: {
-                                        measureDefinition: {
-                                            item: {
-                                                uri: "/gdc/md/projectId/obj/9203",
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        ],
+                        items: [closeEOPMeasure],
                     },
                 ],
-                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+                visualizationClass,
             };
 
             const wrapper = createComponent({
@@ -91,7 +93,7 @@ describe("ScatterPlotConfigurationPanel", () => {
         it("should render configuration panel with disabled name sections", () => {
             const mdObject = {
                 buckets: [] as any,
-                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
+                visualizationClass,
             };
 
             const wrapper = createComponent({
@@ -108,42 +110,36 @@ describe("ScatterPlotConfigurationPanel", () => {
             expect(yAxisSection.props().disabled).toBe(true);
         });
 
-        it("should render configuration panel with enabled X axis name section and disabled Y axis name section", () => {
-            const mdObject = {
-                buckets: [
-                    {
-                        localIdentifier: "measures",
-                        items: [
-                            {
-                                measure: {
-                                    localIdentifier: "measureId",
-                                    definition: {
-                                        measureDefinition: {
-                                            item: {
-                                                uri: "/gdc/md/projectId/obj/9211",
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        ],
-                    },
-                ],
-                visualizationClass: { uri: "/gdc/md/projectId/obj/76297" },
-            };
+        it.each([[false, true, "measures"], [true, false, "secondary_measures"]])(
+            "should render configuration panel with X axis name section is disabled=%s and Y axis name section is disabled=%s",
+            (
+                expectedXAxisSectionDisabled: boolean,
+                expectedYAxisSectionDisabled: boolean,
+                measureIdentifier: string,
+            ) => {
+                const mdObject = {
+                    buckets: [
+                        {
+                            localIdentifier: measureIdentifier,
+                            items: [closeBOPMeasure],
+                        },
+                    ],
+                    visualizationClass,
+                };
 
-            const wrapper = createComponent({
-                ...defaultProps,
-                mdObject,
-            });
+                const wrapper = createComponent({
+                    ...defaultProps,
+                    mdObject,
+                });
 
-            const axisSections = wrapper.find(NameSubsection);
+                const axisSections = wrapper.find(NameSubsection);
 
-            const xAxisSection = axisSections.at(0);
-            expect(xAxisSection.props().disabled).toEqual(false);
+                const xAxisSection = axisSections.at(0);
+                expect(xAxisSection.props().disabled).toEqual(expectedXAxisSectionDisabled);
 
-            const yAxisSection = axisSections.at(1);
-            expect(yAxisSection.props().disabled).toEqual(true);
-        });
+                const yAxisSection = axisSections.at(1);
+                expect(yAxisSection.props().disabled).toEqual(expectedYAxisSectionDisabled);
+            },
+        );
     });
 });


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2519
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2333

# Related Jira tasks
- SD-661: https://jira.intgdc.com/browse/SD-661
