### PR TITLE
RELATED: MC-357 fix exports with experimental executions

### DIFF
--- a/src/components/uri/experimentalDataSource.ts
+++ b/src/components/uri/experimentalDataSource.ts
@@ -1,9 +1,10 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import { SDK } from "@gooddata/gooddata-js";
 import { DataSource } from "@gooddata/gooddata-js/lib/DataLayer/dataSources/DataSource";
 import { IDataSource } from "@gooddata/gooddata-js/lib/DataLayer/interfaces/DataSource";
 import { IVisualizationExecution } from "@gooddata/gooddata-js/lib/execution/execute-afm";
 import { AFM, Execution } from "@gooddata/typings";
+import { mergeFiltersToAfm } from "../../helpers/afmHelper";
 
 /**
  *
@@ -29,7 +30,7 @@ export function _experimentalDataSourceFactory(
     projectId: string,
     reference: string,
     afm: AFM.IAfm,
-    filters: AFM.CompatibilityFilter[],
+    filters: AFM.ExtendedFilter[],
 ): Promise<IDataSource<Execution.IExecutionResponses>> {
     // We have ONE-3961 as followup to take this out of experimental mode
 
@@ -62,7 +63,7 @@ export function _experimentalDataSourceFactory(
 
     const dataSource = new DataSource<Execution.IExecutionResponses>(
         execFactory,
-        afm,
+        mergeFiltersToAfm(afm, filters),
         undefined,
         responseFactory,
         resultFactory,


### PR DESCRIPTION
Previously, any filters added on top of the saved visualization
were ignored by exports, because they were not passed to the datasource.
Also, the type of the filters was narrowed a bit according to usage,
to avoid unnecessary type casting/filtering.

<!--

Description of changes (if multi-commit, short global summary & context;
if single-commit, feel free to leave empty).

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [ ] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [ ] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
<!-- Mandatory 

Example:
- gdc-analytical-designer: https://github.com/gooddata/gdc-analytical-designer/pull/2072

-->

- gdc-analytical-designer:
- gdc-dashboards:

# Related Jira tasks
<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
