### PR TITLE
FEATURE: ONE-4035 Pluggable visualization reports drillable measures

### DIFF
--- a/src/components/core/base/VisualizationLoadingHOC.tsx
+++ b/src/components/core/base/VisualizationLoadingHOC.tsx
@@ -1,9 +1,12 @@
 // (C) 2007-2019 GoodData Corporation
 import * as React from "react";
+
 import noop = require("lodash/noop");
 import get = require("lodash/get");
 import isEqual = require("lodash/isEqual");
 import omit = require("lodash/omit");
+import flatten = require("lodash/flatten");
+
 import {
     factory as createSdk,
     DataLayer,
@@ -18,7 +21,7 @@ import { ErrorStates } from "../../../constants/errorStates";
 import { IEvents, IExportFunction, IExtendedExportConfig, ILoadingState } from "../../../interfaces/Events";
 import { IDrillableItem } from "../../../interfaces/DrillEvents";
 import { ISubject } from "../../../helpers/async";
-import { convertErrors, checkEmptyResult } from "../../../helpers/errorHandlers";
+import { convertErrors, throwEmptyResultError, isEmptyResult } from "../../../helpers/errorHandlers";
 import { IHeaderPredicate } from "../../../interfaces/HeaderPredicate";
 import { IDataSourceProviderInjectedProps } from "../../afm/DataSourceProvider";
 import { injectIntl, InjectedIntl } from "react-intl";
@@ -27,7 +30,7 @@ import { IntlWrapper } from "../../core/base/IntlWrapper";
 import { LoadingComponent, ILoadingProps } from "../../simple/LoadingComponent";
 import { ErrorComponent, IErrorProps } from "../../simple/ErrorComponent";
 import { RuntimeError } from "../../../errors/RuntimeError";
-import { IPushData } from "../../../interfaces/PushData";
+import { IPushData, IDrillableItemPushData } from "../../../interfaces/PushData";
 import { IChartConfig } from "../../../interfaces/Config";
 import { setTelemetryHeaders } from "../../../helpers/utils";
 import { fixEmptyHeaderItems } from "./utils/fixEmptyHeaderItems";
@@ -61,7 +64,9 @@ export interface ILoadingInjectedProps {
     intl: InjectedIntl;
     // if autoExecuteDataSource is false, this callback is passed to the inner component and handles loading
     getPage?: IGetPage;
+
     onDataTooLarge(): void;
+
     onNegativeValues(): void;
 }
 
@@ -187,7 +192,7 @@ export function visualizationLoadingHOC<
             const pagePromise = this.createPagePromise(resultSpec, limit, offset);
 
             return pagePromise
-                .then(checkEmptyResult)
+                .then(this.handleEmptyResult)
                 .then((rawExecution: Execution.IExecutionResponses) => {
                     const emptyHeaderString = `(${this.props.intl.formatMessage({
                         id: "visualization.emptyValue",
@@ -200,11 +205,13 @@ export function visualizationLoadingHOC<
                         ...rawExecution,
                         executionResult: executionResultWithResolvedEmptyValues,
                     };
+                    const possibleDrillableItems = this.getPossibleDrillableItems(result.executionResponse);
                     // This returns only current page,
                     // gooddata-js mergePages doesn't support discontinuous page ranges yet
                     this.setState({ result, error: null });
                     this.props.pushData({
                         result,
+                        possibleDrillableItems,
                     });
                     this.onLoadingChanged({ isLoading: false });
                     this.props.onExportReady(this.createExportFunction(result)); // Pivot tables
@@ -281,15 +288,42 @@ export function visualizationLoadingHOC<
             }
         };
 
+        private getAllMeasureHeaderItems(
+            response: Execution.IExecutionResponse,
+        ): Execution.IMeasureHeaderItem[] {
+            return flatten(
+                flatten(
+                    flatten(response.dimensions).map(
+                        (dimension: Execution.IResultDimension) => dimension.headers,
+                    ),
+                )
+                    .filter((header: Execution.IHeader) => Execution.isMeasureGroupHeader(header))
+                    .map((header: Execution.IMeasureGroupHeader) => header.measureGroupHeader.items),
+            );
+        }
+
+        private getPossibleDrillableItems(response: Execution.IExecutionResponse): IDrillableItemPushData[] {
+            return this.getAllMeasureHeaderItems(response).map(
+                (measure: Execution.IMeasureHeaderItem): IDrillableItemPushData => ({
+                    type: "measure",
+                    localIdentifier: measure.measureHeaderItem.localIdentifier,
+                    title: measure.measureHeaderItem.name,
+                }),
+            );
+        }
+
         private initSubject() {
             this.subject = DataLayer.createSubject<Execution.IExecutionResponses>(
                 result => {
                     this.setState({ result });
-                    this.props.pushData({ result });
+                    const possibleDrillableItems = this.getPossibleDrillableItems(result.executionResponse);
+                    this.props.pushData({ result, possibleDrillableItems });
                     this.onLoadingChanged({ isLoading: false });
                     this.props.onExportReady(this.createExportFunction(result)); // Charts / Tables
                 },
-                error => this.onError(error),
+                error => {
+                    return this.onError(error);
+                },
             );
         }
 
@@ -333,7 +367,7 @@ export function visualizationLoadingHOC<
 
             const promise = dataSource
                 .getData(resultSpec)
-                .then(checkEmptyResult)
+                .then(this.handleEmptyResult)
                 .catch((error: ApiResponseError) => {
                     throw convertErrors(error);
                 });
@@ -378,6 +412,20 @@ export function visualizationLoadingHOC<
             return (_exportConfig: IExtendedExportConfig): Promise<IExportResponse> => {
                 return Promise.reject(error);
             };
+        }
+
+        private handleEmptyResult = (responses: Execution.IExecutionResponses) => {
+            if (!isEmptyResult(responses)) {
+                return responses;
+            }
+
+            this.pushDataForEmptyResponse(responses.executionResponse);
+            throwEmptyResultError();
+        };
+
+        private pushDataForEmptyResponse(executionResponse: Execution.IExecutionResponse) {
+            const possibleDrillableItems = this.getPossibleDrillableItems(executionResponse);
+            this.props.pushData({ possibleDrillableItems });
         }
     }
 

--- a/src/components/core/base/VisualizationLoadingHOC.tsx
+++ b/src/components/core/base/VisualizationLoadingHOC.tsx
@@ -1,6 +1,5 @@
 // (C) 2007-2019 GoodData Corporation
 import * as React from "react";
-
 import noop = require("lodash/noop");
 import get = require("lodash/get");
 import isEqual = require("lodash/isEqual");

--- a/src/components/core/base/VisualizationLoadingHOC.tsx
+++ b/src/components/core/base/VisualizationLoadingHOC.tsx
@@ -204,13 +204,13 @@ export function visualizationLoadingHOC<
                         ...rawExecution,
                         executionResult: executionResultWithResolvedEmptyValues,
                     };
-                    const possibleDrillableItems = this.getPossibleDrillableItems(result.executionResponse);
+                    const supportedDrillableItems = this.getSupportedDrillableItems(result.executionResponse);
                     // This returns only current page,
                     // gooddata-js mergePages doesn't support discontinuous page ranges yet
                     this.setState({ result, error: null });
                     this.props.pushData({
                         result,
-                        possibleDrillableItems,
+                        supportedDrillableItems,
                     });
                     this.onLoadingChanged({ isLoading: false });
                     this.props.onExportReady(this.createExportFunction(result)); // Pivot tables
@@ -301,7 +301,7 @@ export function visualizationLoadingHOC<
             );
         }
 
-        private getPossibleDrillableItems(response: Execution.IExecutionResponse): IDrillableItemPushData[] {
+        private getSupportedDrillableItems(response: Execution.IExecutionResponse): IDrillableItemPushData[] {
             return this.getAllMeasureHeaderItems(response).map(
                 (measure: Execution.IMeasureHeaderItem): IDrillableItemPushData => ({
                     type: "measure",
@@ -315,8 +315,8 @@ export function visualizationLoadingHOC<
             this.subject = DataLayer.createSubject<Execution.IExecutionResponses>(
                 result => {
                     this.setState({ result });
-                    const possibleDrillableItems = this.getPossibleDrillableItems(result.executionResponse);
-                    this.props.pushData({ result, possibleDrillableItems });
+                    const supportedDrillableItems = this.getSupportedDrillableItems(result.executionResponse);
+                    this.props.pushData({ result, supportedDrillableItems });
                     this.onLoadingChanged({ isLoading: false });
                     this.props.onExportReady(this.createExportFunction(result)); // Charts / Tables
                 },
@@ -423,8 +423,8 @@ export function visualizationLoadingHOC<
         };
 
         private pushDataForEmptyResponse(executionResponse: Execution.IExecutionResponse) {
-            const possibleDrillableItems = this.getPossibleDrillableItems(executionResponse);
-            this.props.pushData({ possibleDrillableItems });
+            const supportedDrillableItems = this.getSupportedDrillableItems(executionResponse);
+            this.props.pushData({ supportedDrillableItems });
         }
     }
 

--- a/src/components/core/base/test/VisualizationLoadingHOC.spec.tsx
+++ b/src/components/core/base/test/VisualizationLoadingHOC.spec.tsx
@@ -341,8 +341,7 @@ describe("VisualizationLoadingHOC", () => {
         });
 
         return testUtils.delay().then(() => {
-            expect(pushData).toHaveBeenCalled();
-            expect(pushData.mock.calls[0][0]).toMatchObject({
+            expect(pushData).toHaveBeenCalledWith({
                 possibleDrillableItems: [
                     {
                         localIdentifier: "1st_measure_local_identifier",
@@ -366,8 +365,7 @@ describe("VisualizationLoadingHOC", () => {
         );
 
         return testUtils.delay().then(() => {
-            expect(pushData).toHaveBeenCalled();
-            expect(pushData.mock.calls[0][0]).toMatchObject({
+            expect(pushData).toHaveBeenCalledWith({
                 possibleDrillableItems: [
                     {
                         localIdentifier: "1st_measure_local_identifier",

--- a/src/components/core/base/test/VisualizationLoadingHOC.spec.tsx
+++ b/src/components/core/base/test/VisualizationLoadingHOC.spec.tsx
@@ -321,7 +321,7 @@ describe("VisualizationLoadingHOC", () => {
         return testUtils.delay().then(() => {
             expect(pushData).toHaveBeenCalled();
             expect(pushData.mock.calls[0][0]).toMatchObject({
-                possibleDrillableItems: [
+                supportedDrillableItems: [
                     {
                         type: "measure",
                         title: "Lost",
@@ -332,7 +332,7 @@ describe("VisualizationLoadingHOC", () => {
         });
     });
 
-    it("should push possibleDrillableItems when executing with NO DATA result", () => {
+    it("should push supportedDrillableItems when executing with NO DATA result", () => {
         const pushData = jest.fn();
         createComponent({
             dataSource: emptyDataSource,
@@ -342,7 +342,7 @@ describe("VisualizationLoadingHOC", () => {
 
         return testUtils.delay().then(() => {
             expect(pushData).toHaveBeenCalledWith({
-                possibleDrillableItems: [
+                supportedDrillableItems: [
                     {
                         localIdentifier: "1st_measure_local_identifier",
                         title: "Lost",
@@ -353,7 +353,7 @@ describe("VisualizationLoadingHOC", () => {
         });
     });
 
-    it("should push possibleDrillableItems with empty result from getPage", () => {
+    it("should push supportedDrillableItems with empty result from getPage", () => {
         const pushData = jest.fn();
         createComponent(
             {
@@ -366,7 +366,7 @@ describe("VisualizationLoadingHOC", () => {
 
         return testUtils.delay().then(() => {
             expect(pushData).toHaveBeenCalledWith({
-                possibleDrillableItems: [
+                supportedDrillableItems: [
                     {
                         localIdentifier: "1st_measure_local_identifier",
                         title: "Lost",

--- a/src/components/core/base/test/VisualizationLoadingHOC.spec.tsx
+++ b/src/components/core/base/test/VisualizationLoadingHOC.spec.tsx
@@ -305,10 +305,11 @@ describe("VisualizationLoadingHOC", () => {
         });
 
         return testUtils.delay().then(() => {
-            expect(pushData).toHaveBeenCalled();
-            expect(pushData.mock.calls[0][0]).toMatchObject({
-                result: oneMeasureResponse,
-            });
+            expect(pushData).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    result: oneMeasureResponse,
+                }),
+            );
         });
     });
 
@@ -319,16 +320,17 @@ describe("VisualizationLoadingHOC", () => {
         });
 
         return testUtils.delay().then(() => {
-            expect(pushData).toHaveBeenCalled();
-            expect(pushData.mock.calls[0][0]).toMatchObject({
-                supportedDrillableItems: [
-                    {
-                        type: "measure",
-                        title: "Lost",
-                        localIdentifier: "1st_measure_local_identifier",
-                    },
-                ],
-            });
+            expect(pushData).toBeCalledWith(
+                expect.objectContaining({
+                    supportedDrillableItems: [
+                        {
+                            type: "measure",
+                            title: "Lost",
+                            localIdentifier: "1st_measure_local_identifier",
+                        },
+                    ],
+                }),
+            );
         });
     });
 
@@ -447,10 +449,11 @@ describe("VisualizationLoadingHOC", () => {
             );
 
             return testUtils.delay().then(() => {
-                expect(pushData).toHaveBeenCalled();
-                expect(pushData.mock.calls[0][0]).toMatchObject({
-                    result: oneMeasureResponse,
-                });
+                expect(pushData).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        result: oneMeasureResponse,
+                    }),
+                );
                 expect(onLoadingChanged).toHaveBeenCalledWith({ isLoading: false });
             });
         });

--- a/src/components/core/base/test/VisualizationLoadingHOC.spec.tsx
+++ b/src/components/core/base/test/VisualizationLoadingHOC.spec.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import * as React from "react";
 import * as PropTypes from "prop-types";
 import { mount } from "enzyme";
@@ -305,8 +305,76 @@ describe("VisualizationLoadingHOC", () => {
         });
 
         return testUtils.delay().then(() => {
-            expect(pushData).toHaveBeenCalledWith({
+            expect(pushData).toHaveBeenCalled();
+            expect(pushData.mock.calls[0][0]).toMatchObject({
                 result: oneMeasureResponse,
+            });
+        });
+    });
+
+    it("should call pushData callback with available drill items", () => {
+        const pushData = jest.fn();
+        createComponent({
+            pushData,
+        });
+
+        return testUtils.delay().then(() => {
+            expect(pushData).toHaveBeenCalled();
+            expect(pushData.mock.calls[0][0]).toMatchObject({
+                possibleDrillableItems: [
+                    {
+                        type: "measure",
+                        title: "Lost",
+                        localIdentifier: "1st_measure_local_identifier",
+                    },
+                ],
+            });
+        });
+    });
+
+    it("should push possibleDrillableItems when executing with NO DATA result", () => {
+        const pushData = jest.fn();
+        createComponent({
+            dataSource: emptyDataSource,
+            onError: noop,
+            pushData,
+        });
+
+        return testUtils.delay().then(() => {
+            expect(pushData).toHaveBeenCalled();
+            expect(pushData.mock.calls[0][0]).toMatchObject({
+                possibleDrillableItems: [
+                    {
+                        localIdentifier: "1st_measure_local_identifier",
+                        title: "Lost",
+                        type: "measure",
+                    },
+                ],
+            });
+        });
+    });
+
+    it("should push possibleDrillableItems with empty result from getPage", () => {
+        const pushData = jest.fn();
+        createComponent(
+            {
+                dataSource: emptyDataSource,
+                onError: noop,
+                pushData,
+            },
+            false,
+        );
+
+        return testUtils.delay().then(() => {
+            expect(pushData).toHaveBeenCalled();
+            expect(pushData.mock.calls[0][0]).toMatchObject({
+                possibleDrillableItems: [
+                    {
+                        localIdentifier: "1st_measure_local_identifier",
+                        title: "Lost",
+                        type: "measure",
+                    },
+                ],
             });
         });
     });
@@ -381,7 +449,8 @@ describe("VisualizationLoadingHOC", () => {
             );
 
             return testUtils.delay().then(() => {
-                expect(pushData).toHaveBeenCalledWith({
+                expect(pushData).toHaveBeenCalled();
+                expect(pushData.mock.calls[0][0]).toMatchObject({
                     result: oneMeasureResponse,
                 });
                 expect(onLoadingChanged).toHaveBeenCalledWith({ isLoading: false });

--- a/src/helpers/errorHandlers.ts
+++ b/src/helpers/errorHandlers.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import { Execution, VisualizationObject } from "@gooddata/typings";
 import { ApiResponseError } from "@gooddata/gooddata-js";
 import { InjectedIntl } from "react-intl";
@@ -125,19 +125,15 @@ export function isEmptyResult(responses: Execution.IExecutionResponses): boolean
     return isNullExecutionResult(responses) || isEmptyDataResult(responses);
 }
 
-export function checkEmptyResult(responses: Execution.IExecutionResponses) {
-    if (isEmptyResult(responses)) {
-        throw {
-            name: "EmptyResultError",
-            response: {
-                status: HttpStatusCodes.NO_CONTENT,
-                json: () => Promise.resolve(null),
-                text: () => Promise.resolve(null),
-            },
-        };
-    }
-
-    return responses;
+export function throwEmptyResultError() {
+    throw {
+        name: "EmptyResultError",
+        response: {
+            status: HttpStatusCodes.NO_CONTENT,
+            json: () => Promise.resolve(null),
+            text: () => Promise.resolve(null),
+        },
+    };
 }
 
 export const hasDuplicateIdentifiers = (buckets: VisualizationObject.IBucket[]) => {

--- a/src/helpers/tests/errorHandlers.spec.ts
+++ b/src/helpers/tests/errorHandlers.spec.ts
@@ -1,6 +1,6 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import * as HttpStatusCodes from "http-status-codes";
-import { checkEmptyResult, convertErrors, generateErrorMap, hasDuplicateIdentifiers } from "../errorHandlers";
+import { convertErrors, generateErrorMap, hasDuplicateIdentifiers, isEmptyResult } from "../errorHandlers";
 import { ApiResponseError } from "@gooddata/gooddata-js";
 import "isomorphic-fetch";
 
@@ -106,29 +106,19 @@ describe("convertErrors", () => {
     });
 });
 
-describe("checkEmptyResult", () => {
-    it("should throw 204 if executionResult does not contain any data", () => {
+describe("isEmptyResult", () => {
+    it("should return true if executionResult does not contain any data", () => {
         expect.hasAssertions();
-
-        try {
-            checkEmptyResult(emptyResponse);
-        } catch (obj) {
-            expect(obj.response.status).toEqual(204);
-        }
+        expect(isEmptyResult(emptyResponse)).toBe(true);
     });
 
-    it("should throw 204 if executionResult is null", () => {
+    it("should return true if executionResult is null", () => {
         expect.hasAssertions();
-
-        try {
-            checkEmptyResult(emptyResponseWithNull);
-        } catch (obj) {
-            expect(obj.response.status).toEqual(204);
-        }
+        expect(isEmptyResult(emptyResponseWithNull)).toBe(true);
     });
 
-    it("should not throw 204 if executionResult does not contain any data, but contain headers", () => {
-        expect(() => checkEmptyResult(attributeOnlyResponse)).not.toThrow();
+    it("should return false if executionResult does not contain any data, but contain headers", () => {
+        expect(isEmptyResult(attributeOnlyResponse)).toBe(false);
     });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { VisualizationTypes, ChartType } from "./constants/visualizationTypes";
 import { Execute } from "./execution/Execute";
 import { IDrillableItem, IDrillEventExtended } from "./interfaces/DrillEvents";
 import { IHeaderPredicate } from "./interfaces/HeaderPredicate";
-import { IPushData, IColorsData } from "./interfaces/PushData";
+import { IPushData, IDrillableItemPushData, IColorsData } from "./interfaces/PushData";
 import { AttributeFilter } from "./components/filters/AttributeFilter/AttributeFilter";
 import { AttributeElements } from "./components/filters/AttributeFilter/AttributeElements";
 import * as PropTypes from "./proptypes/index";
@@ -110,6 +110,7 @@ export {
     IColorPalette,
     IColorPaletteItem,
     IPushData,
+    IDrillableItemPushData,
     IColorsData,
     isEmptyResult,
     Kpi,

--- a/src/interfaces/PushData.ts
+++ b/src/interfaces/PushData.ts
@@ -1,10 +1,18 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import { AFM, Execution, VisualizationObject } from "@gooddata/typings";
 import { IColorAssignment, IColorPalette } from "./Config";
 
 export interface IColorsData {
     colorAssignments: IColorAssignment[];
     colorPalette: IColorPalette;
+}
+
+export type DrillableItemType = "measure";
+
+export interface IDrillableItemPushData {
+    type: DrillableItemType;
+    localIdentifier: AFM.Identifier;
+    title: string;
 }
 
 export interface IPushData {
@@ -15,4 +23,5 @@ export interface IPushData {
     };
     propertiesMeta?: any;
     colors?: IColorsData;
+    possibleDrillableItems?: IDrillableItemPushData[];
 }

--- a/src/interfaces/PushData.ts
+++ b/src/interfaces/PushData.ts
@@ -23,5 +23,5 @@ export interface IPushData {
     };
     propertiesMeta?: any;
     colors?: IColorsData;
-    possibleDrillableItems?: IDrillableItemPushData[];
+    supportedDrillableItems?: IDrillableItemPushData[];
 }

--- a/stories/internal/PossibleDrillableItems.tsx
+++ b/stories/internal/PossibleDrillableItems.tsx
@@ -1,0 +1,56 @@
+// (C) 2019 GoodData Corporation
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { wrap } from "../utils/wrap";
+import { Headline } from "../../src/components/Headline";
+import "../../styles/scss/headline.scss";
+import { MEASURE_1_WITH_ALIAS, MEASURE_1, MEASURE_2, ATTRIBUTE_1 } from "../data/componentProps";
+import { PivotTable } from "../../src/components/PivotTable";
+import { BarChart } from "../../src/components/BarChart";
+import { IPushData } from "../../src/interfaces/PushData";
+
+const pushData = (data: IPushData) => {
+    if (data.possibleDrillableItems) {
+        action("possibleDrillableItems")(data);
+    }
+};
+
+storiesOf("Internal/PossibleDrillableItems", module)
+    .add("Headline", () =>
+        wrap(
+            <Headline
+                projectId="storybook"
+                primaryMeasure={MEASURE_1_WITH_ALIAS}
+                LoadingComponent={null}
+                ErrorComponent={null}
+                pushData={pushData}
+            />,
+            "auto",
+            300,
+        ),
+    )
+    .add("PivotTable", () =>
+        wrap(
+            <PivotTable
+                projectId="storybook"
+                measures={[MEASURE_1, MEASURE_2]}
+                rows={[ATTRIBUTE_1]}
+                pushData={pushData}
+            />,
+            300,
+            600,
+        ),
+    )
+    .add("Chart", () =>
+        wrap(
+            <BarChart
+                projectId="storybook"
+                measures={[MEASURE_2]}
+                viewBy={[ATTRIBUTE_1]}
+                pushData={pushData}
+            />,
+            300,
+            600,
+        ),
+    );

--- a/stories/internal/SupportedDrillableItems.tsx
+++ b/stories/internal/SupportedDrillableItems.tsx
@@ -11,12 +11,12 @@ import { BarChart } from "../../src/components/BarChart";
 import { IPushData } from "../../src/interfaces/PushData";
 
 const pushData = (data: IPushData) => {
-    if (data.possibleDrillableItems) {
-        action("possibleDrillableItems")(data);
+    if (data.supportedDrillableItems) {
+        action("supportedDrillableItems")(data);
     }
 };
 
-storiesOf("Internal/PossibleDrillableItems", module)
+storiesOf("Internal/SupportedDrillableItems", module)
     .add("Headline", () =>
         wrap(
             <Headline


### PR DESCRIPTION
All visualizations now reports all possibly drillable items (all measures for now). Used in KD to list such items and user can define drill interactions for such items

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
- ONE-4035: https://jira.intgdc.com/browse/ONE-4035