### PR TITLE
BUGFIX: BB-2398 Trigger onCursor each time cursor position changes

### DIFF
--- a/src/components/simple/SyntaxHighlightingInput.tsx
+++ b/src/components/simple/SyntaxHighlightingInput.tsx
@@ -57,13 +57,12 @@ export const SyntaxHighlightingInput: React.FC<ISyntaxHighlightingProps> = props
         }
     };
 
-    const handleOnChange = (editor: CodeMirror.Editor, _: CodeMirror.EditorChange, value: string): void => {
+    const handleOnChange = (
+        _editor: CodeMirror.Editor,
+        _change: CodeMirror.EditorChange,
+        value: string,
+    ): void => {
         onChange(value);
-        reportCursorPosition(editor);
-    };
-
-    const handleOnBlur = (editor: CodeMirror.Editor): void => {
-        reportCursorPosition(editor);
     };
 
     const modeOptions: IDefineModeOptions = formatting && {
@@ -77,7 +76,7 @@ export const SyntaxHighlightingInput: React.FC<ISyntaxHighlightingProps> = props
             value={value}
             defineMode={modeOptions}
             onChange={handleOnChange}
-            onBlur={handleOnBlur}
+            onCursorActivity={reportCursorPosition}
             autoCursor={false}
             options={{
                 ...defaultOptions,

--- a/src/components/simple/tests/SyntaxHighlightingInput.spec.tsx
+++ b/src/components/simple/tests/SyntaxHighlightingInput.spec.tsx
@@ -30,15 +30,6 @@ const getCodeMirrorDocument = (wrapper: MountWrapper) => {
     return instance.editor.getDoc();
 };
 
-const triggerCodeMirrorBlur = (wrapper: MountWrapper) => {
-    const instance = wrapper.find(CodeMirrorInput).instance() as ICodeMirrorInputInstance;
-    const editor = instance.editor;
-    wrapper
-        .find(CodeMirrorInput)
-        .props()
-        .onBlur(editor);
-};
-
 describe("SyntaxHighlightingInput", () => {
     it("should render CodeMirrorInput component", () => {
         const wrapper = renderComponent();
@@ -72,36 +63,22 @@ describe("SyntaxHighlightingInput", () => {
     describe("onCursor", () => {
         const multiLineValue = "01234\n01234\n01234";
 
-        it("should call onCursor function on editor blur with expected parameters", () => {
+        it("should call onCursor function with expected parameters on cursor position change", () => {
             const onCursor = jest.fn();
             const wrapper = renderComponent({ onCursor, value: multiLineValue });
 
             const doc = getCodeMirrorDocument(wrapper);
             doc.setCursor({ line: 1, ch: 2 });
 
-            triggerCodeMirrorBlur(wrapper);
-
             expect(onCursor).toHaveBeenCalledWith(8, 8);
         });
 
-        it("should call onCursor function on value change with expected parameters", () => {
-            const onCursor = jest.fn();
-            const wrapper = renderComponent({ onCursor, value: multiLineValue });
-
-            const doc = getCodeMirrorDocument(wrapper);
-            doc.setValue("text");
-
-            expect(onCursor).toHaveBeenCalledWith(0, 0);
-        });
-
-        it("should call onCursor function with expected parameters for multiline selection", () => {
+        it("should call onCursor function with expected parameters on multiline selection", () => {
             const onCursor = jest.fn();
             const wrapper = renderComponent({ onCursor, value: multiLineValue });
 
             const doc = getCodeMirrorDocument(wrapper);
             doc.setSelection({ line: 0, ch: 3 }, { line: 2, ch: 2 });
-
-            triggerCodeMirrorBlur(wrapper);
 
             expect(onCursor).toHaveBeenCalledWith(3, 14);
         });


### PR DESCRIPTION
Do not rely on onBlur handling as CodeMirror textarea not always loose its focus and old cursor position is remembered by parent component.

<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
