### PR TITLE
BUGFIX: RAIL-2181 fix date conversion in DateFilter

### DIFF
--- a/src/components/filters/DateFilter/utils/DateConversions.ts
+++ b/src/components/filters/DateFilter/utils/DateConversions.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import * as moment from "moment";
 import isString = require("lodash/isString");
 import isDate = require("lodash/isDate");
@@ -25,11 +25,16 @@ export const convertPlatformDateStringToDate = (
      *   local time is "2019-11-28T06:00:00 GTM+0600"
      *   after converting the local time will be "2019-11-28T00:00:00 GTM+0600"
      */
-    const localTimeOffsetValue = getTimeOffsetInMilliseconds();
-    const localTimeValue = new Date(platformDate).getTime() + localTimeOffsetValue;
+    const convertedDate = new Date(platformDate);
+    const localTimeOffsetValue = getTimeOffsetInMilliseconds(convertedDate);
+    const localTimeValue = convertedDate.getTime() + localTimeOffsetValue;
 
     return new Date(localTimeValue);
 };
 
-export const getTimeOffsetInMilliseconds = (): number =>
-    new Date().getTimezoneOffset() * NUM_OF_MILISECONDS_IN_MINUTE;
+/**
+ * Returns the timezone offset in milliseconds for the given date.
+ * @param when when to return the offset for. This is important because of DST - the offset changes during the year.
+ */
+const getTimeOffsetInMilliseconds = (when: Date): number =>
+    when.getTimezoneOffset() * NUM_OF_MILISECONDS_IN_MINUTE;


### PR DESCRIPTION
The problem was that the local time offset was taken for today,
not for the date we are working with.
These are very different if today is DST and the given date is not
or vice versa.

<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2952
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2662

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
