### PR TITLE
BUGFIX: ONE-4361 Metric column is auto-resized wrongly after sorting

### DIFF
--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -456,11 +456,15 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
         }
 
         const newColumnIds = difference(autoWidthColumnIds, previouslyResizedColumnIds);
-        columnApi.autoSizeColumns(newColumnIds);
+        this.autoresizeColumnsByColumnId(columnApi, newColumnIds);
         setTimeout(() => {
             this.autoresizeVisibleColumns(columnApi, autoWidthColumnIds);
         }, AGGRID_RENDER_NEW_COLUMNS_TIMEOUT);
     };
+
+    private autoresizeColumnsByColumnId(columnApi: ColumnApi, columnIds: string[]) {
+        columnApi.autoSizeColumns(columnIds);
+    }
 
     private autoresizeColumns = (
         event: AgGridEvent,
@@ -1140,7 +1144,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
                 } else if (isMappingHeaderAttributeItem(item)) {
                     return item.attributeHeaderItem.uri;
                 } else if (isMappingHeaderMeasureItem(item)) {
-                    return item.measureHeaderItem.uri;
+                    return item.measureHeaderItem.uri || item.measureHeaderItem.localIdentifier;
                 }
 
                 return undefined;

--- a/src/components/core/tests/PivotTable.spec.tsx
+++ b/src/components/core/tests/PivotTable.spec.tsx
@@ -71,31 +71,37 @@ describe("PivotTable", () => {
 
     describe("column sizing", () => {
         it("should auto-resize columns if executing and default width should fit the viewport", done => {
+            expect.assertions(1);
             const wrapper = renderComponent({
                 config: { columnSizing: { defaultWidth: "viewport" } },
             });
             const table = getTableInstanceFromWrapper(wrapper);
-            const autoresizeColumns = jest.spyOn(table, "autoresizeVisibleColumns");
-            autoresizeColumns.mockImplementation(() => {
-                expect(autoresizeColumns).toHaveBeenCalledTimes(1);
-                done();
-            });
+            const autoresizeVisibleColumns = jest.spyOn(table, "autoresizeVisibleColumns");
+            try {
+                autoresizeVisibleColumns.mockImplementation(() => {
+                    expect(autoresizeVisibleColumns).toHaveBeenCalledTimes(1);
+                    done();
+                });
+            } catch (e) {
+                done.fail(e);
+            }
             wrapper.update();
         });
 
-        it("should not auto-resize columns it the column sizing is not configured", async () => {
+        it("should not auto-resize columns if the column sizing is not configured", async () => {
             const wrapper = renderComponent({
                 config: { columnSizing: undefined },
             });
             const table = getTableInstanceFromWrapper(wrapper);
-            const autoresizeColumns = jest.spyOn(table, "autoresizeVisibleColumns");
-            autoresizeColumns.mockImplementation(noop);
+            const autoresizeVisibleColumns = jest.spyOn(table, "autoresizeVisibleColumns");
+            autoresizeVisibleColumns.mockImplementation(noop);
 
             await waitFor(waitForDataLoaded(wrapper));
-            expect(autoresizeColumns).toHaveBeenCalledTimes(0);
+            expect(autoresizeVisibleColumns).toHaveBeenCalledTimes(0);
         });
 
         it("should auto-resize columns for a table with no measures", done => {
+            expect.assertions(2);
             const wrapper = renderComponent(
                 {
                     config: { columnSizing: { defaultWidth: "viewport" } },
@@ -103,11 +109,18 @@ describe("PivotTable", () => {
                 oneAttributeNoMeasure,
             );
             const table = getTableInstanceFromWrapper(wrapper);
-            const autoresizeColumns = jest.spyOn(table, "autoresizeVisibleColumns");
-            autoresizeColumns.mockImplementation(() => {
-                expect(autoresizeColumns).toHaveBeenCalledTimes(1);
-                done();
-            });
+            const autoresizeColumnsByColumnId = jest.spyOn(table, "autoresizeColumnsByColumnId");
+            try {
+                autoresizeColumnsByColumnId.mockImplementation(() => {
+                    expect(autoresizeColumnsByColumnId).toHaveBeenCalledTimes(1);
+                    expect(autoresizeColumnsByColumnId).toHaveBeenCalledWith(expect.any(Object), [
+                        "a_4DOTdf",
+                    ]);
+                    done();
+                });
+            } catch (e) {
+                done.fail(e);
+            }
             wrapper.update();
         });
     });


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
