### PR TITLE
BUGFIX: ONE-4369 Prevent multiple intervals

### DIFF
--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -595,18 +595,24 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
     private onFirstDataRendered = () => {
         // Since issue here is not resolved, https://github.com/ag-grid/ag-grid/issues/3263,
         // work-around by using 'setInterval'
-        this.watchingIntervalId = window.setInterval(
-            this.startWatchingTableRendered,
-            WATCHING_TABLE_RENDERED_INTERVAL,
-        );
+        if (!this.watchingIntervalId) {
+            // onFirstDataRendered can be called multiple times
+            this.watchingIntervalId = window.setInterval(
+                this.startWatchingTableRendered,
+                WATCHING_TABLE_RENDERED_INTERVAL,
+            );
+        }
 
         // after 15s, this table might or not (due to long backend execution) be rendered
         // either way, 'afterRender' should be called to notify to KPI dashboard
         // if KPI dashboard is in export mode, its content could be exported as much as possible even without this table
-        this.watchingTimeoutId = window.setTimeout(
-            this.stopWatchingTableRendered,
-            WATCHING_TABLE_RENDERED_MAX_TIME,
-        );
+        if (!this.watchingTimeoutId) {
+            // onFirstDataRendered can be called multiple times
+            this.watchingTimeoutId = window.setTimeout(
+                this.stopWatchingTableRendered,
+                WATCHING_TABLE_RENDERED_MAX_TIME,
+            );
+        }
     };
 
     private isColumnAutoresizeEnabled = () =>


### PR DESCRIPTION
onFirstDataRendered can be called multiple times but we need only one running interval. Currently only one interval was canceled but other running caused infinite call of afterRender handler

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: 
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2624

# Related Jira tasks
<!-- Optional

Example:
- ONE-4369: https://jira.intgdc.com/browse/ONE-4369

 -->
