### PR TITLE
BUGFIX: SD-934 SDK - Get wrong value when config tooltipText then drill on geo pushpin

### DIFF
--- a/src/components/core/geoChart/GeoChartRenderer.tsx
+++ b/src/components/core/geoChart/GeoChartRenderer.tsx
@@ -390,7 +390,10 @@ export default class GeoChartRenderer extends React.Component<IGeoChartRendererP
             geoData,
         } = this.props;
         const { features, originalEvent } = e;
-        const { properties } = features[0];
+        const {
+            geometry: { coordinates },
+            properties,
+        } = features[0];
 
         // Disable drilling in edit/export mode
         if (get(viewport, "frozen", false)) {
@@ -406,6 +409,7 @@ export default class GeoChartRenderer extends React.Component<IGeoChartRendererP
             execution,
             geoData,
             properties,
+            coordinates,
             originalEvent.target,
         );
     };

--- a/src/components/core/geoChart/geoChartDataSource.ts
+++ b/src/components/core/geoChart/geoChartDataSource.ts
@@ -22,7 +22,7 @@ export interface IGeoDataSourceProps {
     hasClustering: boolean;
 }
 
-type IGeoDataSourceFeature = GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>;
+type IGeoDataSourceFeature = GeoJSON.Feature<GeoJSON.Point, GeoJSON.GeoJsonProperties>;
 export type IGeoDataSourceFeatures = IGeoDataSourceFeature[];
 
 function transformPushpinDataSource(dataSourceProps: IGeoDataSourceProps): IGeoDataSourceFeatures {

--- a/src/components/visualizations/utils/drilldownEventing.ts
+++ b/src/components/visualizations/utils/drilldownEventing.ts
@@ -560,10 +560,11 @@ export function handleGeoPushpinDrillEvent(
     drillConfig: IDrillConfig,
     execution: Execution.IExecutionResponses,
     geoData: IGeoData,
-    properties: GeoJSON.GeoJsonProperties,
+    pinProperties: GeoJSON.GeoJsonProperties,
+    pinCoordinates: number[],
     target: EventTarget,
 ): void {
-    const { locationIndex } = properties;
+    const { locationIndex } = pinProperties;
     const drillIntersection: IDrillEventIntersectionElementExtended[] = getDrillIntersectionForGeoChart(
         drillableItems,
         drillConfig,
@@ -577,21 +578,21 @@ export function handleGeoPushpinDrillEvent(
     }
 
     const { afm, onDrill, onFiredDrillEvent } = drillConfig;
+    const [lng, lat] = pinCoordinates;
     const {
         locationName: { value: locationNameValue },
         color: { value: colorValue },
         segment: { value: segmentByValue },
         size: { value: sizeValue },
-    } = parseGeoProperties(properties);
-    const locationName: string = locationNameValue ? escape(String(locationNameValue)) : "";
-    const segmentByName: string = segmentByValue ? escape(String(segmentByValue)) : "";
+    } = parseGeoProperties(pinProperties);
     const drillContext: IGeoDrillEvent = {
         element: "pushpin",
         intersection: drillIntersection,
         type: "pushpin",
         color: colorValue,
-        location: locationName,
-        segmentBy: segmentByName,
+        location: { lat, lng },
+        locationName: locationNameValue,
+        segmentBy: segmentByValue,
         size: sizeValue,
     };
     const drillEventExtended: IDrillEventExtended = {

--- a/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
+++ b/src/components/visualizations/utils/test/drilldownEventing.spec.tsx
@@ -1347,6 +1347,7 @@ describe("Drilldown Eventing", () => {
             segment: '{ "title": "segment title", "value": "segment value" }',
             size: '{ "title": "size title", "value": 2 }',
         };
+        const mockCoordinates: number[] = [1, 2];
 
         const defaultDrillConfig: IDrillConfig = { afm: mockAfm, onFiredDrillEvent: () => true };
         const target: any = { dispatchEvent: jest.fn() };
@@ -1363,6 +1364,7 @@ describe("Drilldown Eventing", () => {
                 mockExecution,
                 mockGeoData,
                 mockProperties,
+                mockCoordinates,
                 target as EventTarget,
             );
 
@@ -1433,8 +1435,9 @@ describe("Drilldown Eventing", () => {
                 element: "pushpin",
                 intersection: drillIntersection,
                 type: "pushpin",
-                location: "location%20value",
-                segmentBy: "segment%20value",
+                location: { lat: 2, lng: 1 },
+                locationName: "location value",
+                segmentBy: "segment value",
                 size: 2,
             };
             const drillEventExtended: IDrillEventExtended = {
@@ -1455,6 +1458,7 @@ describe("Drilldown Eventing", () => {
                 mockExecution,
                 mockGeoData,
                 mockProperties,
+                mockCoordinates,
                 target as EventTarget,
             );
 

--- a/src/interfaces/DrillEvents.ts
+++ b/src/interfaces/DrillEvents.ts
@@ -12,6 +12,7 @@ import {
     VisType,
     XirrType,
 } from "../constants/visualizationTypes";
+import { IGeoLngLat } from "../interfaces/GeoChart";
 import { TableRowForDrilling } from "./Table";
 import { OnFiredDrillEvent, OnDrill } from "./Events";
 
@@ -194,7 +195,8 @@ export interface IDrillEventContextExtended extends IDrillEventContextBase {
 
 export interface IGeoDrillEvent extends IDrillEventContextExtended {
     color?: number; // geo chart: color value of the drilled pin
-    location?: string; // geo chart: location of the drilled pin
+    location?: IGeoLngLat; // geo chart: location of the drilled pin
+    locationName?: string; // geo chart: location name of the drilled pin
     segmentBy?: string; // geo chart: segmentBy of the drilled pin
     size?: number; // geo chart: size value of the drilled pin
 }


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)

# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/3028
    - https://client-demo.na.intgdc.com:50029/analyze/
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2746
    - https://client-demo.na.intgdc.com:50023/dashboards/

# Related Jira tasks
- SD-934: https://jira.intgdc.com/browse/SD-934