### PR TITLE
BUGFIX: SD-898 Geo chart cannot render with js error

### DIFF
--- a/src/components/core/geoChart/GeoChartRenderer.tsx
+++ b/src/components/core/geoChart/GeoChartRenderer.tsx
@@ -70,6 +70,13 @@ export default class GeoChartRenderer extends React.Component<IGeoChartRendererP
         } = this.props;
         const { config: { selectedSegmentItems: prevSelectedSegmentItems = [] } = {} } = prevProps || {};
 
+        // only update map when style is ready
+        // work around for ticket SD-898
+        // avoid refresh whole map will be fixed in ticket SD-899
+        if (!this.chart.isStyleLoaded()) {
+            return;
+        }
+
         this.updateMapWithConfig();
 
         if (selectedSegmentItems && !isEqual(selectedSegmentItems, prevSelectedSegmentItems)) {
@@ -269,7 +276,15 @@ export default class GeoChartRenderer extends React.Component<IGeoChartRendererP
         if (!this.chart) {
             return;
         }
-        this.chart.remove();
+        // try catch to hide the mapbox's error message
+        // TypeError: Cannot read property 'off' of undefined
+        // mapbox is trying to call its function after deleted
+        // https://github.com/mapbox/mapbox-gl-js/blob/master/src/ui/control/navigation_control.js#L118
+        try {
+            this.chart.remove();
+        } catch (_e) {
+            return;
+        }
     };
 
     private handlePushpinMoveEnd = (e: mapboxgl.EventData): void => {


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)
- [x] Squash commits

# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2930
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2650

# Related Jira tasks
- SD-898: https://jira.intgdc.com/browse/SD-898
