### PR TITLE
RELATED: RAIL-2675 use up-to-date goodstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
   "dependencies": {
     "@formatjs/intl-pluralrules": "^1.3.6",
     "@gooddata/gooddata-js": "^13.1.2",
-    "@gooddata/goodstrap": "68.20.0",
+    "@gooddata/goodstrap": "^68.20.5",
     "@gooddata/js-utils": "^3.10.5",
     "@gooddata/numberjs": "^3.2.4",
     "@gooddata/typings": "^2.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,10 +1136,10 @@
     rxjs "^5.5.6"
     uuid "^3.2.1"
 
-"@gooddata/goodstrap@68.20.0":
-  version "68.20.0"
-  resolved "https://registry.yarnpkg.com/@gooddata/goodstrap/-/goodstrap-68.20.0.tgz#d9c70612a2834f9a9e1279f3ed725c1e95e66e6b"
-  integrity sha512-7AZhlG5tM7qiLIHY5MPay9w4mEc7BJ2FJ7Bnh3/IhRLxD68D/nPiR03NxLKUPNxYmDMR21TkLI+5VzzzVPmjEQ==
+"@gooddata/goodstrap@^68.20.5":
+  version "68.20.5"
+  resolved "https://registry.yarnpkg.com/@gooddata/goodstrap/-/goodstrap-68.20.5.tgz#9ba185153556bfbf528b2e5187dc426611d618b6"
+  integrity sha512-Msb3/kEQt9mfZKsbpsAr2gP9x6ADOXUIlnRHhIvMT5d5cgx/LTyy0N09HIB+7gALjBoxyr7xOCyevin0KfFuew==
   dependencies:
     "@babel/runtime-corejs2" "^7.0.0"
     "@gooddata/js-utils" "^3.10.9"


### PR DESCRIPTION
This fixes the Spinner keyframes CSS problem.

<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer: N/A r-c not used there
- gdc-dashboards: N/A r-c not used there

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
