### PR TITLE
RELATED: ONE-4559 Don't generate empty columnWidths as default to pre…

### DIFF
--- a/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -207,7 +207,6 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
                     const originalColumnWidths: ColumnWidthItem[] = get(
                         referencePointDraft.properties,
                         "controls.columnWidths",
-                        [],
                     );
                     const columnWidths = adaptReferencePointWidthItemsToPivotTable(
                         originalColumnWidths,
@@ -218,14 +217,13 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
                         previousColumnAttributes ? previousColumnAttributes : [],
                         filters,
                     );
-                    const controlsObj =
-                        this.featureFlags.enableTableColumnsManualResizing || columnWidths.length > 0
-                            ? {
-                                  controls: {
-                                      columnWidths,
-                                  },
-                              }
-                            : {};
+                    const controlsObj = columnWidths
+                        ? {
+                              controls: {
+                                  columnWidths,
+                              },
+                          }
+                        : {};
 
                     referencePointDraft.properties = {
                         sortItems: addDefaultSort(

--- a/src/internal/components/pluggableVisualizations/pivotTable/tests/PluggablePivotTable.spec.tsx
+++ b/src/internal/components/pluggableVisualizations/pivotTable/tests/PluggablePivotTable.spec.tsx
@@ -16,6 +16,7 @@ import {
     IVisConstruct,
     IVisProps,
     IVisualizationPropertiesWrapper,
+    IReferencePoint,
 } from "../../../../interfaces/Visualization";
 import { IDrillableItem } from "../../../../../interfaces/DrillEvents";
 import { PivotTable } from "../../../../../components/core/PivotTable";
@@ -379,6 +380,21 @@ describe("PluggablePivotTable", () => {
                     expect(extendedReferencePoint.properties.controls.columnWidths).toEqual(
                         expectedColumnWidths,
                     );
+                });
+            });
+
+            it("should not generate empty columnWidths in a new reference point", () => {
+                const emptyControlsReferencePoint: IReferencePoint = {
+                    ...sourceReferencePoint,
+                    properties: {
+                        sortItems: sourceReferencePoint.properties.sortItems,
+                    },
+                };
+                const promise: Promise<IExtendedReferencePoint> = pivotTable.getExtendedReferencePoint(
+                    emptyControlsReferencePoint,
+                );
+                return promise.then(extendedReferencePoint => {
+                    expect(extendedReferencePoint.properties.controls).toBeUndefined();
                 });
             });
         });

--- a/src/internal/components/pluggableVisualizations/pivotTable/widthItemsHelpers.ts
+++ b/src/internal/components/pluggableVisualizations/pivotTable/widthItemsHelpers.ts
@@ -117,6 +117,9 @@ function adaptWidthItemsToPivotTable(
     filters: IBucketFilter[],
     firstColumnAttributeAdded: boolean,
 ): ColumnWidthItem[] {
+    if (!originalColumnWidths) {
+        return originalColumnWidths;
+    }
     const attributeLocalIdentifiers = [...rowAttributeLocalIdentifiers, ...columnAttributeLocalIdentifiers];
 
     return originalColumnWidths.reduce((columnWidths: ColumnWidthItem[], columnWidth: ColumnWidthItem) => {


### PR DESCRIPTION
…vent active Save btn
---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/3277
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/3000

# Related Jira tasks
- ONE-4559: https://jira.intgdc.com/browse/ONE-4559