### PR TITLE
BUGFIX: BB-2180 Bullet chart attribute drilling with null value

### DIFF
--- a/src/components/visualizations/chart/chartOptions/bulletChartOptions.ts
+++ b/src/components/visualizations/chart/chartOptions/bulletChartOptions.ts
@@ -47,10 +47,11 @@ const getSeriesItemData = (
     seriesItem.map((pointValue: string) => {
         const value = parseValue(pointValue);
         const isTarget = isTargetSeries(seriesIndex, measureBucketsLocalIdentifiers);
-        const classNameProp = isTarget && value === null ? { className: "hidden-empty-series" } : {};
+        const nullValueProps =
+            isTarget && value === null ? { isNullTarget: true, className: "hidden-empty-series" } : {};
 
         return {
-            ...classNameProp,
+            ...nullValueProps,
             ...getValue(value, isTarget),
             format: unwrap(measureGroup.items[seriesIndex]).format,
             marker: {

--- a/src/components/visualizations/chart/events/setupDrilldownToParentAttribute.ts
+++ b/src/components/visualizations/chart/events/setupDrilldownToParentAttribute.ts
@@ -24,7 +24,7 @@ export function getDDPointsInParentTick(axis: any, tick: IHighchartsParentTick):
     // replace y value by target value for bullet chart target
     ddPoints.forEach(ddPoint => {
         if (get(ddPoint, "series.userOptions.bulletChartMeasureType") === "target") {
-            ddPoint.y = ddPoint.target;
+            ddPoint.y = ddPoint.isNullTarget ? null : ddPoint.target;
         }
     });
 

--- a/src/components/visualizations/chart/events/test/setupDrilldownToParentAttribute.spec.ts
+++ b/src/components/visualizations/chart/events/test/setupDrilldownToParentAttribute.spec.ts
@@ -173,7 +173,8 @@ describe("getDDPointsInParentTick", () => {
                     },
                     x: 0,
                     y: 0,
-                    target: null,
+                    target: 0,
+                    isNullTarget: true,
                 },
             ],
         ];
@@ -224,8 +225,9 @@ describe("getDDPointsInParentTick", () => {
                     },
                 },
                 x: 0,
-                y: null,
-                target: null,
+                y: null as number,
+                target: 0,
+                isNullTarget: true,
             },
         ];
 

--- a/src/components/visualizations/utils/drilldownEventing.ts
+++ b/src/components/visualizations/utils/drilldownEventing.ts
@@ -106,13 +106,20 @@ const getDrillPointCustomProps = (
     return {};
 };
 
+const getYValueForBulletChartTarget = (point: IHighchartsPointObject): number => {
+    if (point.isNullTarget) {
+        return null;
+    }
+    return point.target;
+};
+
 const getDrillPoint = (chartType: ChartType) => (point: IHighchartsPointObject): IDrillPointExtended => {
     const customProps = getDrillPointCustomProps(point, chartType);
 
     const elementChartType = getElementChartType(chartType, point);
     const result: IDrillPointExtended = {
         x: point.x,
-        y: elementChartType === "bullet" ? point.target : point.y,
+        y: elementChartType === "bullet" ? getYValueForBulletChartTarget(point) : point.y,
         intersection: point.drillIntersection,
         ...customProps,
     };

--- a/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
+++ b/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
@@ -238,10 +238,24 @@ describe("Drilldown Eventing", () => {
 
     describe("bullet chart", () => {
         const drillConfig = { afm, onFiredDrillEvent: () => true };
+
         const targetPoint: any = {
             x: 1,
             y: 2,
             target: 100,
+            series: {
+                type: "bullet",
+                userOptions: {
+                    bulletChartMeasureType: "target",
+                },
+            },
+            drillIntersection: [],
+        };
+        const targetPointWithNullValue: any = {
+            x: 1,
+            y: 0,
+            target: 0,
+            isNullTarget: true,
             series: {
                 type: "bullet",
                 userOptions: {
@@ -340,6 +354,28 @@ describe("Drilldown Eventing", () => {
 
             expect(target.dispatchEvent.mock.calls[0][0].detail.drillContext.points).toEqual([
                 { intersection: [], type: "target", x: 1, y: 100 },
+                { intersection: [], type: "primary", x: 1, y: 2 },
+                { intersection: [], type: "comparative", x: 1, y: 3 },
+            ]);
+        });
+
+        it("should fire correct data for attribute drilling with null value target", () => {
+            const target: any = { dispatchEvent: jest.fn() };
+            const pointClickEventData: any = {
+                points: [targetPointWithNullValue, primaryPoint, comparativePoint],
+            };
+
+            chartClick(
+                drillConfig,
+                pointClickEventData as Highcharts.DrilldownEventObject,
+                target as EventTarget,
+                VisualizationTypes.BULLET,
+            );
+
+            jest.runAllTimers();
+
+            expect(target.dispatchEvent.mock.calls[0][0].detail.drillContext.points).toEqual([
+                { intersection: [], type: "target", x: 1, y: null },
                 { intersection: [], type: "primary", x: 1, y: 2 },
                 { intersection: [], type: "comparative", x: 1, y: 3 },
             ]);


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
