### PR TITLE
BUGFIX: SD-985 ignore show in % in measure on geo chart

### DIFF
--- a/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
+++ b/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
@@ -45,6 +45,7 @@ import { IGeoConfig } from "../../../../interfaces/GeoChart";
 import { GEOPUSHPIN_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
 import GeoPushpinConfigurationPanel from "../../configurationPanels/GeoPushpinConfigurationPanel";
 import { IChartConfig } from "../../../..";
+import { configurePercent } from "../../../utils/bucketConfig";
 
 const NUMBER_MEASURES_IN_BUCKETS_LIMIT = 2;
 
@@ -69,11 +70,12 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
         return super
             .getExtendedReferencePoint(referencePoint)
             .then((extendedReferencePoint: IExtendedReferencePoint) => {
-                const newReferencePoint: IExtendedReferencePoint = setGeoPushpinUiConfig(
+                let newReferencePoint: IExtendedReferencePoint = setGeoPushpinUiConfig(
                     extendedReferencePoint,
                     this.intl,
                     this.type,
                 );
+                newReferencePoint = configurePercent(newReferencePoint, true);
                 return this.updateSupportedProperties(newReferencePoint);
             });
     }

--- a/src/internal/components/pluggableVisualizations/geoChart/tests/PluggableGeoPushpinChart.spec.tsx
+++ b/src/internal/components/pluggableVisualizations/geoChart/tests/PluggableGeoPushpinChart.spec.tsx
@@ -201,7 +201,16 @@ describe("PluggableGeoPushpinChart", () => {
             expect(newExtendedReferencePoint.buckets).toEqual([
                 {
                     localIdentifier: "location",
-                    items: [],
+                    items: [
+                        {
+                            aggregation: null,
+                            attribute: "attr.owner.country",
+                            dfUri: "/geo/attribute/displayform/uri/2",
+                            localIdentifier: "a1",
+                            locationDisplayFormUri: "/geo/attribute/displayform/uri/1",
+                            type: "attribute",
+                        },
+                    ],
                 },
                 {
                     localIdentifier: "size",

--- a/src/internal/mocks/referencePointMocks.ts
+++ b/src/internal/mocks/referencePointMocks.ts
@@ -2203,7 +2203,7 @@ export const twoMeasuresWithShowInPercentOnSecondaryAxisReferencePoint: IReferen
         },
         {
             localIdentifier: "view",
-            items: [],
+            items: geoAttributeItems.slice(0, 1),
         },
         {
             localIdentifier: "segment",


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/3168
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2884

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
SD-985: https://jira.intgdc.com/browse/SD-985