### PR TITLE
RELATED: SD-1432 Upgrade Goodstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
   "dependencies": {
     "@formatjs/intl-pluralrules": "^1.3.6",
     "@gooddata/gooddata-js": "^13.2.0",
-    "@gooddata/goodstrap": "^70.2.1",
+    "@gooddata/goodstrap": "^70.2.2",
     "@gooddata/js-utils": "^3.10.17",
     "@gooddata/numberjs": "^3.2.4",
     "@gooddata/typings": "^2.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,10 +1135,10 @@
     rxjs "^6.3.1"
     uuid "^8.3.1"
 
-"@gooddata/goodstrap@^70.2.1":
-  version "70.2.1"
-  resolved "https://registry.yarnpkg.com/@gooddata/goodstrap/-/goodstrap-70.2.1.tgz#c9a13d896b1ed41adb162cb64b2b50a54bb59708"
-  integrity sha512-SOIZ/JzlY0PJPhlMG0jW2qYqDmCpPJ4LBfMK+zw5VOgskRUA96ROcs1ha73E1/RhvNFy77kwAINYwX6pltckwg==
+"@gooddata/goodstrap@^70.2.2":
+  version "70.2.2"
+  resolved "https://registry.yarnpkg.com/@gooddata/goodstrap/-/goodstrap-70.2.2.tgz#5d5a20b607f3c2c8ffa45f6ce076999324fb005d"
+  integrity sha512-4bu1fBEymRoTtjg6E3up3CZXIg6dFolG4yVkQkG0GRQyqiuUtZosz3/8zDyyIbNtscedbJ5VqFw0Z0/ybSgJIA==
   dependencies:
     "@babel/runtime-corejs2" "^7.0.0"
     "@gooddata/js-utils" "^3.10.17"


### PR DESCRIPTION
AD and KD are no longer use `gooddata-react-components`

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

Supported PR commands:

Command | Description
--- | ---
`extended test - examples` | Live examples tests
`extended test - storybook` | Storybook screenshot tests

See more [options](https://confluence.intgdc.com/display/kbhr/How+to+work+with+git+and+Github#HowtoworkwithgitandGithub-Extendedchecks).

# PR Checklist

- [x] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
- [x] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
- [ ] Change was tested by using [gdc-dev-release](https://confluence.intgdc.com/display/~tomas.vojtasek/Private+NPM) in [gdc-analytical-designer](https://github.com/gooddata/gdc-analytical-designer) and [gdc-dashboards](https://github.com/gooddata/gdc-dashboards) (if applicable)
- [x] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
- [x] Successful `extended test - examples`
- [x] Successful `extended test - storybook`
- [x] Checked yarn.lock consistency (no dep. duplicities especially Goodstrap)


# Related PRs
- gdc-analytical-designer:
- gdc-dashboards:
- gdc-data-section: https://github.com/gooddata/gdc-data-section/pull/452

# Related Jira tasks
- SD-1432: https://jira.intgdc.com/browse/SD-1432
