### PR TITLE
BUGFIX: ONE-4524 ONE-4527 Handling still the same, new width structure

### DIFF
--- a/examples/src/components/PivotTableSizingComplexExample.jsx
+++ b/examples/src/components/PivotTableSizingComplexExample.jsx
@@ -80,6 +80,7 @@ export class PivotTableSizingComplexExample extends Component {
     state = {
         columnWidths: [],
         autoResize: false,
+        growToFit: false,
         gridTableCount: 0,
     };
 
@@ -101,6 +102,13 @@ export class PivotTableSizingComplexExample extends Component {
         // change also PivotTable key so by this checkbox we simulate init render
         this.setState(prevState => ({
             autoResize: !prevState.autoResize,
+            gridTableCount: prevState.gridTableCount + 1,
+        }));
+    };
+
+    onGrowToFitChanged = () => {
+        this.setState(prevState => ({
+            growToFit: !prevState.growToFit,
             gridTableCount: prevState.gridTableCount + 1,
         }));
     };
@@ -128,7 +136,7 @@ export class PivotTableSizingComplexExample extends Component {
                         Change all measures width
                     </button>
 
-                    <label style={{ paddingLeft: 50 }}>
+                    <label style={{ paddingLeft: 20 }}>
                         Auto resize:
                         <input
                             className="s-pivot-table-sizing-complex-autoresize-checkbox"
@@ -138,9 +146,20 @@ export class PivotTableSizingComplexExample extends Component {
                             onChange={this.onAutoResizeChanged}
                         />
                     </label>
+
+                    <label style={{ paddingLeft: 20 }}>
+                        Grow to Fit:
+                        <input
+                            className="s-pivot-table-sizing-complex-grow-to-fit-checkbox"
+                            name="grow-to-fit-checkbox"
+                            type="checkbox"
+                            checked={this.state.growToFit}
+                            onChange={this.onGrowToFitChanged}
+                        />
+                    </label>
                 </div>
                 <div
-                    style={{ height: 300, marginTop: 20, resize: "both", overflow: "auto" }}
+                    style={{ width: 1000, height: 300, marginTop: 20, resize: "both", overflow: "auto" }}
                     className="s-pivot-table-sizing-complex"
                 >
                     <PivotTable
@@ -153,7 +172,7 @@ export class PivotTableSizingComplexExample extends Component {
                             columnSizing: {
                                 columnWidths: [...this.state.columnWidths],
                                 defaultWidth: this.state.autoResize ? "viewport" : "unset",
-                                growToFit: false,
+                                growToFit: this.state.growToFit,
                             },
                         }}
                         pageSize={20}

--- a/examples/test/PivotTableSizingReset_test.js
+++ b/examples/test/PivotTableSizingReset_test.js
@@ -23,6 +23,7 @@ const TABLE_SELECTOR_STR = ".s-pivot-table-sizing-complex";
 const CHANGE_WIDTH_BUTTON_ATTRIBUTE_STR = ".s-change-width-button-attribute";
 const CHANGE_WIDTH_BUTTON_MEASURE_STR = ".s-change-width-button-measure";
 const ADD_ALL_MEASURE_WIDTH_BUTTON = ".s-change-width-button-measure-all";
+const TURN_ON_GROW_TO_FIT = ".s-pivot-table-sizing-complex-grow-to-fit-checkbox";
 
 const AGGRID_ON_RESIZE_TIMEOUT = 500;
 const AUTO_SIZE_TOLERANCE = 5;
@@ -30,6 +31,7 @@ const DND_SIZE_TOLERANCE = 5;
 const CELL_DEFAULT_WIDTH = 200;
 const FIRST_CELL_AUTORESIZE_WIDTH = 111;
 const SECOND_CELL_AUTORESIZE_WIDTH = 125;
+const SECOND_CELL_GROW_TO_FIT_WIDTH = 150;
 const FIRST_CELL_MANUAL_WIDTH = 400;
 const SECOND_CELL_MANUAL_WIDTH = 60;
 const ATTRIBUTE_IDENTIFIER = "state";
@@ -90,10 +92,11 @@ test("should reset first column with default width by double click to auto size 
     await t.expect(callBack.length).eql(expectedCallBackArrayItemsCount);
 
     const item = getAttributeColumnWidthItemByIdentifier(callBack, ATTRIBUTE_IDENTIFIER);
+
     await t.expect(item).notEql(undefined);
     await checkWidthWithTolerance(
         t,
-        item.attributeColumnWidthItem.width,
+        item.attributeColumnWidthItem.width.value,
         FIRST_CELL_AUTORESIZE_WIDTH,
         AUTO_SIZE_TOLERANCE,
         "Width of item from callback array",
@@ -134,7 +137,7 @@ test("should reset first column with manual width by double click to auto size a
     await t.expect(item).notEql(undefined);
     await checkWidthWithTolerance(
         t,
-        item.attributeColumnWidthItem.width,
+        item.attributeColumnWidthItem.width.value,
         FIRST_CELL_AUTORESIZE_WIDTH,
         AUTO_SIZE_TOLERANCE,
         "Width of item from callback array",
@@ -213,7 +216,7 @@ test("should resize first column by DnD and notify column as manually resized vi
     await t.expect(item).notEql(undefined);
     await checkWidthWithTolerance(
         t,
-        item.attributeColumnWidthItem.width,
+        item.attributeColumnWidthItem.width.value,
         CELL_DEFAULT_WIDTH + dragOffset,
         DND_SIZE_TOLERANCE,
         "Width of item from callback array",
@@ -259,7 +262,7 @@ test("should reset second column with default width by double click to auto size
     await t.expect(item).notEql(undefined);
     await checkWidthWithTolerance(
         t,
-        item.measureColumnWidthItem.width,
+        item.measureColumnWidthItem.width.value,
         SECOND_CELL_AUTORESIZE_WIDTH,
         AUTO_SIZE_TOLERANCE,
         "Width of item from callback array",
@@ -305,7 +308,7 @@ test("should reset second column with manual width by double click to auto size 
     await t.expect(item).notEql(undefined);
     await checkWidthWithTolerance(
         t,
-        item.measureColumnWidthItem.width,
+        item.measureColumnWidthItem.width.value,
         SECOND_CELL_AUTORESIZE_WIDTH,
         AUTO_SIZE_TOLERANCE,
         "Width of item from callback array",
@@ -389,7 +392,7 @@ test("should resize second column by DnD and notify column as manually resized v
     await t.expect(item).notEql(undefined);
     await checkWidthWithTolerance(
         t,
-        item.measureColumnWidthItem.width,
+        item.measureColumnWidthItem.width.value,
         CELL_DEFAULT_WIDTH + dragOffset,
         DND_SIZE_TOLERANCE,
         "Width of item from callback array",
@@ -447,7 +450,7 @@ test("should resize second column by DnD while meta key pressed and resize all m
     await t.expect(item).notEql(undefined);
     await checkWidthWithTolerance(
         t,
-        item.measureColumnWidthItem.width,
+        item.measureColumnWidthItem.width.value,
         CELL_DEFAULT_WIDTH + dragOffset,
         DND_SIZE_TOLERANCE,
         "Width of item from callback array",
@@ -493,7 +496,7 @@ test("should reset previously resized column with metaKey and notify column as m
     await t.expect(itemAfterReset).notEql(undefined);
     await checkWidthWithTolerance(
         t,
-        itemAfterReset.measureColumnWidthItem.width,
+        itemAfterReset.measureColumnWidthItem.width.value,
         SECOND_CELL_AUTORESIZE_WIDTH,
         AUTO_SIZE_TOLERANCE,
         "Width of item from callback array",
@@ -539,7 +542,7 @@ test("when autosize on it should reset previously resized column with metaKey an
 
     await t.expect(itemAfterReset).notEql(undefined);
 
-    await t.expect(itemAfterReset.measureColumnWidthItem.width).eql("auto");
+    await t.expect(itemAfterReset.measureColumnWidthItem.width.value).eql("auto");
 });
 
 test("should remove all measure width when reset with metaKey and all measures columns should be auto sized", async t => {
@@ -573,4 +576,86 @@ test("should remove all measure width when reset with metaKey and all measures c
 
     const item = getAllMeasureColumnWidth(callBackAfterReset);
     await t.expect(item).eql(undefined);
+});
+
+test("should reset all measaure columns and apply correctly grow to fit on them", async t => {
+    const tableSelector = Selector(TABLE_SELECTOR_STR);
+    const cellSelectorStr = ".s-cell-0-1";
+    const expectedCallBackArrayItemsCount = 5;
+
+    await t.click(TURN_ON_GROW_TO_FIT);
+
+    await waitForPivotTableStopLoading(t, tableSelector);
+
+    await t.click(CHANGE_WIDTH_BUTTON_ATTRIBUTE_STR);
+    await t.click(ADD_ALL_MEASURE_WIDTH_BUTTON);
+
+    const resizer = await getSecondCellResizer(t, TABLE_SELECTOR_STR);
+    await t.doubleClick(resizer, { modifiers: { meta: true } });
+    await sleep(AGGRID_ON_RESIZE_TIMEOUT);
+
+    // after reset
+    const cell = await getCell(t, TABLE_SELECTOR_STR, cellSelectorStr);
+    const resizedLastCellWidth = await cell.getBoundingClientRectProperty("width");
+
+    await checkWidthWithTolerance(
+        t,
+        resizedLastCellWidth,
+        SECOND_CELL_GROW_TO_FIT_WIDTH,
+        DND_SIZE_TOLERANCE,
+        "Width of table column",
+    );
+
+    // check callback
+    const callBackAfterReset = await getCallbackArray(TABLE_SELECTOR_STR);
+    await t.expect(callBackAfterReset.length).eql(expectedCallBackArrayItemsCount);
+
+    const item = getAllMeasureColumnWidth(callBackAfterReset);
+    await t.expect(item).eql(undefined);
+});
+
+test("should not reset all measaure columns when doubleclicked with meta key on attribute resizer", async t => {
+    const tableSelector = Selector(TABLE_SELECTOR_STR);
+    const attrCellSelectorStr = ".s-cell-0-0";
+    const measureCellSelectorStr = ".s-cell-0-1";
+    const expectedCallBackArrayItemsCount = 2;
+
+    await waitForPivotTableStopLoading(t, tableSelector);
+
+    await t.click(CHANGE_WIDTH_BUTTON_ATTRIBUTE_STR);
+    await t.click(ADD_ALL_MEASURE_WIDTH_BUTTON);
+
+    const resizer = await getFirstCellResizer(t, TABLE_SELECTOR_STR);
+    await t.doubleClick(resizer, { modifiers: { meta: true } });
+    await sleep(AGGRID_ON_RESIZE_TIMEOUT);
+
+    // after reset
+    const cell = await getCell(t, TABLE_SELECTOR_STR, attrCellSelectorStr);
+    const resizedAttrCellWidth = await cell.getBoundingClientRectProperty("width");
+
+    await checkWidthWithTolerance(
+        t,
+        resizedAttrCellWidth,
+        FIRST_CELL_AUTORESIZE_WIDTH,
+        AUTO_SIZE_TOLERANCE,
+        "Width of table column",
+    );
+
+    const measureCell = await getCell(t, TABLE_SELECTOR_STR, measureCellSelectorStr);
+    const resizedMeasureCellWidth = await measureCell.getBoundingClientRectProperty("width");
+
+    await checkWidthWithTolerance(
+        t,
+        resizedMeasureCellWidth,
+        SECOND_CELL_MANUAL_WIDTH,
+        DND_SIZE_TOLERANCE,
+        "Width of table column",
+    );
+
+    // check callback
+    const callBackAfterReset = await getCallbackArray(TABLE_SELECTOR_STR);
+    await t.expect(callBackAfterReset.length).eql(expectedCallBackArrayItemsCount);
+
+    const item = getAllMeasureColumnWidth(callBackAfterReset);
+    await t.expect(item).notEql(undefined);
 });

--- a/mock-schema.js
+++ b/mock-schema.js
@@ -2557,7 +2557,7 @@ const getBaseProjectSchema = (title, identifier) => {
                         columnWidths: [
                             {
                                 attributeColumnWidthItem: {
-                                    width: 100,
+                                    width: { value: 100 },
                                     attributeIdentifier: "3",
                                 },
                             }

--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -1045,13 +1045,15 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
 
         if (this.isColumnAutoResized(id)) {
             this.columnApi.setColumnWidth(column, this.autoResizedColumns[id].width);
+            column.getColDef().suppressSizeToFit = false;
             return;
         }
 
         this.autoresizeColumnsByColumnId(this.columnApi, this.getColumnIds([column]));
         if (isColumnDisplayed(this.columnApi.getAllDisplayedVirtualColumns(), column)) {
             // skip columns out of viewport because these can not be autoresized
-            this.resizedColumnsStore.addToManuallyResizedColumn(column);
+            this.resizedColumnsStore.addToManuallyResizedColumn(column, true);
+            column.getColDef().suppressSizeToFit = false;
         }
     }
 
@@ -1079,14 +1081,10 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
         }
     };
 
-    private isAllMeasureResetOperation() {
-        return this.isMetaOrCtrlKeyPressed;
-    }
-
     private onColumnsManualReset = async (columns: Column[]) => {
         let columnsToReset = columns;
 
-        if (this.isAllMeasureResetOperation()) {
+        if (this.isAllMeasureResizeOperation(columns)) {
             this.resizedColumnsStore.removeAllMeasureColumns();
             columnsToReset = this.columnApi.getAllColumns().filter(col => isMeasureColumn(col));
         }

--- a/src/components/core/PivotTable.tsx
+++ b/src/components/core/PivotTable.tsx
@@ -1066,18 +1066,14 @@ export class PivotTableInner extends BaseVisualization<IPivotTableInnerProps, IP
         }
 
         if (this.isManualResizing(columnEvent)) {
-            if (this.hasColumnWidths()) {
-                this.numberOfColumnResizedCalls++;
-                await sleep(COLUMN_RESIZE_TIMEOUT);
+            this.numberOfColumnResizedCalls++;
+            await sleep(COLUMN_RESIZE_TIMEOUT);
 
-                if (this.numberOfColumnResizedCalls === UIClick.DOUBLE_CLICK) {
-                    this.numberOfColumnResizedCalls = 0;
-                    await this.onColumnsManualReset(columnEvent.columns);
-                } else if (this.numberOfColumnResizedCalls === UIClick.CLICK) {
-                    this.numberOfColumnResizedCalls = 0;
-                    this.onColumnsManualResized(columnEvent.columns);
-                }
-            } else {
+            if (this.numberOfColumnResizedCalls === UIClick.DOUBLE_CLICK) {
+                this.numberOfColumnResizedCalls = 0;
+                await this.onColumnsManualReset(columnEvent.columns);
+            } else if (this.numberOfColumnResizedCalls === UIClick.CLICK) {
+                this.numberOfColumnResizedCalls = 0;
                 this.onColumnsManualResized(columnEvent.columns);
             }
         }

--- a/src/components/core/pivotTable/tests/ResizedColumnsStore.spec.ts
+++ b/src/components/core/pivotTable/tests/ResizedColumnsStore.spec.ts
@@ -7,23 +7,28 @@ import { MEASURE_COLUMN, ROW_ATTRIBUTE_COLUMN } from "../agGridConst";
 import { MANUALLY_SIZED_MAX_WIDTH, MIN_WIDTH } from "../agGridColumnSizing";
 
 describe("ResizedColumnsStore", () => {
-    const columnWidthsMock: ColumnWidthItem[] = [
-        {
-            measureColumnWidthItem: {
-                width: 400,
-                locators: [
-                    {
-                        measureLocatorItem: {
-                            measureIdentifier: "m1",
-                            element: "/m1",
-                        },
-                    },
-                ],
+    const measureItem = {
+        measureColumnWidthItem: {
+            width: {
+                value: 400,
             },
+            locators: [
+                {
+                    measureLocatorItem: {
+                        measureIdentifier: "m1",
+                        element: "/m1",
+                    },
+                },
+            ],
         },
+    };
+    const columnWidthsMock: ColumnWidthItem[] = [
+        measureItem,
         {
             attributeColumnWidthItem: {
-                width: 200,
+                width: {
+                    value: 200,
+                },
                 attributeIdentifier: "a1",
             },
         },
@@ -31,21 +36,27 @@ describe("ResizedColumnsStore", () => {
     const columnWidthsAllMeasureMock: ColumnWidthItem[] = [
         {
             measureColumnWidthItem: {
-                width: 400,
+                width: {
+                    value: 400,
+                },
             },
         },
     ];
     const columnWidthsAllMeasureMockMinWidth: ColumnWidthItem[] = [
         {
             measureColumnWidthItem: {
-                width: 10,
+                width: {
+                    value: 10,
+                },
             },
         },
     ];
     const columnWidthsAllMeasureMockMaxWidth: ColumnWidthItem[] = [
         {
             measureColumnWidthItem: {
-                width: 4000,
+                width: {
+                    value: 4000,
+                },
             },
         },
     ];
@@ -114,15 +125,25 @@ describe("ResizedColumnsStore", () => {
 
     describe("getManuallyResizedColumn", () => {
         it("should return correct manually resized measure column", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.manuallyResizedColumns = {
-                m_0: { width: 400, source: "uiColumnDragged" },
-                a_4DOTdf: { width: 200, source: "uiColumnDragged" },
-            };
+            const resizedColumnsStore = new ResizedColumnsStore({
+                m_0: {
+                    width: {
+                        value: 400,
+                    },
+                    source: ColumnEventSourceType.UI_DRAGGED,
+                },
+                a_4DOTdf: {
+                    width: {
+                        value: 200,
+                    },
+                    source: ColumnEventSourceType.UI_DRAGGED,
+                },
+            });
+
             const columnMock = getFakeColumn({
                 colId: "m_0",
             });
-            const expectedResult = { width: 400, source: "uiColumnDragged" };
+            const expectedResult = { width: 400, source: ColumnEventSourceType.UI_DRAGGED };
             const result = resizedColumnsStore.getManuallyResizedColumn(columnMock);
             expect(result).toEqual(expectedResult);
         });
@@ -133,23 +154,32 @@ describe("ResizedColumnsStore", () => {
             const columnMock = getFakeColumn({
                 type: MEASURE_COLUMN,
             });
-            const expectedResult = { width: 42, source: "uiColumnDragged" };
+            const expectedResult = { width: 42, source: ColumnEventSourceType.UI_DRAGGED };
             const result = resizedColumnsStore.getManuallyResizedColumn(columnMock);
             expect(result).toEqual(expectedResult);
         });
 
         it("should return all measure column width when manuallyResizedColumns exists", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.manuallyResizedColumns = {
-                m_0: { width: 400, source: "uiColumnDragged" },
-                a_4DOTdf: { width: 200, source: "uiColumnDragged" },
-            };
-            resizedColumnsStore.allMeasureColumnWidth = 42;
+            const resizedColumnsStore = new ResizedColumnsStore({
+                m_0: {
+                    width: {
+                        value: 400,
+                    },
+                    source: ColumnEventSourceType.UI_DRAGGED,
+                },
+                a_4DOTdf: {
+                    width: {
+                        value: 200,
+                    },
+                    source: ColumnEventSourceType.UI_DRAGGED,
+                },
+            });
+            (resizedColumnsStore as any).allMeasureColumnWidth = 42;
 
             const columnMock = getFakeColumn({
                 type: MEASURE_COLUMN,
             });
-            const expectedResult = { width: 42, source: "uiColumnDragged" };
+            const expectedResult = { width: 42, source: ColumnEventSourceType.UI_DRAGGED };
             const result = resizedColumnsStore.getManuallyResizedColumn(columnMock);
             expect(result).toEqual(expectedResult);
         });
@@ -157,10 +187,14 @@ describe("ResizedColumnsStore", () => {
 
     describe("isColumnManuallyResized", () => {
         it("should return true for manually resized column", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.manuallyResizedColumns = {
-                m_0: { width: 400, source: "uiColumnDragged" },
-            };
+            const resizedColumnsStore = new ResizedColumnsStore({
+                m_0: {
+                    width: {
+                        value: 400,
+                    },
+                    source: ColumnEventSourceType.UI_DRAGGED,
+                },
+            });
             const columnMock = getFakeColumn({
                 colId: "m_0",
             });
@@ -169,8 +203,7 @@ describe("ResizedColumnsStore", () => {
         });
 
         it("should return false for column that is not manually resized", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.manuallyResizedColumns = {};
+            const resizedColumnsStore = new ResizedColumnsStore();
             const columnMock = getFakeColumn({
                 colId: "m.without.manually.resizing",
             });
@@ -188,7 +221,7 @@ describe("ResizedColumnsStore", () => {
                 width: correctWidth,
             });
             resizedColumnsStore.addToManuallyResizedColumn(columnMock);
-            const result = resizedColumnsStore.manuallyResizedColumns.m_1.width;
+            const result = resizedColumnsStore.manuallyResizedColumns.m_1.width.value;
             expect(result).toBe(correctWidth);
         });
     });
@@ -208,10 +241,14 @@ describe("ResizedColumnsStore", () => {
         });
 
         it("should omit from manually resized map by colId", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.manuallyResizedColumns = {
-                m_0: { width: 400, source: "uiColumnDragged" },
-            };
+            const resizedColumnsStore = new ResizedColumnsStore({
+                m_0: {
+                    width: {
+                        value: 400,
+                    },
+                    source: ColumnEventSourceType.UI_DRAGGED,
+                },
+            });
             const columnsMock = [
                 getFakeColumn({
                     colId: "m_0",
@@ -222,16 +259,25 @@ describe("ResizedColumnsStore", () => {
                 }),
             ];
             resizedColumnsStore.addAllMeasureColumns(42, columnsMock);
-            const result = resizedColumnsStore.manuallyResizedColumns.m_0;
+            const result = (resizedColumnsStore as any).manuallyResizedColumns.m_0;
             expect(result).toBeUndefined();
         });
 
         it("should omit from manually resized map by colId and kept other items", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.manuallyResizedColumns = {
-                m_0: { width: 400, source: "uiColumnDragged" },
-                a_4DOTdf: { width: 200, source: "uiColumnDragged" },
-            };
+            const resizedColumnsStore = new ResizedColumnsStore({
+                m_0: {
+                    width: {
+                        value: 400,
+                    },
+                    source: ColumnEventSourceType.UI_DRAGGED,
+                },
+                a_4DOTdf: {
+                    width: {
+                        value: 200,
+                    },
+                    source: ColumnEventSourceType.UI_DRAGGED,
+                },
+            });
             const columnsMock = [
                 getFakeColumn({
                     colId: "m_0",
@@ -242,7 +288,7 @@ describe("ResizedColumnsStore", () => {
                 }),
             ];
             resizedColumnsStore.addAllMeasureColumns(42, columnsMock);
-            const result = resizedColumnsStore.manuallyResizedColumns.a_4DOTdf.width;
+            const result = (resizedColumnsStore as any).manuallyResizedColumns.a_4DOTdf.width.value;
             const correctWidth = 200;
             expect(result).toEqual(correctWidth);
         });
@@ -257,23 +303,21 @@ describe("ResizedColumnsStore", () => {
         });
 
         it("should omit from manually resized columns when width is auto", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.manuallyResizedColumns = {
-                m_0: { width: "auto", source: "uiColumnDragged" },
-            };
+            const resizedColumnsStore = new ResizedColumnsStore({
+                m_0: { width: { value: "auto" }, source: ColumnEventSourceType.UI_DRAGGED },
+            });
             resizedColumnsStore.removeAllMeasureColumns();
-            const result = resizedColumnsStore.manuallyResizedColumns.m_0;
+            const result = (resizedColumnsStore as any).manuallyResizedColumns.m_0;
             expect(result).toBeUndefined();
         });
 
         it("should omit from manually resized columns when width is auto and kept other items", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.manuallyResizedColumns = {
-                m_0: { width: "auto", source: "uiColumnDragged" },
-                a_4DOTdf: { width: 200, source: "uiColumnDragged" },
-            };
+            const resizedColumnsStore = new ResizedColumnsStore({
+                m_0: { width: { value: "auto" }, source: ColumnEventSourceType.UI_DRAGGED },
+                a_4DOTdf: { width: { value: 200 }, source: ColumnEventSourceType.UI_DRAGGED },
+            });
             resizedColumnsStore.removeAllMeasureColumns();
-            const result = resizedColumnsStore.manuallyResizedColumns.a_4DOTdf.width;
+            const result = (resizedColumnsStore as any).manuallyResizedColumns.a_4DOTdf.width.value;
             const correctWidth = 200;
             expect(result).toEqual(correctWidth);
         });
@@ -281,18 +325,17 @@ describe("ResizedColumnsStore", () => {
 
     describe("removeFromManuallyResizedColumn", () => {
         it("should remove measure from manually resized column map by colId", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.manuallyResizedColumns = {
-                m_0: { width: 200, source: "uiColumnDragged" },
-                a_4DOTdf: { width: 200, source: "uiColumnDragged" },
-            };
+            const resizedColumnsStore = new ResizedColumnsStore({
+                m_0: { width: { value: 200 }, source: ColumnEventSourceType.UI_DRAGGED },
+                a_4DOTdf: { width: { value: 200 }, source: ColumnEventSourceType.UI_DRAGGED },
+            });
             const columnMock = getFakeColumn({
                 colId: "m_0",
                 type: MEASURE_COLUMN,
                 suppressSizeToFit: true,
             });
             resizedColumnsStore.removeFromManuallyResizedColumn(columnMock);
-            const result = resizedColumnsStore.manuallyResizedColumns.m_0;
+            const result = (resizedColumnsStore as any).manuallyResizedColumns.m_0;
             expect(result).toBeUndefined();
             expect(columnMock.getColDef().suppressSizeToFit).toBeFalsy();
         });
@@ -300,50 +343,48 @@ describe("ResizedColumnsStore", () => {
         it.each([[null], [150]])(
             "should remove row attribute from manually resized column map by colId when allMeasuresWidth set %d",
             (allMeasuresWidth: number) => {
-                const resizedColumnsStore: any = new ResizedColumnsStore();
-                resizedColumnsStore.manuallyResizedColumns = {
-                    m_0: { width: 200, source: "uiColumnDragged" },
-                    a_4DOTdf: { width: 200, source: "uiColumnDragged" },
-                };
-                resizedColumnsStore.allMeasureColumnWidth = allMeasuresWidth;
+                const resizedColumnsStore = new ResizedColumnsStore({
+                    m_0: { width: { value: 200 }, source: ColumnEventSourceType.UI_DRAGGED },
+                    a_4DOTdf: { width: { value: 200 }, source: ColumnEventSourceType.UI_DRAGGED },
+                });
+                (resizedColumnsStore as any).allMeasureColumnWidth = allMeasuresWidth;
                 const columnMock = getFakeColumn({
                     colId: "a_4DOTdf",
                     type: ROW_ATTRIBUTE_COLUMN,
                     suppressSizeToFit: true,
                 });
                 resizedColumnsStore.removeFromManuallyResizedColumn(columnMock);
-                const result = resizedColumnsStore.manuallyResizedColumns.a_4DOTdf;
+                const result = (resizedColumnsStore as any).manuallyResizedColumns.a_4DOTdf;
                 expect(result).toBeUndefined();
                 expect(columnMock.getColDef().suppressSizeToFit).toBeFalsy();
             },
         );
 
         it("should set auto width when colId does not exists and all measure is used", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.allMeasureColumnWidth = 200;
+            const resizedColumnsStore = new ResizedColumnsStore();
+            (resizedColumnsStore as any).allMeasureColumnWidth = 200;
             const columnMock = getFakeColumn({
                 colId: "m_0",
                 type: MEASURE_COLUMN,
             });
             resizedColumnsStore.removeFromManuallyResizedColumn(columnMock);
-            const expectedResult = { width: "auto", source: "uiColumnDragged" };
-            const result = resizedColumnsStore.manuallyResizedColumns.m_0;
+            const expectedResult = { width: { value: "auto" }, source: ColumnEventSourceType.UI_DRAGGED };
+            const result = (resizedColumnsStore as any).manuallyResizedColumns.m_0;
             expect(result).toEqual(expectedResult);
         });
 
         it("should set auto width when colId does exists and all measure is used", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
-            resizedColumnsStore.allMeasureColumnWidth = 200;
-            resizedColumnsStore.manuallyResizedColumns = {
-                m_0: { width: 200, source: "uiColumnDragged" },
-            };
+            const resizedColumnsStore = new ResizedColumnsStore({
+                m_0: { width: { value: 200 }, source: ColumnEventSourceType.UI_DRAGGED },
+            });
+            (resizedColumnsStore as any).allMeasureColumnWidth = 200;
             const columnMock = getFakeColumn({
                 colId: "m_0",
                 type: MEASURE_COLUMN,
             });
             resizedColumnsStore.removeFromManuallyResizedColumn(columnMock);
-            const expectedResult = { width: "auto", source: "uiColumnDragged" };
-            const result = resizedColumnsStore.manuallyResizedColumns.m_0;
+            const expectedResult = { width: { value: "auto" }, source: ColumnEventSourceType.UI_DRAGGED };
+            const result = (resizedColumnsStore as any).manuallyResizedColumns.m_0;
             expect(result).toEqual(expectedResult);
         });
     });
@@ -355,7 +396,9 @@ describe("ResizedColumnsStore", () => {
             const expectedResult = [
                 {
                     measureColumnWidthItem: {
-                        width: 400,
+                        width: {
+                            value: 400,
+                        },
                         locators: [
                             {
                                 measureLocatorItem: {
@@ -366,7 +409,12 @@ describe("ResizedColumnsStore", () => {
                     },
                 },
                 {
-                    attributeColumnWidthItem: { width: 200, attributeIdentifier: "a1" },
+                    attributeColumnWidthItem: {
+                        width: {
+                            value: 200,
+                        },
+                        attributeIdentifier: "a1",
+                    },
                 },
             ];
             const result = resizedColumnsStore.getColumnWidthsFromMap(executionResponsesMock);
@@ -383,7 +431,9 @@ describe("ResizedColumnsStore", () => {
             const expectedResult = [
                 {
                     measureColumnWidthItem: {
-                        width: 400,
+                        width: {
+                            value: 400,
+                        },
                         locators: [
                             {
                                 measureLocatorItem: {
@@ -394,11 +444,18 @@ describe("ResizedColumnsStore", () => {
                     },
                 },
                 {
-                    attributeColumnWidthItem: { width: 200, attributeIdentifier: "a1" },
+                    attributeColumnWidthItem: {
+                        width: {
+                            value: 200,
+                        },
+                        attributeIdentifier: "a1",
+                    },
                 },
                 {
                     measureColumnWidthItem: {
-                        width: 400,
+                        width: {
+                            value: 400,
+                        },
                     },
                 },
             ];
@@ -409,51 +466,51 @@ describe("ResizedColumnsStore", () => {
 
     describe("updateColumnWidths", () => {
         it("should update column widths", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
+            const resizedColumnsStore = new ResizedColumnsStore();
             const expectedResult = {
-                m_0: { width: 400, source: ColumnEventSourceType.UI_DRAGGED },
-                a_4DOTdf: { width: 200, source: ColumnEventSourceType.UI_DRAGGED },
+                m_0: { width: { value: 400 }, source: ColumnEventSourceType.UI_DRAGGED },
+                a_4DOTdf: { width: { value: 200 }, source: ColumnEventSourceType.UI_DRAGGED },
             };
             resizedColumnsStore.updateColumnWidths(columnWidthsMock, executionResponseMock);
-            const result = resizedColumnsStore.manuallyResizedColumns;
+            const result = (resizedColumnsStore as any).manuallyResizedColumns;
             expect(result).toEqual(expectedResult);
         });
 
         it("should update only measure columns", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
+            const resizedColumnsStore = new ResizedColumnsStore();
             const expectedResult = {
-                m_0: { width: 400, source: ColumnEventSourceType.UI_DRAGGED },
+                m_0: { width: { value: 400 }, source: ColumnEventSourceType.UI_DRAGGED },
             };
             const columnWidthsOnlyMeasureMock = [columnWidthsMock[0]];
             resizedColumnsStore.updateColumnWidths(columnWidthsOnlyMeasureMock, executionResponseMock);
-            const result = resizedColumnsStore.manuallyResizedColumns;
+            const result = (resizedColumnsStore as any).manuallyResizedColumns;
             expect(result).toEqual(expectedResult);
         });
 
         it("should update only attribute measure columns", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
+            const resizedColumnsStore = new ResizedColumnsStore();
             const expectedResult = {
-                a_4DOTdf: { width: 200, source: ColumnEventSourceType.UI_DRAGGED },
+                a_4DOTdf: { width: { value: 200 }, source: ColumnEventSourceType.UI_DRAGGED },
             };
             const columnWidthsOnlyAttributeMock = [columnWidthsMock[1]];
             resizedColumnsStore.updateColumnWidths(columnWidthsOnlyAttributeMock, executionResponseMock);
-            const result = resizedColumnsStore.manuallyResizedColumns;
+            const result = (resizedColumnsStore as any).manuallyResizedColumns;
             expect(result).toEqual(expectedResult);
         });
 
         it("should validate all measure width item with min width", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
+            const resizedColumnsStore = new ResizedColumnsStore();
             resizedColumnsStore.updateColumnWidths(columnWidthsAllMeasureMockMinWidth, executionResponseMock);
             const expectedResult = MIN_WIDTH;
-            const result = resizedColumnsStore.allMeasureColumnWidth;
+            const result = (resizedColumnsStore as any).allMeasureColumnWidth;
             expect(result).toEqual(expectedResult);
         });
 
         it("should validate all measure width item with max width", () => {
-            const resizedColumnsStore: any = new ResizedColumnsStore();
+            const resizedColumnsStore = new ResizedColumnsStore();
             resizedColumnsStore.updateColumnWidths(columnWidthsAllMeasureMockMaxWidth, executionResponseMock);
             const expectedResult = MANUALLY_SIZED_MAX_WIDTH;
-            const result = resizedColumnsStore.allMeasureColumnWidth;
+            const result = (resizedColumnsStore as any).allMeasureColumnWidth;
             expect(result).toEqual(expectedResult);
         });
     });

--- a/src/components/core/pivotTable/tests/agGridColumnSizing.spec.ts
+++ b/src/components/core/pivotTable/tests/agGridColumnSizing.spec.ts
@@ -11,7 +11,7 @@ import {
 import {
     ColumnWidthItem,
     ColumnEventSourceType,
-    AbsoluteColumnWidth,
+    IAbsoluteColumnWidth,
     IResizedColumns,
 } from "../../../../interfaces/PivotTable";
 import { IGridHeader } from "../agGridTypes";
@@ -57,7 +57,9 @@ describe("agGridColumnSizing", () => {
     const columnWidths: ColumnWidthItem[] = [
         {
             measureColumnWidthItem: {
-                width: 60,
+                width: {
+                    value: 60,
+                },
                 locators: [
                     {
                         measureLocatorItem: {
@@ -69,7 +71,9 @@ describe("agGridColumnSizing", () => {
         },
         {
             attributeColumnWidthItem: {
-                width: 400,
+                width: {
+                    value: 400,
+                },
                 attributeIdentifier: "a1",
             },
         },
@@ -131,31 +135,42 @@ describe("agGridColumnSizing", () => {
     const MIN_WIDTH = 100;
     const MAX_WIDTH = 300;
 
-    const widthValidator = (width: AbsoluteColumnWidth): AbsoluteColumnWidth => {
-        if (Number(width) === width) {
-            return Math.min(Math.max(width, MIN_WIDTH), MAX_WIDTH);
+    const widthValidator = (width: IAbsoluteColumnWidth): IAbsoluteColumnWidth => {
+        if (Number(width.value) === width.value) {
+            return {
+                ...width,
+                value: Math.min(Math.max(width.value, MIN_WIDTH), MAX_WIDTH),
+            };
         }
         return width;
     };
 
     const expectedColumnMap = {
         m_0: {
-            width: 60,
+            width: {
+                value: 60,
+            },
             source: ColumnEventSourceType.UI_DRAGGED,
         },
         a_4DOTdf: {
-            width: 400,
+            width: {
+                value: 400,
+            },
             source: ColumnEventSourceType.UI_DRAGGED,
         },
     };
 
     const expectedColumnMapValidated = {
         m_0: {
-            width: MIN_WIDTH,
+            width: {
+                value: MIN_WIDTH,
+            },
             source: ColumnEventSourceType.UI_DRAGGED,
         },
         a_4DOTdf: {
-            width: MAX_WIDTH,
+            width: {
+                value: MAX_WIDTH,
+            },
             source: ColumnEventSourceType.UI_DRAGGED,
         },
     };
@@ -184,7 +199,9 @@ describe("agGridColumnSizing", () => {
         it("should return correct ColumnWidthItem array for only column attribute", async () => {
             const columnAttributeColumnMap = {
                 a_4_1: {
-                    width: 400,
+                    width: {
+                        value: 400,
+                    },
                     source: ColumnEventSourceType.UI_DRAGGED,
                 },
             };
@@ -192,7 +209,9 @@ describe("agGridColumnSizing", () => {
             const expectedColumnWidths: ColumnWidthItem[] = [
                 {
                     measureColumnWidthItem: {
-                        width: 400,
+                        width: {
+                            value: 400,
+                        },
                         locators: [
                             {
                                 attributeLocatorItem: {

--- a/src/helpers/model/tests/widthItems.spec.ts
+++ b/src/helpers/model/tests/widthItems.spec.ts
@@ -8,21 +8,12 @@ describe("widthItems", () => {
             const expected: IAttributeColumnWidthItem = {
                 attributeColumnWidthItem: {
                     attributeIdentifier: "foo",
-                    width: 100,
+                    width: {
+                        value: 100,
+                    },
                 },
             };
             expect(attributeColumnWidthItem("foo", 100)).toMatchObject(expected);
-        });
-
-        it("should return a simple attribute column width item with aggregation", () => {
-            const expected: IAttributeColumnWidthItem = {
-                attributeColumnWidthItem: {
-                    attributeIdentifier: "foo",
-                    width: 100,
-                    aggregation: "sum",
-                },
-            };
-            expect(attributeColumnWidthItem("foo", 100).aggregation("sum")).toMatchObject(expected);
         });
     });
 
@@ -30,7 +21,9 @@ describe("widthItems", () => {
         it("should return a simple measure column width item", () => {
             const expected: IMeasureColumnWidthItem = {
                 measureColumnWidthItem: {
-                    width: 100,
+                    width: {
+                        value: 100,
+                    },
                     locators: [
                         {
                             measureLocatorItem: {
@@ -46,7 +39,9 @@ describe("widthItems", () => {
         it("should return a measure column width item with attribute locators", () => {
             const expected: IMeasureColumnWidthItem = {
                 measureColumnWidthItem: {
-                    width: 100,
+                    width: {
+                        value: 100,
+                    },
                     locators: [
                         {
                             attributeLocatorItem: {

--- a/src/helpers/model/widthItems.ts
+++ b/src/helpers/model/widthItems.ts
@@ -1,43 +1,58 @@
 // (C) 2020 GoodData Corporation
 import {
-    AbsoluteColumnWidth,
     IAttributeColumnWidthItem,
     IMeasureColumnWidthItem,
     IAllMeasureColumnWidthItem,
-    ColumnWidth,
 } from "../../interfaces/PivotTable";
 import { AFM } from "@gooddata/typings";
+import { getAllowGrowToFitProp } from "../../components/core/pivotTable/agGridColumnSizing";
 
 export class AttributeColumnWidthItemBuilder implements IAttributeColumnWidthItem {
     public attributeColumnWidthItem: IAttributeColumnWidthItem["attributeColumnWidthItem"];
 
-    constructor(attributeIdentifier: string, width: AbsoluteColumnWidth) {
+    constructor(attributeIdentifier: string, width: number, allowGrowToFit: boolean = false) {
         this.attributeColumnWidthItem = {
             attributeIdentifier,
-            width,
+            width: {
+                value: width,
+                ...getAllowGrowToFitProp(allowGrowToFit),
+            },
         };
     }
-
-    public aggregation = (aggregation: "sum") => {
-        this.attributeColumnWidthItem.aggregation = aggregation;
-        return this;
-    };
 }
 
 export class MeasureColumnWidthItemBuilder implements IMeasureColumnWidthItem {
     public measureColumnWidthItem: IMeasureColumnWidthItem["measureColumnWidthItem"];
 
-    constructor(measureIdentifier: AFM.Identifier, width: ColumnWidth) {
-        this.measureColumnWidthItem = {
-            width,
-            locators: [
-                {
-                    measureLocatorItem: {
-                        measureIdentifier,
-                    },
+    constructor(measureIdentifier: AFM.Identifier, width: number | "auto", allowGrowToFit: boolean = false) {
+        if (width !== "auto") {
+            this.measureColumnWidthItem = {
+                width: {
+                    value: width,
+                    ...getAllowGrowToFitProp(allowGrowToFit),
                 },
-            ],
-        };
+                locators: [
+                    {
+                        measureLocatorItem: {
+                            measureIdentifier,
+                        },
+                    },
+                ],
+            };
+        } else {
+            this.measureColumnWidthItem = {
+                width: {
+                    value: "auto",
+                },
+                locators: [
+                    {
+                        measureLocatorItem: {
+                            measureIdentifier,
+                        },
+                    },
+                ],
+            };
+        }
     }
 
     public attributeLocators = (
@@ -57,18 +72,22 @@ export class MeasureColumnWidthItemBuilder implements IMeasureColumnWidthItem {
 export class AllMeasureColumnWidthItemBuilder implements IAllMeasureColumnWidthItem {
     public measureColumnWidthItem: IAllMeasureColumnWidthItem["measureColumnWidthItem"];
 
-    constructor(width: AbsoluteColumnWidth) {
+    constructor(width: number) {
         this.measureColumnWidthItem = {
-            width,
+            width: {
+                value: width,
+            },
         };
     }
 }
 
-export const attributeColumnWidthItem = (attributeIdentifier: string, width: AbsoluteColumnWidth) =>
+export const attributeColumnWidthItem = (attributeIdentifier: string, width: number) =>
     new AttributeColumnWidthItemBuilder(attributeIdentifier, width);
 
-export const measureColumnWidthItem = (measureIdentifier: AFM.Identifier, width: ColumnWidth) =>
-    new MeasureColumnWidthItemBuilder(measureIdentifier, width);
+export const measureColumnWidthItem = (
+    measureIdentifier: AFM.Identifier,
+    width: number | "auto",
+    allowGrowToFit: boolean = false,
+) => new MeasureColumnWidthItemBuilder(measureIdentifier, width, allowGrowToFit);
 
-export const allMeasureColumnWidthItem = (width: AbsoluteColumnWidth) =>
-    new AllMeasureColumnWidthItemBuilder(width);
+export const allMeasureColumnWidthItem = (width: number) => new AllMeasureColumnWidthItemBuilder(width);

--- a/src/helpers/tests/featureFlags.spec.ts
+++ b/src/helpers/tests/featureFlags.spec.ts
@@ -50,7 +50,9 @@ describe("getTableConfigFromFeatureFlags", () => {
     const columnWidths = [
         {
             attributeColumnWidthItem: {
-                width: 740,
+                width: {
+                    value: 740,
+                },
                 attributeIdentifier: "294512a6b2ed4be8bd3948dd14db1950",
             },
         },

--- a/src/interfaces/PivotTable.ts
+++ b/src/interfaces/PivotTable.ts
@@ -45,30 +45,34 @@ export interface IResizedColumnsItem {
     source: ColumnEventSourceType;
 }
 
+export interface IManuallyResizedColumnsItem {
+    width: number;
+    source: ColumnEventSourceType;
+    allowGrowToFit?: boolean;
+}
+
 export interface IResizedColumns {
     [columnIdentifier: string]: IResizedColumnsItem;
 }
 
-export type ColumnWidthItem =
-    | IAttributeColumnWidthItem
-    | IMeasureColumnWidthItem
-    | IAllMeasureColumnWidthItem;
-export type AbsoluteColumnWidth = number;
-export type ColumnWidth = AbsoluteColumnWidth | "auto";
-
-export function isAbsoluteColumnWidth(columnWidth: ColumnWidth): columnWidth is AbsoluteColumnWidth {
-    return Number(columnWidth) === columnWidth;
+export function isAbsoluteColumnWidth(columnWidth: ColumnWidth): columnWidth is IAbsoluteColumnWidth {
+    return Number(columnWidth.value) === columnWidth.value;
+}
+export interface IAbsoluteColumnWidth {
+    value: number;
+    allowGrowToFit?: boolean;
 }
 
-export function isColumnWidthAuto(columnWidth: ColumnWidth): boolean {
-    return columnWidth === "auto";
+export interface IAutoColumnWidth {
+    value: "auto";
 }
+
+export type ColumnWidth = IAbsoluteColumnWidth | IAutoColumnWidth;
 
 export interface IAttributeColumnWidthItem {
     attributeColumnWidthItem: {
-        width: AbsoluteColumnWidth;
+        width: IAbsoluteColumnWidth;
         attributeIdentifier: AFM.Identifier;
-        aggregation?: "sum";
     };
 }
 
@@ -81,9 +85,14 @@ export interface IMeasureColumnWidthItem {
 
 export interface IAllMeasureColumnWidthItem {
     measureColumnWidthItem: {
-        width: AbsoluteColumnWidth;
+        width: IAbsoluteColumnWidth;
     };
 }
+
+export type ColumnWidthItem =
+    | IAttributeColumnWidthItem
+    | IMeasureColumnWidthItem
+    | IAllMeasureColumnWidthItem;
 
 type LocatorItem = IAttributeLocatorItem | AFM.IMeasureLocatorItem;
 interface IAttributeLocatorItem {

--- a/src/internal/components/pluggableVisualizations/pivotTable/tests/widthItemsMock.ts
+++ b/src/internal/components/pluggableVisualizations/pivotTable/tests/widthItemsMock.ts
@@ -8,7 +8,7 @@ import {
 
 export const validMeasureColumnWidthItem: IMeasureColumnWidthItem = {
     measureColumnWidthItem: {
-        width: 100,
+        width: { value: 100 },
         locators: [
             {
                 attributeLocatorItem: {
@@ -27,27 +27,27 @@ export const validMeasureColumnWidthItem: IMeasureColumnWidthItem = {
 
 export const validAllMeasureColumnWidthItem: IAllMeasureColumnWidthItem = {
     measureColumnWidthItem: {
-        width: 400,
+        width: { value: 400 },
     },
 };
 
 export const validAttributeColumnWidthItem: IAttributeColumnWidthItem = {
     attributeColumnWidthItem: {
-        width: 100,
+        width: { value: 100 },
         attributeIdentifier: "a1",
     },
 };
 
 export const invalidAttributeColumnWidthItem: IAttributeColumnWidthItem = {
     attributeColumnWidthItem: {
-        width: 100,
+        width: { value: 100 },
         attributeIdentifier: "invalid",
     },
 };
 
 export const invalidMeasureColumnWidthItem: IMeasureColumnWidthItem = {
     measureColumnWidthItem: {
-        width: 100,
+        width: { value: 100 },
         locators: [
             {
                 attributeLocatorItem: {
@@ -66,7 +66,7 @@ export const invalidMeasureColumnWidthItem: IMeasureColumnWidthItem = {
 
 export const invalidMeasureColumnWidthItemInvalidAttribute: IMeasureColumnWidthItem = {
     measureColumnWidthItem: {
-        width: 100,
+        width: { value: 100 },
         locators: [
             {
                 attributeLocatorItem: {
@@ -85,7 +85,7 @@ export const invalidMeasureColumnWidthItemInvalidAttribute: IMeasureColumnWidthI
 
 export const invalidMeasureColumnWidthItemTooManyLocators: IMeasureColumnWidthItem = {
     measureColumnWidthItem: {
-        width: 100,
+        width: { value: 100 },
         locators: [
             {
                 attributeLocatorItem: {
@@ -110,7 +110,7 @@ export const invalidMeasureColumnWidthItemTooManyLocators: IMeasureColumnWidthIt
 
 export const invalidMeasureColumnWidthItemLocatorsTooShort: IMeasureColumnWidthItem = {
     measureColumnWidthItem: {
-        width: 100,
+        width: { value: 100 },
         locators: [
             {
                 measureLocatorItem: {

--- a/src/internal/mocks/referencePointMocks.ts
+++ b/src/internal/mocks/referencePointMocks.ts
@@ -483,7 +483,7 @@ const columnWidths: ColumnWidthItem[] = [
     {
         attributeColumnWidthItem: {
             attributeIdentifier: "a1",
-            width: 100,
+            width: { value: 100 },
         },
     },
 ];

--- a/src/internal/utils/tests/propertiesHelper.spec.ts
+++ b/src/internal/utils/tests/propertiesHelper.spec.ts
@@ -303,7 +303,7 @@ describe("propertiesHelper", () => {
         const columnWidths: ColumnWidthItem[] = [
             {
                 measureColumnWidthItem: {
-                    width: 100,
+                    width: { value: 100 },
                     locators: [
                         {
                             attributeLocatorItem: {

--- a/stories/core_components/PivotTable/ManualResizing.tsx
+++ b/stories/core_components/PivotTable/ManualResizing.tsx
@@ -16,7 +16,9 @@ const ALL_MEASURE_WIDTH = 300;
 
 const measureColumnWidthItemSimple = {
     measureColumnWidthItem: {
-        width: MEASURE_WIDTH,
+        width: {
+            value: MEASURE_WIDTH,
+        },
         locators: [
             {
                 measureLocatorItem: {
@@ -29,13 +31,17 @@ const measureColumnWidthItemSimple = {
 
 const allMeasureColumnWidthItem = {
     measureColumnWidthItem: {
-        width: ALL_MEASURE_WIDTH,
+        width: {
+            value: ALL_MEASURE_WIDTH,
+        },
     },
 };
 
 const measureColumnWidthItemWithAttr = {
     measureColumnWidthItem: {
-        width: MEASURE_WIDTH,
+        width: {
+            value: MEASURE_WIDTH,
+        },
         locators: [
             {
                 attributeLocatorItem: {
@@ -53,7 +59,7 @@ const measureColumnWidthItemWithAttr = {
 };
 const attributeColumnWidthItem = {
     attributeColumnWidthItem: {
-        width: ATTRIBUTE_WIDTH,
+        width: { value: ATTRIBUTE_WIDTH },
         attributeIdentifier: ATTRIBUTE_1.visualizationAttribute.localIdentifier,
     },
 };
@@ -77,7 +83,9 @@ storiesOf("Core components/PivotTable/ManualResizing/Simple table", module)
                                 columnWidths: [
                                     {
                                         measureColumnWidthItem: {
-                                            width: measureColumnWidth,
+                                            width: {
+                                                value: measureColumnWidth,
+                                            },
                                             locators: [
                                                 {
                                                     measureLocatorItem: {
@@ -89,7 +97,9 @@ storiesOf("Core components/PivotTable/ManualResizing/Simple table", module)
                                     },
                                     {
                                         attributeColumnWidthItem: {
-                                            width: attributeColumnWidth,
+                                            width: {
+                                                value: attributeColumnWidth,
+                                            },
                                             attributeIdentifier:
                                                 ATTRIBUTE_1.visualizationAttribute.localIdentifier,
                                         },
@@ -207,13 +217,13 @@ storiesOf("Core components/PivotTable/ManualResizing/Simple table", module)
                                     {
                                         measureColumnWidthItem: {
                                             ...measureColumnWidthItemSimple.measureColumnWidthItem,
-                                            width: 30, // Will be ignored and replaced by MIN_WIDTH limit
+                                            width: { value: 30 }, // Will be ignored and replaced by MIN_WIDTH limit
                                         },
                                     },
                                     {
                                         attributeColumnWidthItem: {
                                             ...attributeColumnWidthItem.attributeColumnWidthItem,
-                                            width: 3000, // Will be ignored and replaced by MAX_WIDTH limit
+                                            width: { value: 3000 }, // Will be ignored and replaced by MAX_WIDTH limit
                                         },
                                     },
                                 ],
@@ -236,7 +246,9 @@ storiesOf("Core components/PivotTable/ManualResizing/Table with column attr", mo
             const attributeWidth = attributeColumnWidth
                 ? {
                       attributeColumnWidthItem: {
-                          width: attributeColumnWidth,
+                          width: {
+                              value: attributeColumnWidth,
+                          },
                           attributeIdentifier: ATTRIBUTE_1.visualizationAttribute.localIdentifier,
                       },
                   }
@@ -245,7 +257,9 @@ storiesOf("Core components/PivotTable/ManualResizing/Table with column attr", mo
             const measureWidth = measureColumnWidth
                 ? {
                       measureColumnWidthItem: {
-                          width: measureColumnWidth,
+                          width: {
+                              value: measureColumnWidth,
+                          },
                           locators: [
                               {
                                   attributeLocatorItem: {


### PR DESCRIPTION
Handling of manual resize and reset is independent on columnWidths prop of PivotTable so it works for existing and new tables the same.
Reset by double click works together with growToFit

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/3187
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/2905

# Related Jira tasks
- ONE-4524: https://jira.intgdc.com/browse/ONE-4524
- ONE-4527: https://jira.intgdc.com/browse/ONE-4527
