### PR TITLE
RELATED: RAIL-2131, RAIL-2138 Fix saveAs button behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   },
   "dependencies": {
     "@formatjs/intl-pluralrules": "^1.3.6",
-    "@gooddata/gooddata-js": "^12.5.0",
+    "@gooddata/gooddata-js": "^12.5.2",
     "@gooddata/goodstrap": "^68.2.1",
     "@gooddata/js-utils": "^3.5.0",
     "@gooddata/numberjs": "^3.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,10 +1209,10 @@
     firstline "^2.0.2"
     line-replace "^1.0.2"
 
-"@gooddata/gooddata-js@^12.5.0":
-  version "12.5.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-12.5.0.tgz#74a49d03095746053253c090eb8e5a15cee9796e"
-  integrity sha512-Cv7s6o21YxG0RLN4VlyZETbrZUK9sSpXwi4e4SRjoiXdRtjXyqu9n7UCDrRSE/Dgm5BN5bKr67HRGhJ8IBoWYw==
+"@gooddata/gooddata-js@^12.5.2":
+  version "12.5.2"
+  resolved "https://registry.yarnpkg.com/@gooddata/gooddata-js/-/gooddata-js-12.5.2.tgz#37bc6e3d2b81ec1d19cf093d36121892f4d01f6d"
+  integrity sha512-XL3h9sYa6jkH1tJYxsOM3b9EXn+VqL2HTUucLs3rfFkO3cV6i2JaoC6oHlSTP9kV7/DKayQ3DszQ0INopdNwPA==
   dependencies:
     "@gooddata/typings" "^2.22.0"
     es6-promise "^3.0.2"


### PR DESCRIPTION
Fix saveAs button saving old dashboards without layout issue.
Fix saveAs button saving created date in meta.

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
