### PR TITLE
RELATED: RAIL-1992 keep attribute sort aggregation in PivotTable

### DIFF
--- a/examples/src/components/PivotTableSortingAggregationExample.jsx
+++ b/examples/src/components/PivotTableSortingAggregationExample.jsx
@@ -1,0 +1,39 @@
+// (C) 2007-2020 GoodData Corporation
+import React, { Component } from "react";
+import { PivotTable, Model } from "@gooddata/react-components";
+
+import "@gooddata/react-components/styles/css/main.css";
+
+import {
+    projectId,
+    quarterDateIdentifier,
+    locationStateDisplayFormIdentifier,
+    franchiseFeesIdentifier,
+} from "../utils/fixtures";
+
+const measures = [Model.measure(franchiseFeesIdentifier).format("#,##0")];
+
+const attributes = [Model.attribute(locationStateDisplayFormIdentifier).localIdentifier("state")];
+
+const columns = [Model.attribute(quarterDateIdentifier)];
+
+const sortBy = [Model.attributeSortItem("state", "desc").aggregation("sum")];
+
+export class PivotTableSortingAggregationExample extends Component {
+    render() {
+        return (
+            <div style={{ height: 300 }} className="s-pivot-table-sorting">
+                <PivotTable
+                    projectId={projectId}
+                    measures={measures}
+                    rows={attributes}
+                    columns={columns}
+                    pageSize={20}
+                    sortBy={sortBy}
+                />
+            </div>
+        );
+    }
+}
+
+export default PivotTableSortingAggregationExample;

--- a/examples/src/routes/PivotTableDemo.jsx
+++ b/examples/src/routes/PivotTableDemo.jsx
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import React from "react";
 
 import ExampleWithSource from "../components/utils/ExampleWithSource";
@@ -12,6 +12,8 @@ import PivotTableRowGroupingExample from "../components/PivotTableRowGroupingExa
 import PivotTableRowGroupingExampleSRC from "!raw-loader!../components/PivotTableRowGroupingExample"; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
 import PivotTableSubtotalsExample from "../components/PivotTableSubtotalsExample";
 import PivotTableSubtotalsExampleSRC from "!raw-loader!../components/PivotTableSubtotalsExample"; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
+import PivotTableSortingAggregationExample from "../components/PivotTableSortingAggregationExample";
+import PivotTableSortingAggregationExampleSRC from "!raw-loader!../components/PivotTableSortingAggregationExample"; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved, import/extensions, import/first
 
 export const PivotTableDemo = () => (
     <div>
@@ -44,6 +46,14 @@ export const PivotTableDemo = () => (
         <ExampleWithSource
             for={() => <PivotTableSubtotalsExample />}
             source={PivotTableSubtotalsExampleSRC}
+        />
+
+        <h2 id="measures-row-attributes-and-column-attributes-and-sort-aggregation">
+            Example of sort with aggregation
+        </h2>
+        <ExampleWithSource
+            for={() => <PivotTableSortingAggregationExample />}
+            source={PivotTableSortingAggregationExampleSRC}
         />
     </div>
 );

--- a/src/components/core/pivotTable/agGridDataSource.ts
+++ b/src/components/core/pivotTable/agGridDataSource.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import { AFM, Execution } from "@gooddata/typings";
 import { IDatasource, IGetRowsParams, GridApi } from "ag-grid-community";
 import { IntlShape } from "react-intl";
@@ -56,7 +56,7 @@ export const getDataSourceRowsGetter = (
         if (sortModel.length > 0 && execution) {
             resultSpecUpdated = {
                 ...resultSpecUpdated,
-                sorts: getSortsFromModel(sortModel, execution),
+                sorts: getSortsFromModel(sortModel, execution, resultSpec.sorts || []),
             };
         }
         if (columnTotals && columnTotals.length > 0) {

--- a/src/components/core/pivotTable/agGridSorting.ts
+++ b/src/components/core/pivotTable/agGridSorting.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import { AFM, Execution } from "@gooddata/typings";
 import { getIdsFromUri, getParsedFields } from "./agGridUtils";
 import {
@@ -61,6 +61,7 @@ export const getSortItemByColId = (
     execution: Execution.IExecutionResponses,
     colId: string,
     direction: AFM.SortDirection,
+    originalSortItems: AFM.SortItem[],
 ): AFM.IMeasureSortItem | AFM.IAttributeSortItem => {
     const { dimensions } = execution.executionResponse;
 
@@ -77,10 +78,26 @@ export const getSortItemByColId = (
     if (lastFieldType === FIELD_TYPE_ATTRIBUTE) {
         for (const header of attributeHeaders) {
             if (getIdsFromUri(header.attributeHeader.uri)[0] === lastFieldId) {
+                const attributeIdentifier = header.attributeHeader.localIdentifier;
+
+                // try to find the original sort item in case it had an aggregation set so we can keep it in (RAIL-1992)
+                // we intentionally ignore the direction to make sure the UX is predictable
+                const matchingOriginalSortItem = originalSortItems.find(
+                    s =>
+                        AFM.isAttributeSortItem(s) &&
+                        s.attributeSortItem.attributeIdentifier === attributeIdentifier,
+                ) as AFM.IAttributeSortItem;
+
+                const aggregationProp =
+                    matchingOriginalSortItem && matchingOriginalSortItem.attributeSortItem.aggregation
+                        ? { aggregation: matchingOriginalSortItem.attributeSortItem.aggregation }
+                        : {};
+
                 return {
                     attributeSortItem: {
                         direction,
-                        attributeIdentifier: header.attributeHeader.localIdentifier,
+                        attributeIdentifier,
+                        ...aggregationProp,
                     },
                 };
             }
@@ -149,10 +166,11 @@ export function isSortedByFirstAttibute(columnDefs: ColDef[], resultSpec: AFM.IR
 export const getSortsFromModel = (
     sortModel: ISortModelItem[], // AgGrid has any, but we can do better
     execution: Execution.IExecutionResponses,
+    originalSortItems: AFM.SortItem[] = [],
 ) => {
     return sortModel.map((sortModelItem: ISortModelItem) => {
         const { colId, sort } = sortModelItem;
-        const sortHeader = getSortItemByColId(execution, colId, sort);
+        const sortHeader = getSortItemByColId(execution, colId, sort, originalSortItems);
         invariant(sortHeader, `unable to find sort item by field ${colId}`);
         return sortHeader;
     });

--- a/src/components/core/pivotTable/tests/agGridSorting.spec.ts
+++ b/src/components/core/pivotTable/tests/agGridSorting.spec.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 
 import { AFM } from "@gooddata/typings";
 import * as fixtures from "../../../../../stories/test_data/fixtures";
@@ -82,13 +82,45 @@ describe("assignSorting", () => {
 
 describe("getSortItemByColId", () => {
     it("should return an attributeSortItem", () => {
-        expect(getSortItemByColId(pivotTableWithColumnAndRowAttributes, "a_2211", "asc")).toEqual({
+        expect(getSortItemByColId(pivotTableWithColumnAndRowAttributes, "a_2211", "asc", [])).toEqual({
             attributeSortItem: { attributeIdentifier: "state", direction: "asc" },
+        });
+    });
+    it("should return an attributeSortItem with aggregation", () => {
+        const originalSorts: AFM.IAttributeSortItem[] = [
+            {
+                attributeSortItem: {
+                    attributeIdentifier: "state",
+                    direction: "desc",
+                    aggregation: "sum",
+                },
+            },
+        ];
+        expect(
+            getSortItemByColId(pivotTableWithColumnAndRowAttributes, "a_2211", "desc", originalSorts),
+        ).toEqual({
+            attributeSortItem: { attributeIdentifier: "state", direction: "desc", aggregation: "sum" },
+        });
+    });
+    it("should return an attributeSortItem with aggregation with different direction", () => {
+        const originalSorts: AFM.IAttributeSortItem[] = [
+            {
+                attributeSortItem: {
+                    attributeIdentifier: "state",
+                    direction: "asc",
+                    aggregation: "sum",
+                },
+            },
+        ];
+        expect(
+            getSortItemByColId(pivotTableWithColumnAndRowAttributes, "a_2211", "desc", originalSorts),
+        ).toEqual({
+            attributeSortItem: { attributeIdentifier: "state", direction: "desc", aggregation: "sum" },
         });
     });
     it("should return a measureSortItem", () => {
         expect(
-            getSortItemByColId(pivotTableWithColumnAndRowAttributes, "a_2009_1-a_2071_1-m_0", "asc"),
+            getSortItemByColId(pivotTableWithColumnAndRowAttributes, "a_2009_1-a_2071_1-m_0", "asc", []),
         ).toEqual({
             measureSortItem: {
                 direction: "asc",
@@ -129,6 +161,62 @@ describe("getSortsFromModel", () => {
                 attributeSortItem: {
                     attributeIdentifier: "state",
                     direction: "asc",
+                },
+            },
+        ]);
+    });
+    it("should return sortItems for row attribute sort with aggregation", () => {
+        const sortModel: any[] = [
+            {
+                colId: "a_2211",
+                sort: "desc",
+            },
+        ];
+
+        const originalSorts: AFM.IAttributeSortItem[] = [
+            {
+                attributeSortItem: {
+                    attributeIdentifier: "state",
+                    direction: "desc",
+                    aggregation: "sum",
+                },
+            },
+        ];
+
+        expect(getSortsFromModel(sortModel, pivotTableWithColumnAndRowAttributes, originalSorts)).toEqual([
+            {
+                attributeSortItem: {
+                    attributeIdentifier: "state",
+                    direction: "desc",
+                    aggregation: "sum",
+                },
+            },
+        ]);
+    });
+    it("should return sortItems for row attribute sort with aggregation with different direction", () => {
+        const sortModel: any[] = [
+            {
+                colId: "a_2211",
+                sort: "desc",
+            },
+        ];
+
+        const originalSorts: AFM.IAttributeSortItem[] = [
+            {
+                attributeSortItem: {
+                    attributeIdentifier: "state",
+                    direction: "asc",
+                    aggregation: "sum",
+                },
+            },
+        ];
+
+        expect(getSortsFromModel(sortModel, pivotTableWithColumnAndRowAttributes, originalSorts)).toEqual([
+            {
+                attributeSortItem: {
+                    attributeIdentifier: "state",
+                    direction: "desc",
+                    aggregation: "sum",
                 },
             },
         ]);


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
