### PR TITLE
BUGFIX: SD-726 Reporting inconsistency about Axis name in AD vs GD.UI

### DIFF
--- a/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
@@ -122,11 +122,12 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
     }
 
     protected getBaseChartAxisSection(axes: IAxisProperties[]) {
-        const { type, properties, propertiesMeta, pushData, mdObject } = this.props;
+        const { featureFlags, type, properties, propertiesMeta, pushData, mdObject } = this.props;
         const controls = properties && properties.controls;
         const controlsDisabled = this.isControlDisabled();
         const isViewedBy = this.isViewedBy();
         const itemsOnAxes = countItemsOnAxes(type, controls, mdObject);
+        const isNameSubsectionVisible: boolean = featureFlags.enableAxisNameConfiguration as boolean;
 
         return axes.map((axis: IAxisProperties) => {
             const disabled = controlsDisabled || (!axis.primary && !isViewedBy);
@@ -147,13 +148,15 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
                     properties={properties}
                     pushData={pushData}
                 >
-                    <NameSubsection
-                        disabled={disabled || hasMoreThanOneItem}
-                        configPanelDisabled={controlsDisabled}
-                        axis={axis.name}
-                        properties={properties}
-                        pushData={pushData}
-                    />
+                    {isNameSubsectionVisible && (
+                        <NameSubsection
+                            disabled={disabled || hasMoreThanOneItem}
+                            configPanelDisabled={controlsDisabled}
+                            axis={axis.name}
+                            properties={properties}
+                            pushData={pushData}
+                        />
+                    )}
                     <LabelSubsection
                         disabled={disabled}
                         configPanelDisabled={controlsDisabled}

--- a/src/internal/components/configurationPanels/BubbleChartConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/BubbleChartConfigurationPanel.tsx
@@ -25,12 +25,13 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
     protected renderConfigurationPanel() {
         const { xAxisVisible, yAxisVisible, gridEnabled } = this.getControlProperties();
 
-        const { propertiesMeta, properties, pushData, type, mdObject } = this.props;
+        const { featureFlags, propertiesMeta, properties, pushData, type, mdObject } = this.props;
         const controls = properties && properties.controls;
         const controlsDisabled = this.isControlDisabled();
         const { xaxis: itemsOnXAxis, yaxis: itemsOnYAxis } = countItemsOnAxes(type, controls, mdObject);
         const xAxisNameSectionDisabled = controlsDisabled || itemsOnXAxis !== 1;
         const yAxisNameSectionDisabled = controlsDisabled || itemsOnYAxis !== 1;
+        const isNameSubsectionVisible: boolean = featureFlags.enableAxisNameConfiguration as boolean;
 
         return (
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
@@ -47,13 +48,15 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                         properties={properties}
                         pushData={pushData}
                     >
-                        <NameSubsection
-                            disabled={xAxisNameSectionDisabled}
-                            configPanelDisabled={controlsDisabled}
-                            axis={"xaxis"}
-                            properties={properties}
-                            pushData={pushData}
-                        />
+                        {isNameSubsectionVisible && (
+                            <NameSubsection
+                                disabled={xAxisNameSectionDisabled}
+                                configPanelDisabled={controlsDisabled}
+                                axis={"xaxis"}
+                                properties={properties}
+                                pushData={pushData}
+                            />
+                        )}
                         <LabelSubsection
                             disabled={controlsDisabled}
                             configPanelDisabled={controlsDisabled}
@@ -74,13 +77,15 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
                         properties={properties}
                         pushData={pushData}
                     >
-                        <NameSubsection
-                            disabled={yAxisNameSectionDisabled}
-                            configPanelDisabled={controlsDisabled}
-                            axis={"yaxis"}
-                            properties={properties}
-                            pushData={pushData}
-                        />
+                        {isNameSubsectionVisible && (
+                            <NameSubsection
+                                disabled={yAxisNameSectionDisabled}
+                                configPanelDisabled={controlsDisabled}
+                                axis={"yaxis"}
+                                properties={properties}
+                                pushData={pushData}
+                            />
+                        )}
                         <LabelSubsection
                             disabled={controlsDisabled}
                             configPanelDisabled={controlsDisabled}

--- a/src/internal/components/configurationPanels/HeatMapConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/HeatMapConfigurationPanel.tsx
@@ -23,12 +23,13 @@ import { noRowsAndHasOneMeasure, noColumnsAndHasOneMeasure } from "../../utils/b
 
 export default class HeatMapConfigurationPanel extends ConfigurationPanelContent {
     protected renderConfigurationPanel() {
-        const { propertiesMeta, properties, pushData } = this.props;
+        const { featureFlags, propertiesMeta, properties, pushData } = this.props;
         const { xAxisVisible, yAxisVisible } = this.getControlProperties();
 
         const controlsDisabled = this.isControlDisabled();
         const xAxisDisabled = this.isAxisDisabled(controlsDisabled, "xaxis", this.props.mdObject);
         const yAxisDisabled = this.isAxisDisabled(controlsDisabled, "yaxis", this.props.mdObject);
+        const isNameSubsectionVisible: boolean = featureFlags.enableAxisNameConfiguration as boolean;
 
         return (
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
@@ -46,13 +47,15 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
                         properties={properties}
                         pushData={pushData}
                     >
-                        <NameSubsection
-                            disabled={xAxisDisabled}
-                            configPanelDisabled={controlsDisabled}
-                            axis={"xaxis"}
-                            properties={properties}
-                            pushData={pushData}
-                        />
+                        {isNameSubsectionVisible && (
+                            <NameSubsection
+                                disabled={xAxisDisabled}
+                                configPanelDisabled={controlsDisabled}
+                                axis={"xaxis"}
+                                properties={properties}
+                                pushData={pushData}
+                            />
+                        )}
                         <LabelSubsection
                             disabled={xAxisDisabled}
                             configPanelDisabled={controlsDisabled}
@@ -73,13 +76,15 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
                         properties={properties}
                         pushData={pushData}
                     >
-                        <NameSubsection
-                            disabled={yAxisDisabled}
-                            configPanelDisabled={controlsDisabled}
-                            axis={"yaxis"}
-                            properties={properties}
-                            pushData={pushData}
-                        />
+                        {isNameSubsectionVisible && (
+                            <NameSubsection
+                                disabled={yAxisDisabled}
+                                configPanelDisabled={controlsDisabled}
+                                axis={"yaxis"}
+                                properties={properties}
+                                pushData={pushData}
+                            />
+                        )}
                         <LabelSubsection
                             disabled={yAxisDisabled}
                             configPanelDisabled={controlsDisabled}

--- a/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
+++ b/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
@@ -32,12 +32,13 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
     protected renderConfigurationPanel() {
         const { xAxisVisible, gridEnabled, yAxisVisible } = this.getControlProperties();
 
-        const { propertiesMeta, properties, pushData, mdObject, type } = this.props;
+        const { featureFlags, propertiesMeta, properties, pushData, mdObject, type } = this.props;
         const controls = properties && properties.controls;
         const controlsDisabled = this.isControlDisabled();
         const { xaxis: itemsOnXAxis, yaxis: itemsOnYAxis } = countItemsOnAxes(type, controls, mdObject);
         const xAxisNameSectionDisabled = controlsDisabled || itemsOnXAxis !== 1;
         const yAxisNameSectionDisabled = controlsDisabled || itemsOnYAxis !== 1;
+        const isNameSubsectionVisible: boolean = featureFlags.enableAxisNameConfiguration as boolean;
 
         return (
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
@@ -54,13 +55,15 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                         properties={properties}
                         pushData={pushData}
                     >
-                        <NameSubsection
-                            disabled={xAxisNameSectionDisabled}
-                            configPanelDisabled={controlsDisabled}
-                            axis={"xaxis"}
-                            properties={properties}
-                            pushData={pushData}
-                        />
+                        {isNameSubsectionVisible && (
+                            <NameSubsection
+                                disabled={xAxisNameSectionDisabled}
+                                configPanelDisabled={controlsDisabled}
+                                axis={"xaxis"}
+                                properties={properties}
+                                pushData={pushData}
+                            />
+                        )}
                         <LabelSubsection
                             disabled={controlsDisabled}
                             configPanelDisabled={controlsDisabled}
@@ -81,13 +84,15 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
                         properties={properties}
                         pushData={pushData}
                     >
-                        <NameSubsection
-                            disabled={yAxisNameSectionDisabled}
-                            configPanelDisabled={controlsDisabled}
-                            axis={"yaxis"}
-                            properties={properties}
-                            pushData={pushData}
-                        />
+                        {isNameSubsectionVisible && (
+                            <NameSubsection
+                                disabled={yAxisNameSectionDisabled}
+                                configPanelDisabled={controlsDisabled}
+                                axis={"yaxis"}
+                                properties={properties}
+                                pushData={pushData}
+                            />
+                        )}
                         <LabelSubsection
                             disabled={controlsDisabled}
                             configPanelDisabled={controlsDisabled}

--- a/src/internal/components/configurationPanels/tests/BaseChartConfigurationPanel.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/BaseChartConfigurationPanel.spec.tsx
@@ -60,6 +60,9 @@ describe("BaseChartConfigurationPanel", () => {
         };
 
         const defaultProps: IConfigurationPanelContentProps = {
+            featureFlags: {
+                enableAxisNameConfiguration: true,
+            },
             isError: false,
             isLoading: false,
             locale: DEFAULT_LOCALE,
@@ -191,6 +194,24 @@ describe("BaseChartConfigurationPanel", () => {
 
             const yAxisSection = axisSections.at(1);
             expect(yAxisSection.props().disabled).toEqual(true); // because of 2 measures on Y axis
+        });
+
+        it("should not render name sections in configuration panel", () => {
+            const mdObject = {
+                buckets: [] as any,
+                visualizationClass,
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                featureFlags: {
+                    enableAxisNameConfiguration: false,
+                },
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+            expect(axisSections.exists()).toEqual(false);
         });
     });
 });

--- a/src/internal/components/configurationPanels/tests/BubbleChartConfigurationPanel.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/BubbleChartConfigurationPanel.spec.tsx
@@ -133,6 +133,9 @@ describe("BubbleChartconfigurationPanel", () => {
 
     describe("axis name configuration", () => {
         const defaultProps: IConfigurationPanelContentProps = {
+            featureFlags: {
+                enableAxisNameConfiguration: true,
+            },
             isError: false,
             isLoading: false,
             locale: DEFAULT_LOCALE,
@@ -272,5 +275,23 @@ describe("BubbleChartconfigurationPanel", () => {
                 expect(yAxisSection.props().disabled).toEqual(expectedYAxisSectionDisabled);
             },
         );
+
+        it("should not render name sections in configuration panel", () => {
+            const mdObject = {
+                buckets: [] as any,
+                visualizationClass,
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                featureFlags: {
+                    enableAxisNameConfiguration: false,
+                },
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+            expect(axisSections.exists()).toEqual(false);
+        });
     });
 });

--- a/src/internal/components/configurationPanels/tests/ScatterPlotConfigurationPanel.spec.tsx
+++ b/src/internal/components/configurationPanels/tests/ScatterPlotConfigurationPanel.spec.tsx
@@ -27,6 +27,9 @@ describe("ScatterPlotConfigurationPanel", () => {
 
     describe("axis name configuration", () => {
         const defaultProps: IConfigurationPanelContentProps = {
+            featureFlags: {
+                enableAxisNameConfiguration: true,
+            },
             isError: false,
             isLoading: false,
             locale: DEFAULT_LOCALE,
@@ -141,5 +144,23 @@ describe("ScatterPlotConfigurationPanel", () => {
                 expect(yAxisSection.props().disabled).toEqual(expectedYAxisSectionDisabled);
             },
         );
+
+        it("should not render name sections in configuration panel", () => {
+            const mdObject = {
+                buckets: [] as any,
+                visualizationClass,
+            };
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                featureFlags: {
+                    enableAxisNameConfiguration: false,
+                },
+                mdObject,
+            });
+
+            const axisSections = wrapper.find(NameSubsection);
+            expect(axisSections.exists()).toEqual(false);
+        });
     });
 });

--- a/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -487,7 +487,8 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
             set(supportedControls, "legend.responsive", true);
         }
 
-        supportedControls = getHighchartsAxisNameConfiguration(supportedControls);
+        supportedControls = getHighchartsAxisNameConfiguration(supportedControls, this.featureFlags
+            .enableAxisNameConfiguration as boolean);
 
         return {
             ...defaultControls,

--- a/src/internal/utils/propertiesHelper.ts
+++ b/src/internal/utils/propertiesHelper.ts
@@ -181,6 +181,7 @@ const AXIS_TYPES: string[] = ["xaxis", "yaxis", "secondary_xaxis", "secondary_ya
 
 export function getHighchartsAxisNameConfiguration(
     controlProperties: IVisualizationProperties,
+    enableAxisNameConfiguration: boolean = false,
 ): IVisualizationProperties {
     const axisProperties: IVisualizationProperties = AXIS_TYPES.reduce(
         (result: IVisualizationProperties, axis: string) => {
@@ -190,7 +191,11 @@ export function getHighchartsAxisNameConfiguration(
                 return result;
             }
 
-            axisNameConfig.position = AXIS_NAME_POSITION_MAPPING[axisNameConfig.position];
+            axisNameConfig.position =
+                AXIS_NAME_POSITION_MAPPING[
+                    enableAxisNameConfiguration ? axisNameConfig.position : AXIS_NAME_POSITION_MAPPING.auto
+                ];
+
             result[axis] = {
                 ...controlProperties[axis],
                 name: axisNameConfig,

--- a/src/internal/utils/tests/propertiesHelper.spec.ts
+++ b/src/internal/utils/tests/propertiesHelper.spec.ts
@@ -248,7 +248,7 @@ describe("propertiesHelper", () => {
                     max: 200,
                 },
             };
-            expect(getHighchartsAxisNameConfiguration(controlsProp)).toEqual(controlsProp);
+            expect(getHighchartsAxisNameConfiguration(controlsProp, true)).toEqual(controlsProp);
         });
 
         it.each([
@@ -268,11 +268,29 @@ describe("propertiesHelper", () => {
                 },
             };
 
-            const newControlsProp = getHighchartsAxisNameConfiguration(controlsProp);
+            const newControlsProp = getHighchartsAxisNameConfiguration(controlsProp, true);
             expect(newControlsProp).toEqual({
                 xaxis: {
                     name: {
                         position: hcValue,
+                    },
+                },
+            });
+        });
+
+        it("should return default position", () => {
+            const controlsProp: IVisualizationProperties = {
+                xaxis: {
+                    name: {
+                        position: "left",
+                    },
+                },
+            };
+            const newControlsProp = getHighchartsAxisNameConfiguration(controlsProp, false);
+            expect(newControlsProp).toEqual({
+                xaxis: {
+                    name: {
+                        position: "middle",
                     },
                 },
             });


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)
- [ ] Squash commits

# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2603
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2422

# Related Jira tasks
- SD-726: https://jira.intgdc.com/browse/SD-726
