### PR TITLE
BUGFIX: SD-943 Measure is removed when switch from geo chart to some charts

### DIFF
--- a/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.spec.tsx
+++ b/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.spec.tsx
@@ -218,6 +218,59 @@ describe("PluggableBulletChart", () => {
         });
     });
 
+    it("should return reference point after switching from Geo Chart", async () => {
+        const {
+            simpleGeoPushpinReferencePoint: { buckets: mockedBuckets, filters: mockedFilters },
+        } = referencePointMocks;
+        const expectedBuckets: IBucket[] = [
+            {
+                localIdentifier: "measures",
+                items: mockedBuckets[1].items.slice(0, 1),
+            },
+            {
+                localIdentifier: "secondary_measures",
+                items: mockedBuckets[2].items.slice(0, 1),
+            },
+            {
+                localIdentifier: "tertiary_measures",
+                items: [],
+            },
+            {
+                localIdentifier: "view",
+                items: [...mockedBuckets[0].items.slice(0, 1), ...mockedBuckets[3].items.slice(0, 1)],
+            },
+        ];
+        const expectedFilters: IFilters = {
+            localIdentifier: "filters",
+            items: mockedFilters.items.slice(0, 1),
+        };
+
+        const extendedReferencePoint = await bulletChart.getExtendedReferencePoint(
+            referencePointMocks.simpleGeoPushpinReferencePoint,
+        );
+
+        const expectedUiConfig = {
+            ...DEFAULT_BULLET_CHART_CONFIG,
+            buckets: {
+                [MEASURES]: {
+                    ...DEFAULT_BULLET_CHART_CONFIG.buckets[MEASURES],
+                    canAddItems: false,
+                },
+                [SECONDARY_MEASURES]: {
+                    ...DEFAULT_BULLET_CHART_CONFIG.buckets[SECONDARY_MEASURES],
+                    canAddItems: false,
+                },
+            },
+        };
+
+        expect(extendedReferencePoint).toMatchObject({
+            buckets: expectedBuckets,
+            filters: expectedFilters,
+            uiConfig: expectedUiConfig,
+            properties: {},
+        });
+    });
+
     describe("isError property", () => {
         it("should set to true if primary measure is missing", async () => {
             await bulletChart.getExtendedReferencePoint(

--- a/src/internal/components/pluggableVisualizations/bulletChart/tests/bucketHelper.spec.ts
+++ b/src/internal/components/pluggableVisualizations/bulletChart/tests/bucketHelper.spec.ts
@@ -159,5 +159,20 @@ describe("bullet chart bucket helper", () => {
                 getBucket(BucketNames.VIEW, []),
             ]);
         });
+
+        it("should distribute measures after switching from Geo Chart", () => {
+            const buckets = [
+                getBucket(BucketNames.SIZE, [referencePointMocks.masterMeasureItems[0]]),
+                getBucket(BucketNames.COLOR, [referencePointMocks.masterMeasureItems[1]]),
+            ];
+            const actual = transformBuckets(buckets);
+
+            expect(actual).toEqual([
+                getBucket(BucketNames.MEASURES, [referencePointMocks.masterMeasureItems[0]]),
+                getBucket(BucketNames.SECONDARY_MEASURES, [referencePointMocks.masterMeasureItems[1]]),
+                getBucket(BucketNames.TERTIARY_MEASURES, []),
+                getBucket(BucketNames.VIEW, []),
+            ]);
+        });
     });
 });

--- a/src/internal/components/pluggableVisualizations/scatterPlot/tests/PluggableScatterPlot.spec.tsx
+++ b/src/internal/components/pluggableVisualizations/scatterPlot/tests/PluggableScatterPlot.spec.tsx
@@ -184,6 +184,43 @@ describe("PluggableScatterPlot", () => {
         });
     });
 
+    it("should return reference point after switching from Geo Chart", async () => {
+        const scatterPlot = createComponent();
+
+        const {
+            simpleGeoPushpinReferencePoint: { buckets: mockedBuckets, filters: mockedFilters },
+        } = referencePointMocks;
+        const expectedBuckets: IBucket[] = [
+            {
+                localIdentifier: "measures",
+                items: mockedBuckets[1].items.slice(0, 1),
+            },
+            {
+                localIdentifier: "secondary_measures",
+                items: mockedBuckets[2].items.slice(0, 1),
+            },
+            {
+                localIdentifier: "attribute",
+                items: mockedBuckets[0].items.slice(0, 1),
+            },
+        ];
+        const expectedFilters: IFilters = {
+            localIdentifier: "filters",
+            items: mockedFilters.items.slice(0, 1),
+        };
+
+        const extendedReferencePoint = await scatterPlot.getExtendedReferencePoint(
+            referencePointMocks.simpleGeoPushpinReferencePoint,
+        );
+
+        expect(extendedReferencePoint).toEqual({
+            buckets: expectedBuckets,
+            filters: expectedFilters,
+            uiConfig: uiConfigMocks.scatterPlotUiConfig,
+            properties: {},
+        });
+    });
+
     describe("Arithmetic measures", () => {
         it("should skip AM that does not fit into two measure bucket item slots", async () => {
             const scatterPlot = createComponent();

--- a/src/internal/utils/bucketHelper.ts
+++ b/src/internal/utils/bucketHelper.ts
@@ -851,7 +851,16 @@ export const transformMeasureBuckets = (
     let unusedMeasures: IBucketItem[] = [];
 
     const newBuckets: IBucket[] = measureBucketItemsLimits.map(({ localIdentifier, itemsLimit }) => {
-        const preferredBucketItems = getPreferredBucketItems(buckets, [localIdentifier], [METRIC]);
+        const preferedBucketlocalIdentifiers: string[] =
+            localIdentifier === BucketNames.MEASURES
+                ? [BucketNames.MEASURES, BucketNames.SIZE]
+                : localIdentifier === BucketNames.SECONDARY_MEASURES
+                ? [BucketNames.SECONDARY_MEASURES, BucketNames.COLOR]
+                : [localIdentifier];
+
+        const preferredBucketItems = getPreferredBucketItems(buckets, preferedBucketlocalIdentifiers, [
+            METRIC,
+        ]);
         const measuresToBePlaced = preferredBucketItems.splice(0, itemsLimit);
 
         if (measuresToBePlaced.length === 0) {

--- a/src/internal/utils/tests/bucketHelper.spec.ts
+++ b/src/internal/utils/tests/bucketHelper.spec.ts
@@ -2791,6 +2791,27 @@ describe("transformMeasureBuckets", () => {
                 ]),
             ],
         ],
+        [
+            "should distribute measures after switching from Geo Chart",
+            [
+                getBucket(BucketNames.MEASURES, [referencePointMocks.masterMeasureItems[0]]),
+                getBucket(BucketNames.SECONDARY_MEASURES, [referencePointMocks.masterMeasureItems[1]]),
+            ],
+            [
+                {
+                    localIdentifier: BucketNames.MEASURES,
+                    itemsLimit: 1,
+                },
+                {
+                    localIdentifier: BucketNames.SECONDARY_MEASURES,
+                    itemsLimit: 1,
+                },
+            ],
+            [
+                getBucket(BucketNames.SIZE, [referencePointMocks.masterMeasureItems[0]]),
+                getBucket(BucketNames.COLOR, [referencePointMocks.masterMeasureItems[1]]),
+            ],
+        ],
     ])(
         `should return %s`,
         (


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)
- [x] Squash commits

# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/3097
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2812

# Related Jira tasks
- SD-943: https://jira.intgdc.com/browse/SD-943
