### PR TITLE
BUGFIX: RAIL-2235 make examples work in IE11

### DIFF
--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -84,10 +84,10 @@ module.exports = async (env, argv) => {
             BASEPATH: JSON.stringify(basePath),
         }),
         new SimplestProgressPlugin(),
-        new Dotenv({ 
+        new Dotenv({
             path: "../.env", // one environment for both storybook and examples
-            systemvars: true
-        })
+            systemvars: true,
+        }),
     ];
 
     if (isProduction) {
@@ -107,6 +107,7 @@ module.exports = async (env, argv) => {
             __filename: true,
         },
         resolve: {
+            mainFields: ["browser", "main", "module"],
             extensions: [".js", ".jsx"],
             alias: {
                 "@gooddata/react-components/styles": path.resolve(__dirname, "../styles/"),
@@ -125,7 +126,9 @@ module.exports = async (env, argv) => {
                 },
                 {
                     test: /\.jsx?$/,
-                    exclude: /node_modules|update-dependencies/,
+                    // we have to explicitly transpile react-intl for it to work in IE11
+                    // see docs https://github.com/formatjs/react-intl/blob/master/docs/Getting-Started.md#webpack
+                    exclude: /update-dependencies|node_modules\/(?!react-intl|intl-messageformat|intl-messageformat-parser)/,
                     use: {
                         loader: "babel-loader",
                     },


### PR DESCRIPTION
react-intl must be explicitly transpiled by us, otherwise it won't work in IE11

<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
