### PR TITLE
BUGFIX: ONE-4151 onApply handler is now optional

### DIFF
--- a/examples/src/components/AttributeFilterComponentExample.jsx
+++ b/examples/src/components/AttributeFilterComponentExample.jsx
@@ -12,6 +12,11 @@ export class AttributeFilterComponentExample extends Component {
         console.log("AttributeFilterComponentExample onApply", ...params);
     }
 
+    onApplyWithFilterDefinition(...params) {
+        // eslint-disable-next-line no-console
+        console.log("AttributeFilterComponentExample onApplyWithFilterDefinition", ...params);
+    }
+
     render() {
         return (
             <div>
@@ -35,6 +40,13 @@ export class AttributeFilterComponentExample extends Component {
                     projectId={projectId}
                     filter={Model.positiveAttributeFilter(employeeNameIdentifier, ["Abbie Adams"], true)}
                     onApply={this.onApply}
+                />
+                <br />
+                <div>attribute filter with new onApplyWithFilterDefinition</div>
+                <AttributeFilter
+                    projectId={projectId}
+                    filter={Model.positiveAttributeFilter(employeeNameIdentifier, ["Abbie Adams"], true)}
+                    onApplyWithFilterDefinition={this.onApplyWithFilterDefinition}
                 />
             </div>
         );

--- a/src/components/filters/AttributeFilter/AttributeFilter.tsx
+++ b/src/components/filters/AttributeFilter/AttributeFilter.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import * as React from "react";
 import * as PropTypes from "prop-types";
 import pick = require("lodash/pick");
@@ -16,7 +16,7 @@ import * as Model from "../../../helpers/model";
 
 export interface IAttributeFilterProps {
     projectId: string;
-    onApply: (...params: any[]) => any; // TODO: make the types more specific (FET-282)
+    onApply?: (...params: any[]) => any; // TODO: make the types more specific (FET-282)
     onApplyWithFilterDefinition?: (
         filter: VisualizationInput.IPositiveAttributeFilter | VisualizationInput.INegativeAttributeFilter,
     ) => void;
@@ -92,7 +92,7 @@ export class AttributeFilter extends React.PureComponent<IAttributeFilterProps> 
         identifier: PropTypes.string,
         filter: PropTypes.object,
         projectId: PropTypes.string.isRequired,
-        onApply: PropTypes.func.isRequired,
+        onApply: PropTypes.func,
         onApplyWithFilterDefinition: PropTypes.func,
         fullscreenOnMobile: PropTypes.bool,
         FilterLoading: PropTypes.func,
@@ -111,6 +111,7 @@ export class AttributeFilter extends React.PureComponent<IAttributeFilterProps> 
         FilterError: DefaultFilterError,
         fullscreenOnMobile: false,
         title: null,
+        onApply: noop,
         onApplyWithFilterDefinition: noop,
     };
 

--- a/src/components/filters/AttributeFilter/tests/AttributeFilter.spec.tsx
+++ b/src/components/filters/AttributeFilter/tests/AttributeFilter.spec.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import * as React from "react";
 import { mount, ReactWrapper } from "enzyme";
 import { VisualizationInput } from "@gooddata/typings";
@@ -24,7 +24,6 @@ describe("AttributeFilter", () => {
 
         const props = {
             projectId: "storybook",
-            onApply: () => ({}),
             sdk,
             ...customProps,
         };

--- a/stories/helper_components/AttributeFilter.tsx
+++ b/stories/helper_components/AttributeFilter.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
@@ -40,6 +40,12 @@ const attributeFilterWithIdentifierFilterWithSelection: IAttributeFilterProps = 
     onApply: action("apply"),
 };
 
+const attributeFilterWithOnApplyWithFilterDefinition: IAttributeFilterProps = {
+    projectId: "storybook",
+    filter: Model.positiveAttributeFilter("3.df", ["Andorra"], true),
+    onApplyWithFilterDefinition: action("onApplyWithFilterDefinition"),
+};
+
 storiesOf("Helper components/AttributeFilter", module).add("AttributeFilter definitions", () => (
     <div style={{ minHeight: 500 }}>
         <p>Attribute definition by uri</p>
@@ -54,5 +60,7 @@ storiesOf("Helper components/AttributeFilter", module).add("AttributeFilter defi
         <AttributeFilter {...attributeFilterWithIdentifierFilterWithSelection} />
         <p>Attribute filter for mobile</p>
         <AttributeFilter {...attributeFilterWithUri} fullscreenOnMobile={true} />
+        <p>Attribute filter with onApplyWithFilterDefinition</p>
+        <AttributeFilter {...attributeFilterWithOnApplyWithFilterDefinition} />
     </div>
 ));


### PR DESCRIPTION
onApply handler of Attribute Filter component is now optional to allow only new onApplyWithFilterDefinition to be used

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)

# Related Jira tasks
Example:
ONE-4151: https://jira.intgdc.com/browse/ONE-4151