### PR TITLE
BUGFIX: BB-2121 The second attribute is never enabled for drilling

### DIFF
--- a/src/components/visualizations/chart/chartOptionsBuilder.ts
+++ b/src/components/visualizations/chart/chartOptionsBuilder.ts
@@ -156,6 +156,7 @@ export const supportedDualAxesChartTypes = [
     VisualizationTypes.COLUMN,
     VisualizationTypes.BAR,
     VisualizationTypes.LINE,
+    VisualizationTypes.BULLET,
     VisualizationTypes.AREA,
     VisualizationTypes.COMBO,
     VisualizationTypes.COMBO2,

--- a/src/components/visualizations/chart/events/setupDrilldownToParentAttribute.ts
+++ b/src/components/visualizations/chart/events/setupDrilldownToParentAttribute.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import get = require("lodash/get");
 import partial = require("lodash/partial");
 import Highcharts from "../highcharts/highchartsEntryPoint";
@@ -54,6 +54,7 @@ function setParentTickDrillable(
 }
 
 export function setupDrilldown(chart: Highcharts.Chart) {
+    console.log("chart: ", chart);
     const xAxes: any[] = (chart && chart.xAxis) || [];
     const axis = xAxes[0];
     if (!axis) {

--- a/stories/core_components/BulletChart.tsx
+++ b/stories/core_components/BulletChart.tsx
@@ -401,14 +401,14 @@ storiesOf("Core components/BulletChart", module)
                     primaryMeasure={MEASURE_1}
                     targetMeasure={MEASURE_2}
                     comparativeMeasure={MEASURE_3}
-                    viewBy={[ATTRIBUTE_1]}
+                    viewBy={[ATTRIBUTE_2, ATTRIBUTE_1]}
                     onError={onErrorHandler}
                     LoadingComponent={null}
                     ErrorComponent={null}
                     drillableItems={[
                         HeaderPredicateFactory.uriMatch("/gdc/md/storybook/obj/1"),
                         HeaderPredicateFactory.uriMatch("/gdc/md/storybook/obj/2"),
-                        HeaderPredicateFactory.uriMatch("/gdc/md/storybook/obj/3"),
+                        HeaderPredicateFactory.uriMatch("/gdc/md/storybook/obj/5/"),
                     ]}
                 />
             </div>,


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
