### PR TITLE
BUGFIX: SD-931 order position navigator and attribute button

### DIFF
--- a/src/components/core/geoChart/GeoChartRenderer.tsx
+++ b/src/components/core/geoChart/GeoChartRenderer.tsx
@@ -193,15 +193,16 @@ export default class GeoChartRenderer extends React.Component<IGeoChartRendererP
 
     private createMapControls() {
         const isViewportFrozen = this.isViewportFrozen();
-        if (!isViewportFrozen) {
-            this.addMapControls();
-        }
 
         this.chart.addControl(
             new mapboxgl.AttributionControl({
                 compact: true,
             }),
         );
+
+        if (!isViewportFrozen) {
+            this.addMapControls();
+        }
     }
 
     private removeMapControls = (): void => {

--- a/styles/scss/geoChart.scss
+++ b/styles/scss/geoChart.scss
@@ -175,6 +175,7 @@
 .mapboxgl-ctrl-bottom-right {
     display: flex;
     align-items: flex-end;
+    flex-direction: row-reverse;
 }
 
 /* Overwrite Mapbox CSS */


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
https://github.com/gooddata/gdc-analytical-designer/pull/3017
Demo is running at https://client-demo.na.intgdc.com:50036/analyze/
- gdc-dashboards:
https://github.com/gooddata/gdc-dashboards/pull/2736
Demo is running at https://client-demo.na.intgdc.com:50037/dashboards/
# Related Jira tasks
https://jira.intgdc.com/browse/SD-931
