### PR TITLE
BUGFIX: RAIL-2081 Fix headline visualization config, RAIL-2233 Fix rendering issue of visualization component

### DIFF
--- a/src/components/uri/Visualization.tsx
+++ b/src/components/uri/Visualization.tsx
@@ -306,6 +306,7 @@ export class VisualizationWrapped extends React.Component<
             this.subject.next(
                 this.prepareDataSources(nextProps.projectId, nextProps.identifier, nextProps.filters),
             );
+            this.setState({ error: null });
         }
     }
 

--- a/src/helpers/featureFlags.ts
+++ b/src/helpers/featureFlags.ts
@@ -2,6 +2,7 @@
 import { IFeatureFlags, SDK } from "@gooddata/gooddata-js";
 import { getCachedOrLoad } from "./sdkCache";
 import { IChartConfig } from "../interfaces/Config";
+import isNil = require("lodash/isNil");
 
 export async function getFeatureFlags(sdk: SDK, projectId: string): Promise<IFeatureFlags> {
     const apiCallIdentifier = `getFeatureFlags.${projectId}`;
@@ -21,11 +22,12 @@ export function setConfigFromFeatureFlags(config: IChartConfig, featureFlags: IF
     }
 
     let result = config;
-
-    if (featureFlags.disableKpiDashboardHeadlineUnderline === true) {
+    if (
+        featureFlags.disableKpiDashboardHeadlineUnderline === true &&
+        (!config || isNil(config.disableDrillUnderline))
+    ) {
         result = { ...result, disableDrillUnderline: true };
     }
-
     return result;
 }
 


### PR DESCRIPTION
Fixed headline visualization config behaviour. When user sets config disableDrillUnderline it will override featureflag if it is set.

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/3007
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2725

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
