### PR TITLE
FEATURE: SD-750 SD-751 SD-752 SD-753 SD-783 add bucket items and pluggable for geo pushpin

### DIFF
--- a/__mocks__/fixtures.ts
+++ b/__mocks__/fixtures.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import { VisualizationObject, VisualizationClass, AFM } from "@gooddata/typings";
 import IVisualizationClassWrapped = VisualizationClass.IVisualizationClassWrapped;
 import IVisualization = VisualizationObject.IVisualization;

--- a/src/constants/visualizationTypes.ts
+++ b/src/constants/visualizationTypes.ts
@@ -36,6 +36,7 @@ export type ChartType =
     | "bubble"
     | "heatmap"
     | "geo"
+    | "pushpin"
     | "combo"
     | "combo2"
     | "histogram"

--- a/src/internal/assets/geoPushpin/bucket-title-color.svg
+++ b/src/internal/assets/geoPushpin/bucket-title-color.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="10" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#94A1AD" d="M7 8h9v2H7zm0-4h9v2H7zm0-4h9v2H7z"/>
+    <path fill-opacity=".45" fill="#B0BECA" d="M0 8h5v2H0zm0-4h5v2H0zm0-4h5v2H0z"/>
+  </g>
+</svg>

--- a/src/internal/assets/geoPushpin/bucket-title-location.svg
+++ b/src/internal/assets/geoPushpin/bucket-title-location.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="10" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#94A1AD" d="M7 8h9v2H7zm0-4h9v2H7zm0-4h9v2H7z"/>
+    <path fill-opacity=".45" fill="#B0BECA" d="M0 8h5v2H0zm0-4h5v2H0zm0-4h5v2H0z"/>
+  </g>
+</svg>

--- a/src/internal/assets/geoPushpin/bucket-title-segment.svg
+++ b/src/internal/assets/geoPushpin/bucket-title-segment.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="10" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#94A1AD" d="M7 8h9v2H7zm0-4h9v2H7zm0-4h9v2H7z"/>
+    <path fill-opacity=".45" fill="#B0BECA" d="M0 8h5v2H0zm0-4h5v2H0zm0-4h5v2H0z"/>
+  </g>
+</svg>

--- a/src/internal/assets/geoPushpin/bucket-title-size.svg
+++ b/src/internal/assets/geoPushpin/bucket-title-size.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="10" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#94A1AD" d="M7 8h9v2H7zm0-4h9v2H7zm0-4h9v2H7z"/>
+    <path fill-opacity=".45" fill="#B0BECA" d="M0 8h5v2H0zm0-4h5v2H0zm0-4h5v2H0z"/>
+  </g>
+</svg>

--- a/src/internal/components/BaseVisualization.tsx
+++ b/src/internal/components/BaseVisualization.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import * as React from "react";
 import * as uuid from "uuid";
 import isEqual = require("lodash/isEqual");
@@ -38,6 +38,7 @@ import { PluggableTreemap } from "./pluggableVisualizations/treeMap/PluggableTre
 import { PluggableFunnelChart } from "./pluggableVisualizations/funnelChart/PluggableFunnelChart";
 import { PluggableBubbleChart } from "./pluggableVisualizations/bubbleChart/PluggableBubbleChart";
 import { PluggableXirr } from "./pluggableVisualizations/xirr/PluggableXirr";
+import { PluggableGeoPushpinChart } from "./pluggableVisualizations/geoChart/PluggableGeoPushpinChart";
 
 // visualization catalogue - add your new visualization here
 const VisualizationsCatalog = {
@@ -57,6 +58,7 @@ const VisualizationsCatalog = {
     treemap: PluggableTreemap,
     funnel: PluggableFunnelChart,
     xirr: PluggableXirr,
+    pushpin: PluggableGeoPushpinChart,
 };
 
 export interface IBaseVisualizationProps extends IVisCallbacks {

--- a/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
+++ b/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
@@ -1,0 +1,215 @@
+// (C) 2019-2020 GoodData Corporation
+import * as React from "react";
+import { render } from "react-dom";
+import { VisualizationObject, AFM } from "@gooddata/typings";
+
+import cloneDeep = require("lodash/cloneDeep");
+import get = require("lodash/get");
+import set = require("lodash/set");
+
+import * as BucketNames from "../../../../constants/bucketNames";
+import {
+    IReferencePoint,
+    IExtendedReferencePoint,
+    IVisConstruct,
+    IVisualizationProperties,
+    IVisProps,
+    IBucketItem,
+    IBucket,
+} from "../../../interfaces/Visualization";
+import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
+import { BUCKETS, METRIC, ATTRIBUTE } from "../../../constants/bucket";
+import { GEO_PUSHPIN_CHART_UICONFIG } from "../../../constants/uiConfig";
+import {
+    sanitizeFilters,
+    getBucketItemsByType,
+    getPreferredBucketItems,
+    hasBucket,
+} from "../../../utils/bucketHelper";
+import { setGeoPushpinUiConfig } from "../../../utils/uiConfigHelpers/geoPushpinChartUiConfigHelper";
+import { removeSort, createSorts } from "../../../utils/sort";
+import { getReferencePointWithSupportedProperties } from "../../../utils/propertiesHelper";
+import { VisualizationTypes } from "../../../../constants/visualizationTypes";
+
+import UnsupportedConfigurationPanel from "../../configurationPanels/UnsupportedConfigurationPanel";
+import { DASHBOARDS_ENVIRONMENT } from "../../../constants/properties";
+import { GeoChart } from "../../../../components/core/GeoChart";
+
+export class PluggableGeoPushpinChart extends PluggableBaseChart {
+    private geoPushpinElement: string;
+
+    constructor(props: IVisConstruct) {
+        super(props);
+
+        const { callbacks, element, visualizationProperties } = props;
+        this.type = VisualizationTypes.PUSHPIN;
+        this.supportedPropertiesList = [];
+        this.callbacks = callbacks;
+        this.geoPushpinElement = element;
+        this.initializeProperties(visualizationProperties);
+    }
+
+    public getExtendedReferencePoint(referencePoint: IReferencePoint): Promise<IExtendedReferencePoint> {
+        const clonedReferencePoint = cloneDeep(referencePoint);
+        let newReferencePoint: IExtendedReferencePoint = {
+            ...clonedReferencePoint,
+            uiConfig: cloneDeep(GEO_PUSHPIN_CHART_UICONFIG),
+        };
+
+        const buckets = get(clonedReferencePoint, BUCKETS, []);
+        const locations = getBucketItemsByType(buckets, BucketNames.LOCATION, [ATTRIBUTE]);
+        const measuresSize = this.getMeasureSizeBucketItem(buckets);
+        const measuresColor = this.getMeasureColorBucketItem(buckets);
+        const segments = getPreferredBucketItems(
+            buckets,
+            [BucketNames.STACK, BucketNames.SEGMENT_BY],
+            [ATTRIBUTE],
+        );
+
+        set(newReferencePoint, BUCKETS, [
+            {
+                localIdentifier: BucketNames.LOCATION,
+                items: locations,
+            },
+            {
+                localIdentifier: BucketNames.SIZE,
+                items: measuresSize,
+            },
+            {
+                localIdentifier: BucketNames.COLOR,
+                items: measuresColor,
+            },
+            {
+                localIdentifier: BucketNames.SEGMENT_BY,
+                items: segments,
+            },
+        ]);
+
+        newReferencePoint = setGeoPushpinUiConfig(newReferencePoint, this.intl, this.type);
+        newReferencePoint = getReferencePointWithSupportedProperties(
+            newReferencePoint,
+            this.supportedPropertiesList,
+        );
+        newReferencePoint = removeSort(newReferencePoint);
+
+        return Promise.resolve(sanitizeFilters(newReferencePoint));
+    }
+
+    protected renderConfigurationPanel() {
+        const configPanelElement = document.querySelector(this.configPanelElement);
+        if (configPanelElement) {
+            const properties: IVisualizationProperties = get(this, "visualizationProperties.properties", {});
+
+            render(
+                <UnsupportedConfigurationPanel
+                    locale={this.locale}
+                    pushData={this.callbacks.pushData}
+                    properties={properties}
+                />,
+                configPanelElement,
+            );
+        }
+    }
+
+    protected renderVisualization(
+        options: IVisProps,
+        visualizationProperties: IVisualizationProperties,
+        mdObject: VisualizationObject.IVisualizationObjectContent,
+    ) {
+        const { dataSource } = options;
+        if (!dataSource) {
+            return;
+        }
+
+        const { projectId, intl, geoPushpinElement } = this;
+        const {
+            dimensions: { height },
+            custom: { drillableItems },
+            locale,
+            config,
+        } = options;
+        const {
+            afterRender,
+            onDrill,
+            onFiredDrillEvent,
+            onError,
+            onExportReady,
+            onLoadingChanged,
+        } = this.callbacks;
+
+        // keep height undef for AD; causes indigo-visualizations to pick default 100%
+        const resultingHeight = this.environment === DASHBOARDS_ENVIRONMENT ? height : undefined;
+
+        const resultSpec = this.getResultSpec(options, visualizationProperties, mdObject);
+
+        const fullConfig = this.buildVisualizationConfig(mdObject, config, null);
+        const geoPushpinProps = {
+            projectId,
+            drillableItems,
+            config: fullConfig,
+            height: resultingHeight,
+            intl,
+            locale,
+            dataSource,
+            resultSpec,
+            pushData: this.handlePushData,
+            afterRender,
+            onDrill,
+            onError,
+            onExportReady,
+            onLoadingChanged,
+            onFiredDrillEvent,
+            LoadingComponent: null as any,
+            ErrorComponent: null as any,
+        };
+
+        render(<GeoChart {...geoPushpinProps} />, document.querySelector(geoPushpinElement));
+    }
+
+    private getResultSpec(
+        options: IVisProps,
+        visualizationProperties: IVisualizationProperties,
+        mdObject: VisualizationObject.IVisualizationObjectContent,
+    ): AFM.IResultSpec {
+        const { resultSpec, dataSource } = options;
+
+        const resultSpecWithDimensions: AFM.IResultSpec = {
+            ...resultSpec,
+            dimensions: this.getDimensions(mdObject),
+        };
+
+        const hasSizeMeasure = mdObject.buckets.some(bucket => bucket.localIdentifier === BucketNames.SIZE);
+
+        const allProperties: IVisualizationProperties = get(visualizationProperties, "properties", {});
+
+        // only DESC sort on Size measure to always lay smaller pushpins on top of bigger ones
+        const sorts: AFM.SortItem[] = hasSizeMeasure
+            ? createSorts(this.type, dataSource.getAfm(), resultSpecWithDimensions, allProperties)
+            : [];
+
+        return {
+            ...resultSpecWithDimensions,
+            sorts,
+        };
+    }
+
+    private getMeasureSizeBucketItem(buckets: IBucket[]): IBucketItem[] {
+        if (hasBucket(buckets, BucketNames.MEASURES)) {
+            return getBucketItemsByType(buckets, BucketNames.MEASURES, [METRIC]).slice(0, 1);
+        }
+
+        return getBucketItemsByType(buckets, BucketNames.SIZE, [METRIC]);
+    }
+
+    private getMeasureColorBucketItem(buckets: IBucket[]): IBucketItem[] {
+        if (hasBucket(buckets, BucketNames.SECONDARY_MEASURES)) {
+            return getBucketItemsByType(buckets, BucketNames.SECONDARY_MEASURES, [METRIC]).slice(0, 1);
+        }
+
+        if (hasBucket(buckets, BucketNames.MEASURES)) {
+            return getBucketItemsByType(buckets, BucketNames.MEASURES, [METRIC]).slice(1, 2);
+        }
+
+        return getBucketItemsByType(buckets, BucketNames.COLOR, [METRIC]);
+    }
+}

--- a/src/internal/components/pluggableVisualizations/geoChart/tests/PluggableGeoPushpinChart.spec.tsx
+++ b/src/internal/components/pluggableVisualizations/geoChart/tests/PluggableGeoPushpinChart.spec.tsx
@@ -1,0 +1,48 @@
+// (C) 2019-2020 GoodData Corporation
+import noop = require("lodash/noop");
+import * as referencePointMocks from "../../../../mocks/referencePointMocks";
+import * as uiConfigMocks from "../../../../mocks/uiConfigMocks";
+import { PluggableGeoPushpinChart } from "../PluggableGeoPushpinChart";
+import { IExtendedReferencePoint, IVisConstruct } from "../../../../interfaces/Visualization";
+
+describe("PluggableGeoPushpinChart", () => {
+    const defaultProps: IVisConstruct = {
+        projectId: "PROJECTID",
+        element: "body",
+        configPanelElement: null as string,
+        callbacks: {
+            afterRender: noop,
+            pushData: noop,
+        },
+    };
+
+    function createComponent(props: IVisConstruct = defaultProps) {
+        return new PluggableGeoPushpinChart(props);
+    }
+
+    it("should create geo pushpin visualization", () => {
+        const visualization = createComponent();
+
+        expect(visualization).toBeTruthy();
+    });
+
+    describe("getExtendedReferencePoint", () => {
+        const geoPushpin = createComponent();
+        const sourceReferencePoint = referencePointMocks.simpleGeoPushpinReferencePoint;
+        const extendedReferencePointPromise: Promise<
+            IExtendedReferencePoint
+        > = geoPushpin.getExtendedReferencePoint(sourceReferencePoint);
+
+        it("should return a new reference point with geoPushpin adapted buckets", () => {
+            return extendedReferencePointPromise.then(extendedReferencePoint => {
+                expect(extendedReferencePoint.buckets).toEqual(sourceReferencePoint.buckets);
+            });
+        });
+
+        it("should return a new reference point with geoPushpin UI config", () => {
+            return extendedReferencePointPromise.then(extendedReferencePoint => {
+                expect(extendedReferencePoint.uiConfig).toEqual(uiConfigMocks.defaultGeoPushpinUiConfig);
+            });
+        });
+    });
+});

--- a/src/internal/constants/bucket.ts
+++ b/src/internal/constants/bucket.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import { IBucket } from "../interfaces/Visualization";
 
 // Buckets

--- a/src/internal/constants/uiConfig.ts
+++ b/src/internal/constants/uiConfig.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import { IUiConfig } from "../interfaces/Visualization";
 
 import { METRIC, FACT, ATTRIBUTE, DATE } from "./bucket";
@@ -16,6 +16,8 @@ export const MAX_VIEW_COUNT = 2;
 export const DEFAULT_HEADLINE_METRICS_COUNT = 1;
 export const DEFAULT_XIRR_METRICS_COUNT = 1;
 export const DEFAULT_XIRR_ATTRIBUTES_COUNT = 1;
+export const DEFAULT_GEO_ATTRIBUTES_COUNT = 1;
+export const DEFAULT_PUSHPIN_METRICS_COUNT = 1;
 
 export const UICONFIG = "uiConfig";
 export const RECOMMENDATIONS = "recommendations";
@@ -539,4 +541,44 @@ export const DEFAULT_XIRR_UICONFIG: IUiConfig = {
     },
     ...defaultRootUiConfigProperties,
     ...disabledExportConfig,
+};
+
+const geoMeasuresBase = {
+    accepts: [METRIC, FACT, ATTRIBUTE],
+    allowsDuplicateItems: true,
+    enabled: true,
+    allowsReordering: false,
+    allowsSwapping: true,
+    itemsLimit: DEFAULT_PUSHPIN_METRICS_COUNT,
+    isShowInPercentEnabled: false,
+    isShowInPercentVisible: false,
+    canAddItems: true,
+};
+
+const geoAttributesBase = {
+    accepts: [ATTRIBUTE],
+    itemsLimit: DEFAULT_GEO_ATTRIBUTES_COUNT,
+    allowsSwapping: true,
+    allowsReordering: false,
+    enabled: true,
+    isShowInPercentEnabled: false,
+};
+
+export const GEO_PUSHPIN_CHART_UICONFIG: IUiConfig = {
+    buckets: {
+        location: {
+            ...geoAttributesBase,
+        },
+        size: {
+            ...geoMeasuresBase,
+        },
+        color: {
+            ...geoMeasuresBase,
+        },
+        segmentBy: {
+            ...geoAttributesBase,
+        },
+        ...defaultFilters,
+    },
+    ...defaultRootUiConfigProperties,
 };

--- a/src/internal/mocks/referencePointMocks.ts
+++ b/src/internal/mocks/referencePointMocks.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import {
     IReferencePoint,
     IBucketItem,
@@ -311,6 +311,62 @@ export const attributeItems: IBucketItem[] = [
         localIdentifier: "a3",
         type: "attribute",
         attribute: "attr.owner.region",
+    },
+];
+
+export const geoAttributeItems: IBucketItem[] = [
+    {
+        localIdentifier: "a1",
+        type: "attribute",
+        aggregation: null,
+        attribute: "attr.owner.country",
+    },
+    {
+        localIdentifier: "a2",
+        type: "attribute",
+        aggregation: null,
+        attribute: "attr.owner.city",
+    },
+];
+
+export const geoAttributeFilters: IFiltersBucketItem[] = [
+    {
+        localIdentifier: "a1",
+        type: "attribute",
+        aggregation: null,
+        attribute: "attr.owner.country",
+        filters: [
+            {
+                attribute: "attr.owner.country",
+                isInverted: false,
+                totalElementsCount: 10,
+                selectedElements: [
+                    {
+                        title: "string",
+                        uri: "string",
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        localIdentifier: "a2",
+        type: "attribute",
+        aggregation: null,
+        attribute: "attr.owner.city",
+        filters: [
+            {
+                attribute: "attr.owner.city",
+                totalElementsCount: 10,
+                isInverted: true,
+                selectedElements: [
+                    {
+                        title: "string",
+                        uri: "string",
+                    },
+                ],
+            },
+        ],
     },
 ];
 
@@ -1914,5 +1970,33 @@ export const measureValueFilterReferencePoint: IReferencePoint = {
                 ],
             },
         ],
+    },
+};
+
+export const simpleGeoPushpinReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "location",
+            items: geoAttributeItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "size",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "color",
+            items: masterMeasureItems.slice(1, 2),
+        },
+        {
+            localIdentifier: "segmentBy",
+            items: geoAttributeItems.slice(1, 2),
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: geoAttributeFilters.slice(0, 1),
+    },
+    properties: {
+        sortItems: [defaultSortItem],
     },
 };

--- a/src/internal/mocks/uiConfigMocks.ts
+++ b/src/internal/mocks/uiConfigMocks.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import {
     MAX_METRICS_COUNT,
     DEFAULT_PIE_METRICS_COUNT,
@@ -1204,4 +1204,72 @@ export const fullySpecifiedXirrUiConfig: IUiConfig = {
     exportConfig: disabledExportConfig,
     openAsReport: disabledOpenAsReportConfig,
     supportedOverTimeComparisonTypes: [],
+};
+
+export const defaultGeoPushpinUiConfig: IUiConfig = {
+    buckets: {
+        location: {
+            accepts: ["attribute"],
+            allowsReordering: false,
+            allowsSwapping: true,
+            enabled: true,
+            icon: "",
+            isShowInPercentEnabled: false,
+            itemsLimit: 1,
+            title: "Location",
+        },
+        size: {
+            accepts: ["metric", "fact", "attribute"],
+            allowsDuplicateItems: true,
+            allowsReordering: false,
+            allowsSwapping: true,
+            enabled: true,
+            icon: "",
+            isShowInPercentEnabled: false,
+            isShowInPercentVisible: false,
+            itemsLimit: 1,
+            subtitle: "Size",
+            title: "Measure",
+            canAddItems: true,
+        },
+        color: {
+            accepts: ["metric", "fact", "attribute"],
+            allowsDuplicateItems: true,
+            allowsReordering: false,
+            allowsSwapping: true,
+            enabled: true,
+            icon: "",
+            isShowInPercentEnabled: false,
+            isShowInPercentVisible: false,
+            itemsLimit: 1,
+            subtitle: "Color",
+            title: "Measure",
+            canAddItems: true,
+        },
+        segmentBy: {
+            accepts: ["attribute"],
+            allowsReordering: false,
+            allowsSwapping: true,
+            enabled: true,
+            icon: "",
+            isShowInPercentEnabled: false,
+            itemsLimit: 1,
+            title: "Segment by",
+        },
+        filters: {
+            accepts: ["attribute", "date"],
+            allowsReordering: false,
+            enabled: true,
+            isShowInPercentEnabled: false,
+            itemsLimit: 20,
+        },
+    },
+    exportConfig: {
+        supported: true,
+    },
+    openAsReport: {
+        supported: false,
+    },
+    recommendations: {},
+    supportedOverTimeComparisonTypes: noSupportedOverTimeComparisonTypes,
 };

--- a/src/internal/translations/en-US.json
+++ b/src/internal/translations/en-US.json
@@ -164,6 +164,31 @@
         "comment": "",
         "limit": 0
     },
+    "dashboard.bucket.location_title.pushpin": {
+        "value": "Location",
+        "comment": "Geological location (position of a pin pushed to a map).",
+        "limit": 0
+    },
+    "dashboard.bucket.size_title.pushpin": {
+        "value": "Measure",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.size_subtitle.pushpin": {
+        "value": "Size",
+        "comment": "Geological size (size of a pin pushed to a map).",
+        "limit": 0
+    },
+    "dashboard.bucket.color_title.pushpin": {
+        "value": "Measure",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.color_subtitle.pushpin": {
+        "value": "Color",
+        "comment": "Geological color (color of a pin pushed to a map).",
+        "limit": 0
+    },
     "dashboard.bucket.view_title.bubble": {
         "value": "View by",
         "comment": "",
@@ -245,6 +270,11 @@
         "limit": 0
     },
     "dashboard.bucket.segment_title.treemap": {
+        "value": "Segment by",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.segmentBy_title.pushpin": {
         "value": "Segment by",
         "comment": "",
         "limit": 0

--- a/src/internal/utils/bucketHelper.ts
+++ b/src/internal/utils/bucketHelper.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import set = require("lodash/set");
 import get = require("lodash/get");
 import uniq = require("lodash/uniq");
@@ -243,6 +243,13 @@ function bucketSupportsSubtitle(visualizationType: string, bucketLocalIdentifier
     if (visualizationType === VisualizationTypes.COMBO) {
         return bucketLocalIdentifier !== BucketNames.VIEW;
     }
+
+    if (visualizationType === VisualizationTypes.PUSHPIN) {
+        return (
+            bucketLocalIdentifier !== BucketNames.LOCATION && bucketLocalIdentifier !== BucketNames.SEGMENT_BY
+        );
+    }
+
     return false;
 }
 

--- a/src/internal/utils/sort.ts
+++ b/src/internal/utils/sort.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import get = require("lodash/get");
 import set = require("lodash/set");
 import includes = require("lodash/includes");
@@ -45,6 +45,15 @@ function getDefaultTableSort(afm: AFM.IAfm): AFM.SortItem[] {
     }
 
     return [SortsHelper.getAttributeSortItem(attribute.localIdentifier, SORT_DIR_ASC)];
+}
+
+function getDefaultGeoPushpinSort(afm: AFM.IAfm): AFM.SortItem[] {
+    const measure: AFM.IMeasure = get(afm, "measures.0");
+    if (measure) {
+        return getMeasureSortItems(measure.localIdentifier, SORT_DIR_DESC);
+    }
+
+    return [];
 }
 
 export function getDefaultPivotTableSort(afm: AFM.IAfm): AFM.SortItem[] {
@@ -97,6 +106,8 @@ export function createSorts(
             );
         case VisualizationTypes.TREEMAP:
             return SortsHelper.getDefaultTreemapSort(afm, resultSpec);
+        case VisualizationTypes.PUSHPIN:
+            return getDefaultGeoPushpinSort(afm);
     }
     return [];
 }

--- a/src/internal/utils/tests/sort.spec.ts
+++ b/src/internal/utils/tests/sort.spec.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import cloneDeep = require("lodash/cloneDeep");
 
 import { AFM } from "@gooddata/typings";
@@ -364,6 +364,23 @@ describe("createSorts", () => {
             sortItems: [SORTED_BY_M1],
         };
         expect(createSorts("table", emptyAfm, emptyResultSpec, visualizationProperties)).toEqual([]);
+    });
+
+    it("should sort by measure size if chart is geo Pushpin", () => {
+        const afm: AFM.IAfm = {
+            measures: [M1],
+            attributes: [A1, A2],
+        };
+        const resultSpec: AFM.IResultSpec = {
+            dimensions: [
+                { itemIdentifiers: ["measureGroup"] },
+                {
+                    itemIdentifiers: ["a1", "a2"],
+                },
+            ],
+        };
+        const expectedSort: AFM.SortItem[] = [SORTED_BY_M1];
+        expect(createSorts("pushpin", afm, resultSpec, emptyVisualizationProperties)).toEqual(expectedSort);
     });
 });
 

--- a/src/internal/utils/uiConfigHelpers/geoPushpinChartUiConfigHelper.ts
+++ b/src/internal/utils/uiConfigHelpers/geoPushpinChartUiConfigHelper.ts
@@ -1,0 +1,34 @@
+// (C) 2019-2020 GoodData Corporation
+import { IntlShape } from "react-intl";
+import cloneDeep = require("lodash/cloneDeep");
+import set = require("lodash/set");
+
+import { IExtendedReferencePoint } from "../../interfaces/Visualization";
+import { UICONFIG } from "../../constants/uiConfig";
+import { BUCKETS } from "../../constants/bucket";
+import { setBucketTitles } from "../bucketHelper";
+
+import * as BucketNames from "../../../constants/bucketNames";
+import * as geoPushPinLocationIcon from "../../assets/geoPushpin/bucket-title-location.svg";
+import * as geoPushPinMeasuresSizeIcon from "../../assets/geoPushpin/bucket-title-size.svg";
+import * as geoPushPinMeasuresColorIcon from "../../assets/geoPushpin/bucket-title-color.svg";
+import * as geoPushPinSegmentIcon from "../../assets/geoPushpin/bucket-title-segment.svg";
+
+export function setGeoPushpinUiConfig(
+    referencePoint: IExtendedReferencePoint,
+    intl: IntlShape,
+    visualizationType: string,
+): IExtendedReferencePoint {
+    const referencePointConfigured = cloneDeep(referencePoint);
+    set(referencePointConfigured, UICONFIG, setBucketTitles(referencePoint, visualizationType, intl));
+    set(referencePointConfigured, [UICONFIG, BUCKETS, BucketNames.LOCATION, "icon"], geoPushPinLocationIcon);
+    set(referencePointConfigured, [UICONFIG, BUCKETS, BucketNames.SIZE, "icon"], geoPushPinMeasuresSizeIcon);
+    set(
+        referencePointConfigured,
+        [UICONFIG, BUCKETS, BucketNames.COLOR, "icon"],
+        geoPushPinMeasuresColorIcon,
+    );
+    set(referencePointConfigured, [UICONFIG, BUCKETS, BucketNames.SEGMENT_BY, "icon"], geoPushPinSegmentIcon);
+
+    return referencePointConfigured;
+}

--- a/styles/scss/geoChart.scss
+++ b/styles/scss/geoChart.scss
@@ -1,5 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
-@import "~mapbox-gl/dist/mapbox-gl";
+// (C) 2007-2020 GoodData Corporation
 
 .gd-geo-component {
     position: absolute;


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2707
- gdc-dashboards:

# Related Jira tasks
https://jira.intgdc.com/browse/SD-750
https://jira.intgdc.com/browse/SD-751
https://jira.intgdc.com/browse/SD-752
https://jira.intgdc.com/browse/SD-753
https://jira.intgdc.com/browse/SD-783

