### PR TITLE
BUGFIX: SD-743 get length of measures in secondary yAxis config when it existed

### DIFF
--- a/src/helpers/MdObjectHelper.ts
+++ b/src/helpers/MdObjectHelper.ts
@@ -113,7 +113,7 @@ export function areAllMeasuresOnSingleAxis(
     secondaryYAxis: IAxisConfig,
 ): boolean {
     const measureCount = getMeasuresFromMdObject(mdObject).length;
-    const numberOfMeasureOnSecondaryAxis = secondaryYAxis ? secondaryYAxis.measures.length : 0;
+    const numberOfMeasureOnSecondaryAxis = get(secondaryYAxis, "measures.length", 0);
     return numberOfMeasureOnSecondaryAxis === 0 || measureCount === numberOfMeasureOnSecondaryAxis;
 }
 

--- a/src/helpers/tests/MdObjectHelper.spec.ts
+++ b/src/helpers/tests/MdObjectHelper.spec.ts
@@ -376,6 +376,14 @@ describe("MdObjectHelper", () => {
             expect(isSingleAxis).toEqual(true);
         });
 
+        it("should return true if measures is undefined on secondary axis config", () => {
+            const isSingleAxis = areAllMeasuresOnSingleAxis(
+                visualizationObjects[0].visualizationObject.content,
+                {},
+            );
+            expect(isSingleAxis).toEqual(true);
+        });
+
         it("should return false if measures are on 2 axes", () => {
             const isSingleAxis = areAllMeasuresOnSingleAxis(
                 visualizationObjects[0].visualizationObject.content,


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2665
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2465

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
