### PR TITLE
BUGFIX: SD-922 should re-render geo chart when config or data source changed

### DIFF
--- a/src/components/core/base/GeoValidatorHOC.tsx
+++ b/src/components/core/base/GeoValidatorHOC.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 import isEqual = require("lodash/isEqual");
 import { injectIntl } from "react-intl";
+import { IColorItem } from "@gooddata/gooddata-js";
 
 import { IGeoChartInnerProps } from "../geoChart/GeoChartInner";
 import { IntlWrapper } from "./IntlWrapper";
@@ -10,6 +11,8 @@ import { ErrorStates } from "../../../constants/errorStates";
 import { RuntimeError } from "../../../errors/RuntimeError";
 import { generateErrorMap, IErrorMap } from "../../../helpers/errorHandlers";
 import { isLocationMissing } from "../../../helpers/geoChart/common";
+import { IGeoConfig } from "../../../interfaces/GeoChart";
+import { IColorMapping } from "../../../interfaces/Config";
 
 type IGeoValidatorProps = IGeoChartInnerProps;
 
@@ -44,7 +47,7 @@ export function geoValidatorHOC<T>(InnerComponent: React.ComponentClass<T>): Rea
             const { config: nextConfig, dataSource: nextDataSource } = nextProps;
 
             // check if buckets, filters and config are changed
-            const isSameConfig = isEqual(config, nextConfig);
+            const isSameConfig = this.isSameConfig(config, nextConfig);
             const isSameDatasource = isEqual(dataSource.getAfm(), nextDataSource.getAfm());
 
             return !isSameConfig || !isSameDatasource;
@@ -79,6 +82,25 @@ export function geoValidatorHOC<T>(InnerComponent: React.ComponentClass<T>): Rea
             const errorProps = this.errorMap[errorState] || this.errorMap[ErrorStates.UNKNOWN_ERROR];
 
             return <ErrorComponent code={errorState} {...errorProps} />;
+        }
+
+        private isSameConfig(config: IGeoConfig, nextConfig: IGeoConfig): boolean {
+            const colorMapping = (config.colorMapping || []).map(
+                (currentColor: IColorMapping): IColorItem => currentColor.color,
+            );
+            const nextColorMapping = (nextConfig.colorMapping || []).map(
+                (newColor: IColorMapping): IColorItem => newColor.color,
+            );
+            const configProps = {
+                ...config,
+                colorMapping,
+            };
+            const nextConfigProps = {
+                ...nextConfig,
+                colorMapping: nextColorMapping,
+            };
+
+            return isEqual(configProps, nextConfigProps);
         }
     }
 


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/3003
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2720

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
