### PR TITLE
BUGFIX: ONE-4366 Fix of condition when resizing is done

### DIFF
--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -473,11 +473,16 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
         previouslyResizedColumnIds: string[] = [],
     ) => {
         const alreadyResized = () => this.state.resized || this.resizing;
+        const noRowHeadersOrRows = (executionResult: Execution.IExecutionResult) =>
+            executionResult &&
+            (executionResult.data.length === 0 &&
+                executionResult.headerItems[0] &&
+                executionResult.headerItems[0].length === 0);
         const dataRendered = () => {
             const executionResult = this.getExecutionResult();
             return (
-                executionResult &&
-                (executionResult.data.length === 0 || event.api.getRenderedNodes().length > 0)
+                noRowHeadersOrRows(executionResult) ||
+                (executionResult && event.api.getRenderedNodes().length > 0)
             );
         };
         const tablePagesLoaded = () => {
@@ -485,7 +490,12 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
             return Object.keys(pages).every((pageId: string) => pages[pageId].pageStatus === "loaded");
         };
 
-        if (force || (this.state.execution && !alreadyResized() && dataRendered() && tablePagesLoaded())) {
+        if (
+            this.state.execution &&
+            tablePagesLoaded() &&
+            dataRendered() &&
+            (!alreadyResized() || (alreadyResized() && force))
+        ) {
             this.resizing = true;
             setTimeout(() => {
                 this.autoresizeVisibleColumns(event.columnApi, previouslyResizedColumnIds);

--- a/src/components/core/tests/PivotTable.spec.tsx
+++ b/src/components/core/tests/PivotTable.spec.tsx
@@ -13,7 +13,7 @@ import {
 } from "../PivotTable";
 import {
     executionObjectWithTotalsDataSource,
-    oneAttributeNoMeasure,
+    oneColumnAttributeNoMeasure,
     oneAttributeOneMeasureDataSource,
     oneMeasureDataSource,
     twoMeasuresOneDimensionDataSource,
@@ -106,7 +106,7 @@ describe("PivotTable", () => {
                 {
                     config: { columnSizing: { defaultWidth: "viewport" } },
                 },
-                oneAttributeNoMeasure,
+                oneColumnAttributeNoMeasure,
             );
             const table = getTableInstanceFromWrapper(wrapper);
             const autoresizeColumnsByColumnId = jest.spyOn(table, "autoresizeColumnsByColumnId");
@@ -114,7 +114,8 @@ describe("PivotTable", () => {
                 autoresizeColumnsByColumnId.mockImplementation(() => {
                     expect(autoresizeColumnsByColumnId).toHaveBeenCalledTimes(1);
                     expect(autoresizeColumnsByColumnId).toHaveBeenCalledWith(expect.any(Object), [
-                        "a_4DOTdf",
+                        "a_4_1",
+                        "a_4_3",
                     ]);
                     done();
                 });

--- a/src/components/tests/mocks.tsx
+++ b/src/components/tests/mocks.tsx
@@ -11,7 +11,7 @@ import {
     locationSizeColorSegmentFiltersAfm,
     locationSizeColorSegmentFiltersResponse,
     oneAttributeAfm,
-    oneAttributeNoMeasureResponse,
+    oneColumnAttributeNoMeasureResponse,
     oneAttributeOneMeasureExecutionObject,
     oneAttributeOneMeasureOneFilterExecutionObject,
     oneAttributesOneMeasureResponse,
@@ -108,11 +108,11 @@ export const oneAttributeOneMeasureOneFilterDataSource: IDataSource = {
     getFingerprint: () => JSON.stringify(oneAttributesOneMeasureResponse),
 };
 
-export const oneAttributeNoMeasure: IDataSource = {
-    getData: () => Promise.resolve(oneAttributeNoMeasureResponse),
-    getPage: () => Promise.resolve(oneAttributeNoMeasureResponse),
+export const oneColumnAttributeNoMeasure: IDataSource = {
+    getData: () => Promise.resolve(oneColumnAttributeNoMeasureResponse),
+    getPage: () => Promise.resolve(oneColumnAttributeNoMeasureResponse),
     getAfm: () => oneAttributeAfm,
-    getFingerprint: () => JSON.stringify(oneAttributeNoMeasureResponse),
+    getFingerprint: () => JSON.stringify(oneColumnAttributeNoMeasureResponse),
 };
 
 export const executionObjectWithTotalsDataSource: IDataSource = {

--- a/src/execution/fixtures/ExecuteAfm.fixtures.ts
+++ b/src/execution/fixtures/ExecuteAfm.fixtures.ts
@@ -685,9 +685,12 @@ const oneAttributesOneMeasureResponse: Execution.IExecutionResponses = {
     },
 };
 
-const oneAttributeNoMeasureResponse: Execution.IExecutionResponses = {
+const oneColumnAttributeNoMeasureResponse: Execution.IExecutionResponses = {
     executionResponse: {
         dimensions: [
+            {
+                headers: [],
+            },
             {
                 headers: [
                     {
@@ -705,9 +708,6 @@ const oneAttributeNoMeasureResponse: Execution.IExecutionResponses = {
                     },
                 ],
             },
-            {
-                headers: [],
-            },
         ],
         links: {
             executionResult:
@@ -718,6 +718,7 @@ const oneAttributeNoMeasureResponse: Execution.IExecutionResponses = {
     executionResult: {
         data: [],
         headerItems: [
+            [],
             [
                 [
                     {
@@ -794,7 +795,6 @@ const oneAttributeNoMeasureResponse: Execution.IExecutionResponses = {
                     },
                 ],
             ],
-            [],
         ],
         paging: {
             count: [0, 1000],
@@ -1236,6 +1236,6 @@ export {
     oneAttributeOneMeasureOneFilterExecutionObject,
     oneAttributesOneMeasureResponse,
     oneAttributeOneMeasureSortByMeasureExecutionObject,
-    oneAttributeNoMeasureResponse,
+    oneColumnAttributeNoMeasureResponse,
     oneAttributeAfm,
 };


### PR DESCRIPTION
Column autoresize on onVirtualColumnsChanged can't be done before initial render. Handle tables with row attributes only.

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2876
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2610

# Related Jira tasks
<!-- Optional

Example:
- ONE-4366: https://jira.intgdc.com/browse/ONE-4366

 -->
