### PR TITLE
BUGFIX: SD-582 Child label is disappeared when change rotation Y-axis to 90° on Bar chart

### DIFF
--- a/src/components/visualizations/chart/highcharts/customConfiguration.ts
+++ b/src/components/visualizations/chart/highcharts/customConfiguration.ts
@@ -113,8 +113,12 @@ export function formatOverlappingForParentAttribute(category: any) {
         return formatOverlapping.call(this);
     }
 
-    const chartHeight = get(this, "axis.chart.chartHeight", 1);
     const categoriesCount = get(this, "axis.categoriesTree", []).length;
+    if (categoriesCount === 1) {
+        // Let the width be auto to make sure "this.value" is displayed on screen
+        return `<div style="overflow: hidden; text-overflow: ellipsis">${this.value}</div>`;
+    }
+    const chartHeight = get(this, "axis.chart.chartHeight", 1);
     const width = Math.floor(chartHeight / categoriesCount);
     const pixelOffset = 40; // parent attribute should have more space than its children
 
@@ -126,8 +130,12 @@ export function formatOverlappingForParentAttribute(category: any) {
 }
 
 export function formatOverlapping() {
-    const chartHeight = get(this, "chart.chartHeight", 1);
     const categoriesCount = get(this, "axis.categories", []).length;
+    if (categoriesCount === 1) {
+        // Let the width be auto to make sure "this.value" is displayed on screen
+        return `<div align="center" style="overflow: hidden; text-overflow: ellipsis">${this.value}</div>`;
+    }
+    const chartHeight = get(this, "chart.chartHeight", 1);
     const width = Math.floor(chartHeight / categoriesCount);
     const pixelOffset = 20;
 


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/3318
- gdc-dashboards: https://github.com/gooddata/gdc-dashboards/pull/3064

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
SD-582: https://jira.intgdc.com/browse/SD-582
