### PR TITLE
RELATED: BB-2121 Incorrect parent attribute drilling for bullet chart

### DIFF
--- a/src/components/visualizations/chart/events/setupDrilldownToParentAttribute.ts
+++ b/src/components/visualizations/chart/events/setupDrilldownToParentAttribute.ts
@@ -1,5 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
-import get = require("lodash/get");
+// (C) 2007-2020 GoodData Corporation
 import partial = require("lodash/partial");
 import Highcharts from "../highcharts/highchartsEntryPoint";
 import { styleVariables } from "../../styles/variables";
@@ -12,13 +11,20 @@ import {
     IHighchartsPointObject,
 } from "../../../../interfaces/DrillEvents";
 
-function getDDPointsInParentTick(axis: any, tick: IHighchartsParentTick): IHighchartsPointObject[] {
+export function getDDPointsInParentTick(axis: any, tick: IHighchartsParentTick): IHighchartsPointObject[] {
     const { startAt, leaves } = tick;
     const ddPoints: IHighchartsPointObject[] = []; // drilldown points
 
     for (let i = startAt; i < startAt + leaves; i++) {
         ddPoints.push(...axis.getDDPoints(i));
     }
+
+    // replace y value by target value for bullet chart target
+    ddPoints.forEach(ddPoint => {
+        if (!!ddPoint.target) {
+            ddPoint.y = ddPoint.target;
+        }
+    });
 
     return ddPoints;
 }
@@ -53,7 +59,7 @@ function setParentTickDrillable(
     }
 }
 
-export function setupDrilldown(chart: Highcharts.Chart) {
+export function setupDrilldown(chart: Highcharts.Chart, chartType: ChartType) {
     const xAxes: any[] = (chart && chart.xAxis) || [];
     const axis = xAxes[0];
     if (!axis) {
@@ -61,7 +67,6 @@ export function setupDrilldown(chart: Highcharts.Chart) {
     }
 
     // not support chart without type
-    const chartType: ChartType | null = get(chart, "options.chart.type", null);
     if (!chartType) {
         return;
     }

--- a/src/components/visualizations/chart/events/test/setupDrilldownToParentAttribute.spec.ts
+++ b/src/components/visualizations/chart/events/test/setupDrilldownToParentAttribute.spec.ts
@@ -1,6 +1,6 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import get = require("lodash/get");
-import { setupDrilldown } from "../setupDrilldownToParentAttribute";
+import { setupDrilldown, getDDPointsInParentTick } from "../setupDrilldownToParentAttribute";
 import { styleVariables } from "../../../styles/variables";
 import { IHighchartsPointObject } from "../../../../../interfaces/DrillEvents";
 
@@ -43,14 +43,14 @@ describe("setupDrilldown", () => {
         const highchartObject: any = {
             xAxis: [],
         };
-        expect(setupDrilldown(highchartObject)).toBeFalsy();
+        expect(setupDrilldown(highchartObject, "column")).toBeFalsy();
     });
 
     it("should not setup drill without chart type", () => {
         const highchartObject: any = {
             xAxis: [{}],
         };
-        expect(setupDrilldown(highchartObject)).toBeFalsy();
+        expect(setupDrilldown(highchartObject, null)).toBeFalsy();
     });
 
     it("should set parent item drillable", () => {
@@ -82,7 +82,7 @@ describe("setupDrilldown", () => {
             },
         };
 
-        setupDrilldown(highchartObject);
+        setupDrilldown(highchartObject, "column");
 
         const label = get(highchartObject, "xAxis.0.categoriesTree.0.tick.label", null);
         expect(label.hasClass("highcharts-drilldown-axis-label")).toBeTruthy();
@@ -122,11 +122,73 @@ describe("setupDrilldown", () => {
             },
         };
 
-        setupDrilldown(highchartObject);
+        setupDrilldown(highchartObject, "column");
 
         const label = get(highchartObject, "xAxis.0.categoriesTree.0.tick.label", null);
         expect(label.hasClass("highcharts-drilldown-axis-label")).toBeFalsy();
         expect(label.hasEvent("click")).toBeFalsy();
         expect(label.getCss()).toEqual({ cursor: "default" });
+    });
+});
+
+describe("getDDPointsInParentTick", () => {
+    it("should return the right drilldown points for bullet chart", () => {
+        const ddPointsForBulletChart = [
+            [
+                {
+                    x: 0,
+                    y: 200,
+                },
+                {
+                    x: 0,
+                    y: 0,
+                    target: 300,
+                },
+                {
+                    x: 0,
+                    y: 400,
+                },
+            ],
+            [
+                {
+                    x: 0,
+                    y: 0,
+                    target: 500,
+                },
+            ],
+        ];
+
+        const axis = {
+            getDDPoints: (i: number) => ddPointsForBulletChart[i] || [],
+        };
+
+        const tick = {
+            startAt: 0,
+            leaves: 3,
+            label: new MockHighChartsLabel(),
+        };
+
+        const expectedDDPoints = [
+            {
+                x: 0,
+                y: 200,
+            },
+            {
+                x: 0,
+                y: 300,
+                target: 300,
+            },
+            {
+                x: 0,
+                y: 400,
+            },
+            {
+                x: 0,
+                y: 500,
+                target: 500,
+            },
+        ];
+
+        expect(getDDPointsInParentTick(axis, tick)).toEqual(expectedDDPoints);
     });
 });

--- a/src/components/visualizations/chart/highcharts/commonConfiguration.ts
+++ b/src/components/visualizations/chart/highcharts/commonConfiguration.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import cloneDeep = require("lodash/cloneDeep");
 import invoke = require("lodash/invoke");
 import get = require("lodash/get");
@@ -12,6 +12,7 @@ import { supportedDualAxesChartTypes } from "../chartOptionsBuilder";
 import { setupDrilldown } from "../events/setupDrilldownToParentAttribute";
 import { IHighchartsAxisExtend } from "../../../../interfaces/HighchartsExtend";
 import { IDrillConfig } from "../../../../interfaces/DrillEvents";
+import { ChartType } from "../../../..";
 
 const isTouchDevice = "ontouchstart" in window || navigator.msMaxTouchPoints;
 const HIGHCHART_PLOT_LIMITED_RANGE = 1e5;
@@ -143,13 +144,15 @@ function registerDrilldownHandler(configuration: any, chartOptions: any, drillCo
     return configuration;
 }
 
-export function handleChartLoad(): void {
-    setupDrilldown(this);
+export function handleChartLoad(chartType: ChartType) {
+    return function() {
+        setupDrilldown(this, chartType);
+    };
 }
 
 function registerRenderHandler(configuration: any, chartOptions: any) {
     if (isOneOfTypes(chartOptions.type, supportedDualAxesChartTypes)) {
-        set(configuration, "chart.events.render", handleChartLoad);
+        set(configuration, "chart.events.render", handleChartLoad(chartOptions.type));
     }
     return configuration;
 }

--- a/src/components/visualizations/chart/test/highChartsCreators.spec.ts
+++ b/src/components/visualizations/chart/test/highChartsCreators.spec.ts
@@ -1,9 +1,8 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import noop = require("lodash/noop");
 import { getHighchartsOptions } from "../highChartsCreators";
 import { VisualizationTypes } from "../../../../constants/visualizationTypes";
 import { supportedDualAxesChartTypes } from "../chartOptionsBuilder";
-import { handleChartLoad } from "../highcharts/commonConfiguration";
 import { IDrillConfig } from "../../../../interfaces/DrillEvents";
 
 const chartOptions = {
@@ -197,7 +196,7 @@ describe("highChartCreators", () => {
         it("should dual axis charts be registered render event", () => {
             supportedDualAxesChartTypes.forEach((type: string) => {
                 const config = getConfig(type);
-                expect(config.chart.events.render).toBe(handleChartLoad);
+                expect(config.chart.events.render).toBeTruthy();
             });
         });
 


### PR DESCRIPTION
Fixing issues for parents attribute drilling in bullet chart:
- The type is bar instead of bullet
- y value for target measure drill event is wrong

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
