### PR TITLE
BUGFIX: ONE-4459 Change stacked chart label to white font

### DIFF
--- a/src/components/visualizations/chart/highcharts/plugins/dataLabelsColors.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/dataLabelsColors.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import flatMap = require("lodash/flatMap");
 import { VisualizationTypes } from "../../../../../constants/visualizationTypes";
 import { getChartType, getVisibleSeries, isStacked, getShapeAttributes } from "../helpers";
@@ -17,6 +17,9 @@ const setBlackColor = (point: any) => {
     point.dataLabel.element.childNodes[0].style.fill = "#000";
     point.dataLabel.element.childNodes[0].style["text-shadow"] = "none";
 };
+
+const changeDataLabelsColor = (condition: boolean, point: any) =>
+    condition ? setWhiteColor(point) : setBlackColor(point);
 
 function getVisiblePointsWithLabel(chart: any) {
     return flatMap(getVisibleSeries(chart), (series: any) => series.points).filter(
@@ -51,6 +54,26 @@ function setBarDataLabelsColor(chart: any) {
     });
 }
 
+function setColumnDataLabelsColor(chart: any) {
+    const points = getVisiblePointsWithLabel(chart);
+
+    return points.forEach((point: any) => {
+        const labelDimensions = getDataLabelAttributes(point);
+        const columnDimensions = getShapeAttributes(point);
+        const columnTop = columnDimensions.y + columnDimensions.height;
+        const columnDown = columnDimensions.y;
+        const labelDown = labelDimensions.y;
+
+        if (point.negative) {
+            changeDataLabelsColor(labelDown < columnDown, point);
+        } else if (!isStacked(chart)) {
+            changeDataLabelsColor(labelDown > columnTop, point);
+        } else {
+            changeDataLabelsColor(labelDown < columnTop, point);
+        }
+    });
+}
+
 export function isWhiteNotContrastEnough(color: string) {
     // to keep first 17 colors from our default palette with white labels
     const HIGHCHARTS_CONTRAST_THRESHOLD = 530;
@@ -78,9 +101,13 @@ export function extendDataLabelColors(Highcharts: any) {
         const type: string = getChartType(chart);
 
         const changeLabelColor = () => {
-            if (type === VisualizationTypes.BAR && !isStacked(chart)) {
+            if (type === VisualizationTypes.BAR) {
                 setTimeout(() => {
                     setBarDataLabelsColor(chart);
+                }, 500);
+            } else if (isOneOfTypes(type, [VisualizationTypes.COLUMN, VisualizationTypes.PIE])) {
+                setTimeout(() => {
+                    setColumnDataLabelsColor(chart);
                 }, 500);
             } else if (isOneOfTypes(type, [VisualizationTypes.HEATMAP, VisualizationTypes.TREEMAP])) {
                 setContrastLabelsColor(chart);


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [ ] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
