### PR TITLE
BUGFIX: ONE-4593 Do not touch labels of line series in combo charts

### DIFF
--- a/src/components/visualizations/chart/highcharts/plugins/dataLabelsColors.ts
+++ b/src/components/visualizations/chart/highcharts/plugins/dataLabelsColors.ts
@@ -57,21 +57,23 @@ function setBarDataLabelsColor(chart: any) {
 function setColumnDataLabelsColor(chart: any) {
     const points = getVisiblePointsWithLabel(chart);
 
-    return points.forEach((point: any) => {
-        const labelDimensions = getDataLabelAttributes(point);
-        const columnDimensions = getShapeAttributes(point);
-        const columnTop = columnDimensions.y + columnDimensions.height;
-        const columnDown = columnDimensions.y;
-        const labelDown = labelDimensions.y;
+    return points
+        .filter((point: any) => point.shapeArgs) // skip if shapeArgs missing (such as line points in line/column combo chart)
+        .forEach((point: any) => {
+            const labelDimensions = getDataLabelAttributes(point);
+            const columnDimensions = getShapeAttributes(point);
+            const columnTop = columnDimensions.y + columnDimensions.height;
+            const columnDown = columnDimensions.y;
+            const labelDown = labelDimensions.y;
 
-        if (point.negative) {
-            changeDataLabelsColor(labelDown < columnDown, point);
-        } else if (!isStacked(chart)) {
-            changeDataLabelsColor(labelDown > columnTop, point);
-        } else {
-            changeDataLabelsColor(labelDown < columnTop, point);
-        }
-    });
+            if (point.negative) {
+                changeDataLabelsColor(labelDown < columnDown, point);
+            } else if (!isStacked(chart)) {
+                changeDataLabelsColor(labelDown > columnTop, point);
+            } else {
+                changeDataLabelsColor(labelDown < columnTop, point);
+            }
+        });
 }
 
 export function isWhiteNotContrastEnough(color: string) {


### PR DESCRIPTION
<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [x] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->