### PR TITLE
BUGFIX: SD-908 keep zoom after clicking items on category legend

### DIFF
--- a/src/components/core/geoChart/GeoChartRenderer.tsx
+++ b/src/components/core/geoChart/GeoChartRenderer.tsx
@@ -75,11 +75,11 @@ export default class GeoChartRenderer extends React.Component<IGeoChartRendererP
             return;
         }
 
-        this.updateMapWithConfig(prevConfig);
-
         if (selectedSegmentItems && !isEqual(selectedSegmentItems, prevSelectedSegmentItems)) {
-            this.setFilterMap();
+            return this.setFilterMap();
         }
+
+        this.updateMapWithConfig(prevConfig);
     }
 
     public componentDidMount() {
@@ -135,8 +135,9 @@ export default class GeoChartRenderer extends React.Component<IGeoChartRendererP
             // Then calling resetMap here is needed
             this.resetMap();
         }
+
         this.updatePanAndZoom();
-        this.updateViewport();
+        this.updateViewport(prevConfig);
     };
 
     private resetMap = (): void => {
@@ -205,13 +206,20 @@ export default class GeoChartRenderer extends React.Component<IGeoChartRendererP
         this.toggleInteractionEvents();
     };
 
-    private updateViewport = (): void => {
+    private updateViewport = (prevConfig: IGeoConfig): void => {
         const {
             config,
             geoData: {
                 location: { data },
             },
         } = this.props;
+
+        const { viewport: prevViewport } = prevConfig;
+        const { viewport } = config;
+        if (isEqual(prevViewport, viewport)) {
+            return;
+        }
+
         const { bounds } = getViewportOptions(data, config);
         if (bounds) {
             this.chart.fitBounds(bounds, DEFAULT_MAPBOX_OPTIONS.fitBoundsOptions);


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2975
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2688

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
SD-908: https://jira.intgdc.com/browse/SD-908