### PR TITLE
BUGFIX: ONE-4522 Filter out only displayed virtual columns

### DIFF
--- a/src/components/core/pivotTable/agGridUtils.ts
+++ b/src/components/core/pivotTable/agGridUtils.ts
@@ -258,3 +258,7 @@ export const sanitizeFingerprint = (fingerprint: string): string => {
         afm: sanitizedParsedFingerprintAfm,
     });
 };
+
+export const isColumnDisplayed = (displayedColumns: Column[], column: Column) => {
+    return displayedColumns.some(displayedColumn => displayedColumn.getColId() === column.getColId());
+};


### PR DESCRIPTION
To avoid too long properties field in MD we will not create columnWidth definitions for columns which are out of current viewport during batch reset

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/3198
- gdc-dashboards:

# Related Jira tasks
- ONE-4522: https://jira.intgdc.com/browse/ONE-4522
