### PR TITLE
BUGFIX: ONE-4421 Use `columnId` when marking resized columns

### DIFF
--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -559,7 +559,7 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
     };
 
     private onVirtualColumnsChanged = (event: GridColumnsChangedEvent) => {
-        const { execution, columnDefs } = this.state;
+        const { execution } = this.state;
         const tableIsNotScrolled = () => {
             const horizontalPixelRange = event.api.getHorizontalPixelRange();
             const verticalPixelRange = event.api.getVerticalPixelRange();
@@ -567,10 +567,11 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
         };
         if (execution && tableIsNotScrolled()) {
             const resizedColumnIdentifiers = Object.keys(this.resizedColumns);
-            const previouslyResizedColumnIds = getTreeLeaves(columnDefs)
-                .filter(d => resizedColumnIdentifiers.includes(this.getColumnIdentifier(d)))
-                .map(d => d.field);
-            this.autoresizeColumns(event, true, previouslyResizedColumnIds);
+            const columns = event.columnApi.getAllDisplayedVirtualColumns();
+            const previouslyResizedColumnIdentifiers = columns
+                .filter(d => resizedColumnIdentifiers.includes(this.getColumnIdentifier(d.getColDef())))
+                .map(d => d.getColId());
+            this.autoresizeColumns(event, true, previouslyResizedColumnIdentifiers);
         }
     };
 


### PR DESCRIPTION
Fixes `columnId` vs `field` conflict when resizing column after the table size change.

<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
