### PR TITLE
FEATURE: SETI-3833 add mapbox token prop and inject vault token to storybook test

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
+const Dotenv = require('dotenv-webpack');
 
 const commitHash = require('child_process')
   .execSync('git rev-parse --short HEAD')
@@ -51,6 +52,7 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
           __COMMIT_HASH__: JSON.stringify(commitHash),
-        })
+        }),
+        new Dotenv()
     ]
 };

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ yarn examples
 ```
 Then open https://localhost:8999 and login using Live Examples account (you can [create one here](https://gooddata-examples.herokuapp.com/registration)).
 
+### Run storybook locally for Geo chart 
+Geo chart uses Mapbox to render map which requires a mapbox access token.
+- Register an account and create Mapbox token as [guide](https://docs.mapbox.com/help/how-mapbox-works/access-tokens/)
+- Run storybook with token stored in `.env` for more secure
+```bash
+echo "STORYBOOK_MAPBOX_ACCESS_TOKEN=token" > .env # only need to run once
+yarn storybook
+```
+- Or run storybook with token env param exposed to cli (not suggested)
+```bash
+STORYBOOK_MAPBOX_ACCESS_TOKEN=token yarn storybook
+```
+- Apply either above way to `yarn build-storybook` or `yarn test-storybook`
+
 ### Source code formatting
 The source code in the repository is formatted by [Prettier](https://prettier.io/). 
 The format of the code is validated by our Continuous Integration server and is one of the requirements of successful merge.

--- a/gdc-ci.yaml
+++ b/gdc-ci.yaml
@@ -5,10 +5,13 @@ pull-request:
   - yarn validate-ci
   - JEST_SUITE_NAME="GoodData React Components Unit Tests" JEST_JUNIT_OUTPUT="./ci/results/test-results.xml" jest --config=jest.ci.js
 dist:
+  - export STORYBOOK_MAPBOX_ACCESS_TOKEN="$MAPBOX_TOKEN"
   - yarn build-storybook
 rpm-build:
+  - export STORYBOOK_MAPBOX_ACCESS_TOKEN="$MAPBOX_TOKEN"
   - yarn build-storybook
 test-storybook:
+  - export STORYBOOK_MAPBOX_ACCESS_TOKEN="$MAPBOX_TOKEN"
   - yarn test-storybook
 
 # Mandatory env params:

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "commander": "2.14.1",
     "compression-webpack-plugin": "2.0.0",
     "css-loader": "0.28.7",
+    "dotenv-webpack": "^1.7.0",
     "enzyme": "3.5.0",
     "enzyme-adapter-react-16": "1.3.1",
     "eslint": "4.19.1",

--- a/src/components/core/GeoChart.tsx
+++ b/src/components/core/GeoChart.tsx
@@ -50,6 +50,9 @@ export class GeoChartInner extends BaseVisualization<IGeoChartInnerProps, {}> {
         chartRenderer: renderChart,
         legendRenderer: renderLegend,
         legendPostion: TOP,
+        config: {
+            mapboxAccessToken: "",
+        },
     };
 
     public componentDidUpdate(prevProps: IGeoChartInnerProps) {

--- a/src/components/core/base/test/GeoValidatorHOC.spec.tsx
+++ b/src/components/core/base/test/GeoValidatorHOC.spec.tsx
@@ -21,7 +21,9 @@ describe("GeoValidatorHOC", () => {
 
     const createComponent = (customProps: Partial<ITestInnerComponentProps> = {}): ReactWrapper => {
         const props: ITestInnerComponentProps = {
-            config: {},
+            config: {
+                mapboxAccessToken: "",
+            },
             ...customProps,
         };
         const WrappedComponent = geoValidatorHOC(TestInnerComponent);
@@ -32,6 +34,7 @@ describe("GeoValidatorHOC", () => {
         const buckets: VisualizationObject.IBucket[] = [SIZE_ITEM];
         const wrapper = createComponent({
             config: {
+                mapboxAccessToken: "",
                 mdObject: {
                     buckets,
                     visualizationClass,
@@ -46,6 +49,7 @@ describe("GeoValidatorHOC", () => {
         const buckets: VisualizationObject.IBucket[] = [LOCATION_ITEM, SIZE_ITEM];
         const wrapper = createComponent({
             config: {
+                mapboxAccessToken: "",
                 mdObject: {
                     buckets,
                     visualizationClass,

--- a/src/components/core/geoChart/GeoChartRenderer.tsx
+++ b/src/components/core/geoChart/GeoChartRenderer.tsx
@@ -17,7 +17,6 @@ import {
     DEFAULT_LONGITUDE,
     DEFAULT_MAPBOX_OPTIONS,
     DEFAULT_ZOOM,
-    MAPBOX_ACCESS_TOKEN,
     DEFAULT_TOOLTIP_OPTIONS,
 } from "../../../constants/geoChart";
 import { IGeoConfig, IGeoData } from "../../../interfaces/GeoChart";
@@ -25,8 +24,6 @@ import { IGeoConfig, IGeoData } from "../../../interfaces/GeoChart";
 import "../../../../styles/scss/geoChart.scss";
 import { handlePushpinMouseEnter, handlePushpinMouseLeave } from "./geoChartTooltip";
 import { getGeoData } from "../../../helpers/geoChart";
-
-mapboxgl.accessToken = MAPBOX_ACCESS_TOKEN;
 
 export interface IGeoChartRendererProps {
     config: IGeoConfig;
@@ -36,7 +33,9 @@ export interface IGeoChartRendererProps {
 
 export default class GeoChartRenderer extends React.PureComponent<IGeoChartRendererProps> {
     public static defaultProps: Partial<IGeoChartRendererProps> = {
-        config: {},
+        config: {
+            mapboxAccessToken: "",
+        },
         afterRender: noop,
     };
 
@@ -44,6 +43,12 @@ export default class GeoChartRenderer extends React.PureComponent<IGeoChartRende
     private tooltip: mapboxgl.Popup;
     private chartRef: HTMLElement;
     private geoData: IGeoData = {};
+
+    public constructor(props: IGeoChartRendererProps) {
+        super(props);
+
+        mapboxgl.accessToken = props.config.mapboxAccessToken;
+    }
 
     public componentDidUpdate(prevProps: IGeoChartRendererProps) {
         if (!isEqual(this.props.execution, prevProps.execution)) {
@@ -139,6 +144,7 @@ export default class GeoChartRenderer extends React.PureComponent<IGeoChartRende
                 (clusterLayer: mapboxgl.Layer) => chart.addLayer(clusterLayer, "state-label"), // cluster points will be rendered under state/county label
             );
         }
+
         // keep listening to the data event until the style is loaded
         chart.on("data", this.handleLayerLoaded);
     };

--- a/src/components/core/tests/GeoChart.spec.tsx
+++ b/src/components/core/tests/GeoChart.spec.tsx
@@ -36,6 +36,7 @@ describe("GeoChart", () => {
         const defaultProps: Partial<IGeoChartInnerProps> = {
             config: {
                 mdObject,
+                mapboxAccessToken: "",
             },
             execution: {
                 executionResponse: getExecutionResponse(true),
@@ -70,6 +71,7 @@ describe("GeoChart", () => {
         renderComponent({
             config: {
                 limit: 20,
+                mapboxAccessToken: "",
                 mdObject,
             },
             onDataTooLarge,

--- a/src/components/tests/GeoPushpinChart.spec.tsx
+++ b/src/components/tests/GeoPushpinChart.spec.tsx
@@ -22,6 +22,7 @@ describe("Geo Pushpin Chart", () => {
     ).localIdentifier("segmentBy");
 
     const chartConfig: IGeoConfig = {
+        mapboxAccessToken: "",
         tooltipText: Model.attribute("attribute_tooltip").localIdentifier("tooltipText"),
     };
     function renderShallowComponent(customProps: Partial<IGeoPushpinChartProps>) {

--- a/src/constants/geoChart.ts
+++ b/src/constants/geoChart.ts
@@ -38,9 +38,6 @@ export const DEFAULT_PUSHPIN_OPTIONS = {
 export const DEFAULT_PUSHPIN_SIZE_SCALE = [10, 28, 46, 64, 82, 100];
 export const DEFAULT_PUSHPIN_SIZE_VALUE = 10;
 
-export const MAPBOX_ACCESS_TOKEN =
-    "pk.eyJ1IjoiaW1udXR6IiwiYSI6ImNrMHAxY2UxZzBnc2EzZG11YmVhd2dubG0ifQ.bUTN7ceAHq6kVooe3MKgqg";
-
 const DEFAULT_MAPBOX_STYLE = "mapbox://styles/mapbox/light-v10";
 export const DEFAULT_MAPBOX_OPTIONS = {
     // hide mapbox's information on map

--- a/src/interfaces/GeoChart.ts
+++ b/src/interfaces/GeoChart.ts
@@ -36,6 +36,7 @@ export interface IGeoConfig {
     selectedSegmentItem?: string;
     tooltipText?: VisualizationInput.IAttribute;
     zoom?: number;
+    mapboxAccessToken: string;
 }
 
 export interface IGeoPushpinChartBucketProps {

--- a/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
+++ b/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
@@ -34,6 +34,7 @@ import { VisualizationTypes } from "../../../../constants/visualizationTypes";
 import UnsupportedConfigurationPanel from "../../configurationPanels/UnsupportedConfigurationPanel";
 import { DASHBOARDS_ENVIRONMENT } from "../../../constants/properties";
 import { GeoChart } from "../../../../components/core/GeoChart";
+import { IGeoConfig } from "../../../../interfaces/GeoChart";
 
 export class PluggableGeoPushpinChart extends PluggableBaseChart {
     private geoPushpinElement: string;
@@ -126,7 +127,6 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
             dimensions: { height },
             custom: { drillableItems },
             locale,
-            config,
         } = options;
         const {
             afterRender,
@@ -142,7 +142,8 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
 
         const resultSpec = this.getResultSpec(options, visualizationProperties, mdObject);
 
-        const fullConfig = this.buildVisualizationConfig(mdObject, config, null);
+        const fullConfig = this.buildGeoChartConfig(options, mdObject);
+
         const geoPushpinProps = {
             projectId,
             drillableItems,
@@ -164,6 +165,21 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
         };
 
         render(<GeoChart {...geoPushpinProps} />, document.querySelector(geoPushpinElement));
+    }
+
+    private buildGeoChartConfig(
+        options: IVisProps,
+        mdObject: VisualizationObject.IVisualizationObjectContent,
+    ): IGeoConfig {
+        const { config } = options;
+        const fullConfig = this.buildVisualizationConfig(mdObject, config, null);
+
+        // TODO: Remove hard-coded token here once WA-11019 is resolved in both BE and FE
+        return {
+            ...fullConfig,
+            mapboxAccessToken:
+                "pk.eyJ1IjoicGhhbXV5dnUiLCJhIjoiY2s1NmQ0czJvMDF3NTNsb2R2b2djM3V1eiJ9.X0DnlbX8wBZowC2Xjp8OOg",
+        };
     }
 
     private getResultSpec(

--- a/stories/core_components/GeoChart.tsx
+++ b/stories/core_components/GeoChart.tsx
@@ -4,7 +4,7 @@ import { action } from "@storybook/addon-actions";
 import { storiesOf } from "@storybook/react";
 import { screenshotWrap } from "@gooddata/test-storybook";
 import { Execution } from "@gooddata/typings";
-import { GeoChartInner, IGeoChartInnerProps } from "../../src/components/core/GeoChart";
+import { GeoChartInner } from "../../src/components/core/GeoChart";
 import { createIntlMock } from "../../src/components/visualizations/utils/intlUtils";
 import { IGeoConfig } from "../../src/interfaces/GeoChart";
 import { getExecutionResponse, getExecutionResult } from "../data/geoChart";
@@ -17,14 +17,10 @@ import {
 } from "../../src/helpers/tests/geoChart/data";
 
 const wrapperStyle: React.CSSProperties = { width: 900, height: 600, position: "relative" };
-const DEFAULT_PROPS: Partial<IGeoChartInnerProps> = {
-    intl: createIntlMock(),
-    isLoading: false,
-    projectId: "storybook",
-};
-const DEFAULT_CONFIG: Partial<IGeoConfig> = {
+const DEFAULT_CONFIG: IGeoConfig = {
     center: [-94.60376, 38.573936],
     zoom: 3.3,
+    mapboxAccessToken: process.env.STORYBOOK_MAPBOX_ACCESS_TOKEN,
 };
 
 function getExecution(
@@ -62,19 +58,20 @@ const dataLarge = () => {
 
 const afterRender = () => console.log("GDC_GEO_CANVAS_READY"); // tslint:disable-line:no-console
 
+const intl = createIntlMock();
+
 function renderChart(config: IGeoConfig, execution: Execution.IExecutionResponses): React.ReactElement {
     return (
         <div style={wrapperStyle}>
             <GeoChartInner
-                config={{
-                    ...DEFAULT_CONFIG,
-                    ...config,
-                }}
-                {...DEFAULT_PROPS}
+                projectId="storybook"
                 execution={execution}
                 getPage={getPageWithExecution(execution)}
                 onDataTooLarge={dataLarge}
                 afterRender={afterRender}
+                intl={intl}
+                isLoading={false}
+                config={config}
             />
         </div>
     );
@@ -84,6 +81,7 @@ storiesOf("Core components/GeoChartInner", module)
     .add("with location", () => {
         const execution = getExecution(true);
         const config: IGeoConfig = {
+            ...DEFAULT_CONFIG,
             mdObject: {
                 visualizationClass: {
                     uri: "any_vis_class",
@@ -96,6 +94,7 @@ storiesOf("Core components/GeoChartInner", module)
     .add("with location and size", () => {
         const execution = getExecution(true, false, true, true, false);
         const config: IGeoConfig = {
+            ...DEFAULT_CONFIG,
             mdObject: {
                 visualizationClass: {
                     uri: "any_vis_class",
@@ -108,6 +107,7 @@ storiesOf("Core components/GeoChartInner", module)
     .add("with location and color", () => {
         const execution = getExecution(true, false, true, false, true);
         const config: IGeoConfig = {
+            ...DEFAULT_CONFIG,
             mdObject: {
                 visualizationClass: {
                     uri: "any_vis_class",
@@ -120,6 +120,7 @@ storiesOf("Core components/GeoChartInner", module)
     .add("with location, size and color", () => {
         const execution = getExecution(true, false, true, true, true);
         const config: IGeoConfig = {
+            ...DEFAULT_CONFIG,
             mdObject: {
                 visualizationClass: {
                     uri: "any_vis_class",
@@ -132,6 +133,7 @@ storiesOf("Core components/GeoChartInner", module)
     .add("with location, size, color and segmentBy", () => {
         const execution = getExecution(true, true, true, true, true);
         const config: IGeoConfig = {
+            ...DEFAULT_CONFIG,
             mdObject: {
                 visualizationClass: {
                     uri: "any_vis_class",

--- a/stories/core_components/GeoPushpinChart.tsx
+++ b/stories/core_components/GeoPushpinChart.tsx
@@ -4,7 +4,7 @@ import { storiesOf } from "@storybook/react";
 import { VisualizationInput } from "@gooddata/typings";
 import { screenshotWrap } from "@gooddata/test-storybook";
 
-import { IGeoConfig } from "../../src/interfaces/GeoChart";
+import { IGeoConfig, IGeoPushpinChartProps } from "../../src/interfaces/GeoChart";
 import { GeoPushpinChart } from "../../src";
 import { onErrorHandler } from "../mocks";
 import {
@@ -16,28 +16,27 @@ import {
 } from "../data/geoChartComponentProps";
 
 const wrapperStyle: React.CSSProperties = { width: 900, height: 600, position: "relative" };
-const DEFAULT_CONFIG: Partial<IGeoConfig> = {
+
+const DEFAULT_CONFIG: IGeoConfig = {
     center: [-94.60376, 38.573936],
     zoom: 3.3,
+    mapboxAccessToken: process.env.STORYBOOK_MAPBOX_ACCESS_TOKEN,
 };
 
 const afterRender = () => console.log("GDC_GEO_CANVAS_READY"); // tslint:disable-line:no-console
 
-function renderGeoPushpinChart(props: any = {}): React.ReactElement {
-    const { location, size, color, segmentBy, config, filters } = props;
+function renderGeoPushpinChart(props: IGeoPushpinChartProps): React.ReactElement {
+    const { projectId, location, size, color, segmentBy, config, filters } = props;
     return (
         <div style={wrapperStyle}>
             <GeoPushpinChart
-                projectId="storybook"
+                projectId={projectId}
                 location={location}
                 size={size}
                 color={color}
                 segmentBy={segmentBy}
-                config={{
-                    ...DEFAULT_CONFIG,
-                    ...config,
-                }}
                 filters={filters}
+                config={config}
                 onError={onErrorHandler}
                 afterRender={afterRender}
                 LoadingComponent={null}
@@ -49,33 +48,53 @@ function renderGeoPushpinChart(props: any = {}): React.ReactElement {
 
 storiesOf("Core components/GeoPushpinChart", module)
     .add("with location", () =>
-        screenshotWrap(renderGeoPushpinChart({ location: ATTRIBUTE_LOCATION_GEOCHART })),
+        screenshotWrap(
+            renderGeoPushpinChart({
+                projectId: "storybook",
+                location: ATTRIBUTE_LOCATION_GEOCHART,
+                config: DEFAULT_CONFIG,
+            }),
+        ),
     )
     .add("with location and size", () =>
         screenshotWrap(
-            renderGeoPushpinChart({ location: ATTRIBUTE_LOCATION_GEOCHART, size: MEASURE_SIZE_GEOCHART }),
+            renderGeoPushpinChart({
+                projectId: "storybook",
+                location: ATTRIBUTE_LOCATION_GEOCHART,
+                size: MEASURE_SIZE_GEOCHART,
+                config: DEFAULT_CONFIG,
+            }),
         ),
     )
     .add("with location and color", () =>
         screenshotWrap(
-            renderGeoPushpinChart({ location: ATTRIBUTE_LOCATION_GEOCHART, color: MEASURE_COLOR_GEOCHART }),
+            renderGeoPushpinChart({
+                projectId: "storybook",
+                location: ATTRIBUTE_LOCATION_GEOCHART,
+                color: MEASURE_COLOR_GEOCHART,
+                config: DEFAULT_CONFIG,
+            }),
         ),
     )
     .add("with location, size and color", () =>
         screenshotWrap(
             renderGeoPushpinChart({
+                projectId: "storybook",
                 location: ATTRIBUTE_LOCATION_GEOCHART,
                 size: MEASURE_SIZE_GEOCHART,
                 color: MEASURE_COLOR_GEOCHART,
+                config: DEFAULT_CONFIG,
             }),
         ),
     )
     .add("with location, size, color, segmentBy and tooltipText", () => {
         const config: IGeoConfig = {
+            ...DEFAULT_CONFIG,
             tooltipText: ATTRIBUTE_TOOLTIP_GEOCHART,
         };
         return screenshotWrap(
             renderGeoPushpinChart({
+                projectId: "storybook",
                 location: ATTRIBUTE_LOCATION_GEOCHART,
                 size: MEASURE_SIZE_GEOCHART,
                 color: MEASURE_COLOR_GEOCHART,
@@ -86,6 +105,7 @@ storiesOf("Core components/GeoPushpinChart", module)
     })
     .add("with location, size, color, segmentBy, tooltipText and location filter", () => {
         const config: IGeoConfig = {
+            ...DEFAULT_CONFIG,
             tooltipText: ATTRIBUTE_TOOLTIP_GEOCHART,
         };
         const locationFilter: VisualizationInput.IPositiveAttributeFilter = {
@@ -103,12 +123,13 @@ storiesOf("Core components/GeoPushpinChart", module)
         };
         return screenshotWrap(
             renderGeoPushpinChart({
+                projectId: "storybook",
                 location: ATTRIBUTE_LOCATION_GEOCHART,
                 size: MEASURE_SIZE_GEOCHART,
                 color: MEASURE_COLOR_GEOCHART,
                 segmentBy: ATTRIBUTE_SEGMENT_GEOCHART,
-                config,
                 filters: [locationFilter],
+                config,
             }),
         );
     });

--- a/stories/data/geoChart.ts
+++ b/stories/data/geoChart.ts
@@ -1212,6 +1212,7 @@ export function getGeoConfig(props: IGeoOptions): IGeoConfig {
     };
     const config: IGeoConfig = {
         mdObject,
+        mapboxAccessToken: "",
     };
     return config;
 }


### PR DESCRIPTION
How to run Geo chart storybook locally
1. Create Mapbox token as guide [here](https://docs.mapbox.com/help/how-mapbox-works/access-tokens/)
2. Run `yarn install` to install `dotenv-webpack`
3. Run ` STORYBOOK_MAPBOX_ACCESS_TOKEN=your_mapbox_token_here yarn storybook`, or
4. Create `.env` file with content as
```
STORYBOOK_MAPBOX_ACCESS_TOKEN=your_mapbox_token_here
```
5. Run `yarn storybook`
---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
- gdc-analytical-designer: N/A
- gdc-dashboards: N/A

# Successful test on cing-dev
- https://cing-dev.intgdc.com/job/client-libs/job/gooddata-react-components-storybook-zuul-docker/20/console


# Related Jira tasks
- SD-768: https://jira.intgdc.com/browse/SD-768
- SETI-3833: https://jira.intgdc.com/browse/SETI-3833