### PR TITLE
FEATURE: SD-869 Geo chart displays friendly message when Mapbox token is missed

### DIFF
--- a/src/components/core/base/test/GeoValidatorHOC.spec.tsx
+++ b/src/components/core/base/test/GeoValidatorHOC.spec.tsx
@@ -34,9 +34,6 @@ describe("GeoValidatorHOC", () => {
 
     const createComponent = (customProps: Partial<ITestInnerComponentProps> = {}): ReactWrapper => {
         const props: ITestInnerComponentProps = {
-            config: {
-                mapboxToken: "",
-            },
             dataSource: locationSizeColorSegmentDataSource,
             ...customProps,
         };
@@ -49,7 +46,7 @@ describe("GeoValidatorHOC", () => {
         const onError = jest.fn();
         const wrapper = createComponent({
             config: {
-                mapboxToken: "",
+                mapboxToken: "mapboxToken",
                 mdObject: {
                     buckets,
                     visualizationClass,
@@ -60,14 +57,39 @@ describe("GeoValidatorHOC", () => {
 
         expect(wrapper.find(ErrorComponent).exists()).toEqual(true);
         expect(onError).toBeCalledTimes(1);
+        expect(wrapper.find(ErrorComponent).props()).toEqual(
+            expect.objectContaining({
+                code: "GEO_LOCATION_MISSING",
+                message: "Sorry, we can't display this insight",
+            }),
+        );
     });
 
-    it("should not show GEO_LOCATION_MISSING error", () => {
-        const buckets: VisualizationObject.IBucket[] = [LOCATION_ITEM, SIZE_ITEM];
+    it("should show GEO_MAPBOX_TOKEN_MISSING error", () => {
         const onError = jest.fn();
         const wrapper = createComponent({
             config: {
                 mapboxToken: "",
+            },
+            onError,
+        });
+
+        expect(wrapper.find(ErrorComponent).exists()).toEqual(true);
+        expect(onError).toBeCalledTimes(1);
+        expect(wrapper.find(ErrorComponent).props()).toEqual(
+            expect.objectContaining({
+                description: "An API access token is required to use Mapbox GL in Geo chart (pushpins)",
+                code: "GEO_MAPBOX_TOKEN_MISSING",
+            }),
+        );
+    });
+
+    it("should not render ErrorComponent", () => {
+        const buckets: VisualizationObject.IBucket[] = [LOCATION_ITEM, SIZE_ITEM];
+        const onError = jest.fn();
+        const wrapper = createComponent({
+            config: {
+                mapboxToken: "mapboxToken",
                 mdObject: {
                     buckets,
                     visualizationClass,
@@ -85,14 +107,14 @@ describe("GeoValidatorHOC", () => {
         const bucketsWithLocation: VisualizationObject.IBucket[] = [LOCATION_ITEM, SIZE_ITEM];
         const onError = jest.fn();
         const config: IGeoConfig = {
-            mapboxToken: "",
+            mapboxToken: "mapboxToken",
             mdObject: {
                 buckets,
                 visualizationClass,
             },
         };
         const configWithLocation: IGeoConfig = {
-            mapboxToken: "",
+            mapboxToken: "mapboxToken",
             mdObject: {
                 buckets: bucketsWithLocation,
                 visualizationClass,
@@ -113,7 +135,7 @@ describe("GeoValidatorHOC", () => {
 
     it("should component be updated to new prop when filters changed", () => {
         const config: IGeoConfig = {
-            mapboxToken: "",
+            mapboxToken: "mapboxToken",
             mdObject: {
                 buckets: [SIZE_ITEM, COLOR_ITEM, LOCATION_ITEM, SEGMENT_BY_ITEM],
                 visualizationClass,

--- a/src/components/core/tests/GeoChart.spec.tsx
+++ b/src/components/core/tests/GeoChart.spec.tsx
@@ -44,7 +44,7 @@ describe("GeoChart", () => {
             chartRenderer: jest.fn(),
             legendRenderer: jest.fn(),
             config: {
-                mapboxToken: "",
+                mapboxToken: "mapboxToken",
                 mdObject,
                 ...customConfig,
             },

--- a/src/constants/errorStates.ts
+++ b/src/constants/errorStates.ts
@@ -76,4 +76,9 @@ export const ErrorStates = {
      * This error means that request has been cancelled usually after component has been unmounted.
      */
     CANCELLED: "CANCELLED",
+
+    /**
+     * This error means that mapbox token of GeoChart is missing
+     */
+    GEO_MAPBOX_TOKEN_MISSING: "GEO_MAPBOX_TOKEN_MISSING",
 };

--- a/src/helpers/errorHandlers.ts
+++ b/src/helpers/errorHandlers.ts
@@ -53,6 +53,10 @@ export function generateErrorMap(intl: IntlShape): IErrorMap {
             message: intl.formatMessage({ id: "visualization.ErrorMessageGeneric" }),
             description: intl.formatMessage({ id: "visualization.ErrorDescriptionGeneric" }),
         },
+        [ErrorStates.GEO_MAPBOX_TOKEN_MISSING]: {
+            message: intl.formatMessage({ id: "visualization.ErrorMessageGeneric" }),
+            description: intl.formatMessage({ id: "visualization.ErrorDescriptionMissingMapboxToken" }),
+        },
     };
     return errorMap;
 }

--- a/src/helpers/tests/__snapshots__/errorHandlers.spec.ts.snap
+++ b/src/helpers/tests/__snapshots__/errorHandlers.spec.ts.snap
@@ -7,6 +7,10 @@ Object {
     "icon": "icon-cloud-rain",
     "message": "visualization.ErrorMessageDataTooLarge",
   },
+  "GEO_MAPBOX_TOKEN_MISSING": Object {
+    "description": "visualization.ErrorDescriptionMissingMapboxToken",
+    "message": "visualization.ErrorMessageGeneric",
+  },
   "NOT_FOUND": Object {
     "description": "visualization.ErrorDescriptionNotFound",
     "message": "visualization.ErrorMessageNotFound",

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -194,6 +194,11 @@
         "comment": "",
         "limit": 0
     },
+    "visualization.ErrorDescriptionMissingMapboxToken": {
+        "value": "An API access token is required to use Mapbox GL in Geo chart (pushpins)",
+        "comment": "Mapbox GL should not be translated",
+        "limit": 0
+    },
     "gs.filter.loading": {
         "value": "Loading filter…",
         "comment": "Use '…' as one character, not 3 dots ('...').",


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2997
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2712

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
 SD-869: https://jira.intgdc.com/browse/SD-869