### PR TITLE
[DO NOT MERGE]Use headless tip and enable gpu

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@gooddata/eslint-config": "^1.0.0",
     "@gooddata/frontend-npm-scripts": "1.1.0",
     "@gooddata/mock-js": "2.6.0",
-    "@gooddata/test-storybook": "3.1.1",
+    "@gooddata/test-storybook": "3.1.1-alpha-naibinh-nab-sd-796-storybook-with-canvas-2020-01-29T05-52-23-277Z",
     "@gooddata/tslint-config": "1.0.0",
     "@storybook/addon-actions": "5.0.11",
     "@storybook/addon-options": "5.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1282,10 +1282,10 @@
   resolved "https://registry.yarnpkg.com/@gooddata/numberjs/-/numberjs-3.2.4.tgz#4363751f4a589e9d3f12d185b38b954183dc1c48"
   integrity sha512-v4JO9dIQ9PIJCxjiBkUNCSa40tHGShFsSYBo6B+YuMxpZpslLClvC1tcXRuk7tc9OsCAorcKzcEgtHQTLPtH2A==
 
-"@gooddata/test-storybook@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@gooddata/test-storybook/-/test-storybook-3.1.1.tgz#7ec8f5390c3a7ca477d87b2d3b61e1e498e1768c"
-  integrity sha512-TFsNz5H2FfUI26BxSLd2ZqkPG1/Hp5edYdA/6e3areKGhI+YAbsAC677N3K8KICLhroZpw+fjjQWEXp4YoXBug==
+"@gooddata/test-storybook@3.1.1-alpha-naibinh-nab-sd-796-storybook-with-canvas-2020-01-29T05-52-23-277Z":
+  version "3.1.1-alpha-naibinh-nab-sd-796-storybook-with-canvas-2020-01-29T05-52-23-277Z"
+  resolved "https://registry.yarnpkg.com/@gooddata/test-storybook/-/test-storybook-3.1.1-alpha-naibinh-nab-sd-796-storybook-with-canvas-2020-01-29T05-52-23-277Z.tgz#f72dd80eecd9846b7d4555888f55e515dba319b0"
+  integrity sha512-HxmlI3xMi3uyBlRGVHlpqYKLQfUMeHGQYsGLoYJba0DEDOHzL+ZrAbAjP9F9bbdKJbQY0TnhDbsT2exb/eCZvw==
   dependencies:
     acorn "^5.1.1"
     acorn-jsx "^4.0.1"


### PR DESCRIPTION
### Case 1
- Test current storybook cases with headless [tip](https://github.com/puppeteer/puppeteer/issues/1260#issuecomment-348878456) and enable gpu
- Result is 131 failed, 532 passed : https://checklist.intgdc.com/job/client-libs/job/gooddata-react-components-storybook-zuul-docker/2956/artifact/test-storybook/html-report/index.html
- Main diff is chart rendered to right side about 5px

### Case 2
- Test current storybook cases with original setting (with flag --disable-gpu)
- Result is all passed: https://checklist.intgdc.com/job/client-libs/job/gooddata-react-components-storybook-zuul-docker/2957/artifact/test-storybook/html-report/index.html

### Related PR
- test-storybook: https://github.com/gooddata/gdc-client-utils/pull/196

### Performance Comparison
| #        | Original Setup           | Canvas support setup  |
| ------------- |-------------| -----|
| 1st  | 21m 38s | 21m 42s|
| 2nd | 16m 13s |   16m 58s |
| 3rd | 13m 11s  |    14m 14s |
| 4th |  13m 17s |    16m 36s |
| 5th | 13m 30s |    14m 09s |