### PR TITLE
BUGFIX: ONE-4226 ProjectId not relevant when URI prop used

### DIFF
--- a/examples/src/components/AttributeFilterComponentExample.jsx
+++ b/examples/src/components/AttributeFilterComponentExample.jsx
@@ -29,11 +29,7 @@ export class AttributeFilterComponentExample extends Component {
                     />
                 </div>
                 <div>attribute defined by display form uri</div>
-                <AttributeFilter
-                    projectId={projectId}
-                    uri={employeeNameDisplayFormUri}
-                    onApply={this.onApply}
-                />
+                <AttributeFilter uri={employeeNameDisplayFormUri} onApply={this.onApply} />
                 <br />
                 <div>attribute defined by filter definition, including selection</div>
                 <AttributeFilter

--- a/src/components/filters/AttributeFilter/AttributeDropdown.tsx
+++ b/src/components/filters/AttributeFilter/AttributeDropdown.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import * as React from "react";
 import * as PropTypes from "prop-types";
 import InvertableList from "@gooddata/goodstrap/lib/List/InvertableList";
@@ -49,7 +49,7 @@ export interface IAttributeMetadata {
 
 export interface IAttributeDropdownProps {
     attributeDisplayForm: IAttributeDisplayForm;
-    projectId: string;
+    projectId?: string; // remove it in SDK 8 because it is not used anywhere - breaking change
     selection: IAttributeElement[];
     isInverted: boolean;
     onApply: (selection: IAttributeElement[], isInverted: boolean) => void;
@@ -130,7 +130,7 @@ export class AttributeDropdownWrapped extends React.PureComponent<
 > {
     public static propTypes = {
         attributeDisplayForm: PropTypes.object.isRequired,
-        projectId: PropTypes.string.isRequired,
+        projectId: PropTypes.string,
         selection: PropTypes.array,
         isInverted: PropTypes.bool,
 
@@ -150,6 +150,7 @@ export class AttributeDropdownWrapped extends React.PureComponent<
     public static defaultProps: Partial<IAttributeDropdownProps> = {
         fullscreenOnMobile: false,
         title: null,
+        projectId: null,
         selection: new Array<IAttributeElement>(),
 
         getListItem: () => <AttributeFilterItem />,

--- a/src/components/filters/AttributeFilter/AttributeFilter.tsx
+++ b/src/components/filters/AttributeFilter/AttributeFilter.tsx
@@ -15,14 +15,15 @@ import { IAttributeElement } from "./model";
 import * as Model from "../../../helpers/model";
 
 export interface IAttributeFilterProps {
-    projectId: string;
     onApply?: (...params: any[]) => any; // TODO: make the types more specific (FET-282)
     onApplyWithFilterDefinition?: (
         filter: VisualizationInput.IPositiveAttributeFilter | VisualizationInput.INegativeAttributeFilter,
     ) => void;
     sdk?: SDK;
-    // one of these three needs to be provided
+    // one of: uri | projectId + identifier | filter by df uri | projectId + filter by df identifier
+    // needs to be provided
     uri?: string;
+    projectId?: string;
     identifier?: string;
     filter?: VisualizationInput.IPositiveAttributeFilter | VisualizationInput.INegativeAttributeFilter;
     locale?: string;
@@ -91,7 +92,7 @@ export class AttributeFilter extends React.PureComponent<IAttributeFilterProps> 
         uri: PropTypes.string,
         identifier: PropTypes.string,
         filter: PropTypes.object,
-        projectId: PropTypes.string.isRequired,
+        projectId: PropTypes.string,
         onApply: PropTypes.func,
         onApplyWithFilterDefinition: PropTypes.func,
         fullscreenOnMobile: PropTypes.bool,
@@ -102,6 +103,7 @@ export class AttributeFilter extends React.PureComponent<IAttributeFilterProps> 
     };
 
     public static defaultProps: Partial<IAttributeFilterProps> = {
+        projectId: null,
         uri: null,
         identifier: null,
         filter: null,

--- a/src/components/filters/AttributeFilter/AttributeLoader.tsx
+++ b/src/components/filters/AttributeFilter/AttributeLoader.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import * as React from "react";
 import * as PropTypes from "prop-types";
 import { IAttributeDisplayForm } from "./model";
@@ -10,7 +10,7 @@ export interface IAttributeLoaderMetadataProps {
 
 export interface IAttributeLoaderProps {
     metadata: IAttributeLoaderMetadataProps;
-    projectId: string;
+    projectId?: string;
     uri?: string;
     identifier?: string;
 
@@ -66,7 +66,7 @@ function getAttributeDisplayForm(
 
 export class AttributeLoader extends React.PureComponent<IAttributeLoaderProps, IAttributeLoaderState> {
     public static propTypes = {
-        projectId: PropTypes.string.isRequired,
+        projectId: PropTypes.string,
         uri: PropTypes.string,
         identifier: PropTypes.string,
         metadata: PropTypes.shape({
@@ -78,6 +78,7 @@ export class AttributeLoader extends React.PureComponent<IAttributeLoaderProps, 
     public static defaultProps: Partial<IAttributeLoaderProps> = {
         uri: null,
         identifier: null,
+        projectId: null,
     };
 
     constructor(props: IAttributeLoaderProps) {


### PR DESCRIPTION
ProjectId is only optional prop, because it doesn't make sense when URI or Filter by display form URI are used

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related Jira tasks
- ONE-4226: https://jira.intgdc.com/browse/ONE-4226