### PR TITLE
REALTED: ONE-4035 Fix `pushData` for unmounted PlugableVisualization

### DIFF
--- a/src/helpers/errorHandlers.ts
+++ b/src/helpers/errorHandlers.ts
@@ -17,8 +17,8 @@ function getJSONFromText(data: string): object {
     }
 }
 
-function isApiResponseError(error: TypeError | ApiResponseError): error is ApiResponseError {
-    return (error as ApiResponseError).response !== undefined;
+export function isApiResponseError(error: TypeError | ApiResponseError): error is ApiResponseError {
+    return error && (error as ApiResponseError).response !== undefined;
 }
 
 export interface IErrorMap {
@@ -125,15 +125,19 @@ export function isEmptyResult(responses: Execution.IExecutionResponses): boolean
     return isNullExecutionResult(responses) || isEmptyDataResult(responses);
 }
 
-export function throwEmptyResultError() {
-    throw {
-        name: "EmptyResultError",
-        response: {
-            status: HttpStatusCodes.NO_CONTENT,
-            json: () => Promise.resolve(null),
-            text: () => Promise.resolve(null),
-        },
-    };
+export function checkEmptyResult(responses: Execution.IExecutionResponses) {
+    if (isEmptyResult(responses)) {
+        throw {
+            name: "EmptyResultError",
+            response: {
+                status: HttpStatusCodes.NO_CONTENT,
+                json: () => Promise.resolve(responses),
+                text: () => Promise.resolve(null),
+            },
+        };
+    }
+
+    return responses;
 }
 
 export const hasDuplicateIdentifiers = (buckets: VisualizationObject.IBucket[]) => {

--- a/src/helpers/tests/errorHandlers.spec.ts
+++ b/src/helpers/tests/errorHandlers.spec.ts
@@ -1,6 +1,12 @@
 // (C) 2007-2019 GoodData Corporation
 import * as HttpStatusCodes from "http-status-codes";
-import { convertErrors, generateErrorMap, hasDuplicateIdentifiers, isEmptyResult } from "../errorHandlers";
+import {
+    convertErrors,
+    generateErrorMap,
+    hasDuplicateIdentifiers,
+    isEmptyResult,
+    checkEmptyResult,
+} from "../errorHandlers";
 import { ApiResponseError } from "@gooddata/gooddata-js";
 import "isomorphic-fetch";
 
@@ -119,6 +125,43 @@ describe("isEmptyResult", () => {
 
     it("should return false if executionResult does not contain any data, but contain headers", () => {
         expect(isEmptyResult(attributeOnlyResponse)).toBe(false);
+    });
+});
+
+describe("checkEmptyResult", () => {
+    it("should throw 204 if executionResult does not contain any data", () => {
+        expect.hasAssertions();
+
+        try {
+            checkEmptyResult(emptyResponse);
+        } catch (obj) {
+            expect(obj.response.status).toEqual(204);
+        }
+    });
+
+    it("should throw 204 if executionResult is null", () => {
+        expect.hasAssertions();
+
+        try {
+            checkEmptyResult(emptyResponseWithNull);
+        } catch (obj) {
+            expect(obj.response.status).toEqual(204);
+        }
+    });
+
+    it("should not throw 204 if executionResult does not contain any data, but contain headers", () => {
+        expect(() => checkEmptyResult(attributeOnlyResponse)).not.toThrow();
+    });
+
+    it("should forward the response if executionResult is empty", async () => {
+        expect.hasAssertions();
+
+        try {
+            checkEmptyResult(emptyResponse);
+        } catch (obj) {
+            const expected = await obj.response.json();
+            expect(expected).toEqual(emptyResponse);
+        }
     });
 });
 


### PR DESCRIPTION
Invalid NO DATA handling caused that `pushData` promise was not
cancelled properly and was processed even for unmounted visualization.

<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2576
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2397

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
